### PR TITLE
Allow llm SDKs as workflow types

### DIFF
--- a/src/monocle_apptrace/instrumentation/metamodel/openai/_helper.py
+++ b/src/monocle_apptrace/instrumentation/metamodel/openai/_helper.py
@@ -162,7 +162,7 @@ def get_inference_type(instance):
 
 class OpenAISpanHandler(NonFrameworkSpanHandler):
     def is_teams_span_in_progress(self) -> bool:
-        return self.is_framework_span_in_progess() and self.get_workflow_name_in_progress() == WORKFLOW_TYPE_MAP["teams.ai"]
+        return self.is_framework_span_in_progress() and self.get_workflow_name_in_progress() == WORKFLOW_TYPE_MAP["teams.ai"]
 
     # If openAI is being called by Teams AI SDK, then retain the metadata part of the span events
     def skip_processor(self, to_wrap, wrapped, instance, span, args, kwargs) -> list[str]:

--- a/tests/integration/test_anthropic_sdk_sample.py
+++ b/tests/integration/test_anthropic_sdk_sample.py
@@ -93,7 +93,7 @@ def test_anthropic_metamodel_sample(setup):
     
     assert workflow_span.attributes["span.type"] == "workflow"
     assert workflow_span.attributes["entity.1.name"] == "anthropic_app_1"
-    assert workflow_span.attributes["entity.1.type"] == "workflow.generic"
+    assert workflow_span.attributes["entity.1.type"] == "workflow.anthropic"
 
 @pytest.mark.integration()
 def test_anthropic_invalid_api_key(setup):

--- a/tests/integration/test_openai_api_sample.py
+++ b/tests/integration/test_openai_api_sample.py
@@ -100,7 +100,7 @@ def test_openai_api_sample(setup):
     assert workflow_span.attributes["span.type"] == "workflow"
     assert workflow_span.attributes["entity.1.name"] == "generic_openai_1"
     assert workflow_span.attributes["workflow.name"] == "generic_openai_1"
-    assert workflow_span.attributes["entity.1.type"] == "workflow.generic"
+    assert workflow_span.attributes["entity.1.type"] == "workflow.openai"
 
 
 @pytest.mark.integration()

--- a/tests/integration/test_openai_api_sample_stream.py
+++ b/tests/integration/test_openai_api_sample_stream.py
@@ -93,7 +93,7 @@ async def test_openai_api_sample(setup):
     
     assert workflow_span.attributes["span.type"] == "workflow"
     assert workflow_span.attributes["entity.1.name"] == "generic_openai_1"
-    assert workflow_span.attributes["entity.1.type"] == "workflow.generic"
+    assert workflow_span.attributes["entity.1.type"] == "workflow.openai"
 
 
 @pytest.mark.integration()
@@ -179,7 +179,7 @@ async def test_openai_api_sample_stream(setup):
     
     assert workflow_span.attributes["span.type"] == "workflow"
     assert workflow_span.attributes["entity.1.name"] == "generic_openai_1"
-    assert workflow_span.attributes["entity.1.type"] == "workflow.generic"
+    assert workflow_span.attributes["entity.1.type"] == "workflow.openai"
 
     # Assert we got a valid response
     assert len(collected_chunks) > 0

--- a/tests/integration/test_openai_api_sample_sync.py
+++ b/tests/integration/test_openai_api_sample_sync.py
@@ -87,7 +87,7 @@ def test_openai_api_sample(setup):
     
     assert workflow_span.attributes["span.type"] == "workflow"
     assert workflow_span.attributes["entity.1.name"] == "generic_openai_1"
-    assert workflow_span.attributes["entity.1.type"] == "workflow.generic"
+    assert workflow_span.attributes["entity.1.type"] == "workflow.openai"
 
 
 @pytest.mark.integration()
@@ -171,7 +171,7 @@ def test_openai_api_sample_stream(setup):
     
     assert workflow_span.attributes["span.type"] == "workflow"
     assert workflow_span.attributes["entity.1.name"] == "generic_openai_1"
-    assert workflow_span.attributes["entity.1.type"] == "workflow.generic"
+    assert workflow_span.attributes["entity.1.type"] == "workflow.openai"
     
 # run something after each test
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_openai_response_sample.py
+++ b/tests/integration/test_openai_response_sample.py
@@ -92,7 +92,7 @@ async def test_openai_response_api_sample_async(setup):
     
     assert workflow_span.attributes["span.type"] == "workflow"
     assert workflow_span.attributes["entity.1.name"] == "generic_openai_1"
-    assert workflow_span.attributes["entity.1.type"] == "workflow.generic"
+    assert workflow_span.attributes["entity.1.type"] == "workflow.openai"
 
 @pytest.mark.integration()
 @pytest.mark.asyncio
@@ -162,7 +162,7 @@ async def test_openai_response_api_sample_async_stream(setup):
     
     assert workflow_span.attributes["span.type"] == "workflow"
     assert workflow_span.attributes["entity.1.name"] == "generic_openai_1"
-    assert workflow_span.attributes["entity.1.type"] == "workflow.generic"
+    assert workflow_span.attributes["entity.1.type"] == "workflow.openai"
 
 
 @pytest.mark.integration()
@@ -229,7 +229,7 @@ def test_openai_response_api_sample(setup):
     
     assert workflow_span.attributes["span.type"] == "workflow"
     assert workflow_span.attributes["entity.1.name"] == "generic_openai_1"
-    assert workflow_span.attributes["entity.1.type"] == "workflow.generic"
+    assert workflow_span.attributes["entity.1.type"] == "workflow.openai"
 
 @pytest.mark.integration()
 def test_azure_openai_response_api_sample(setup):
@@ -296,7 +296,7 @@ def test_azure_openai_response_api_sample(setup):
     
     assert workflow_span.attributes["span.type"] == "workflow"
     assert workflow_span.attributes["entity.1.name"] == "generic_openai_1"
-    assert workflow_span.attributes["entity.1.type"] == "workflow.generic"
+    assert workflow_span.attributes["entity.1.type"] == "workflow.openai"
 
 if __name__ == "__main__":
     pytest.main([__file__, "-s", "--tb=short"])


### PR DESCRIPTION
## Proposed changes

Allow openai, anthropic etc as workflow types (today it's set to workflow.generic) for the app that directly uses the provider SDK and not language frameworks.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...