### PR TITLE
Add support for teams finish type, move finish types to metadata section

### DIFF
--- a/src/monocle_apptrace/instrumentation/common/constants.py
+++ b/src/monocle_apptrace/instrumentation/common/constants.py
@@ -86,3 +86,4 @@ MONOCLE_SDK_VERSION = "monocle_apptrace.version"
 MONOCLE_SDK_LANGUAGE = "monocle_apptrace.language"
 MONOCLE_DETECTED_SPAN_ERROR = "monocle_apptrace.detected_span_error"
 HTTP_SUCCESS_CODES = ('200', '201', '202', '204', '205', '206')
+CHILD_ERROR_CODE = "child.error.code"

--- a/src/monocle_apptrace/instrumentation/metamodel/anthropic/entities/inference.py
+++ b/src/monocle_apptrace/instrumentation/metamodel/anthropic/entities/inference.py
@@ -60,6 +60,15 @@ INFERENCE = {
                     "_comment": "this is result from LLM",
                     "attribute": "response",
                     "accessor": lambda arguments: _helper.extract_assistant_message(arguments)
+                }
+            ]
+        },
+        {
+            "name": "metadata",
+            "attributes": [
+                {
+                    "_comment": "this is metadata usage from LLM",
+                    "accessor": lambda arguments: _helper.update_span_from_llm_response(arguments['result'])
                 },
                 {
                     "_comment": "finish reason from Anthropic response",
@@ -70,15 +79,6 @@ INFERENCE = {
                     "_comment": "finish type mapped from finish reason",
                     "attribute": "finish_type",
                     "accessor": lambda arguments: _helper.map_finish_reason_to_finish_type(_helper.extract_finish_reason(arguments))
-                }
-            ]
-        },
-        {
-            "name": "metadata",
-            "attributes": [
-                {
-                    "_comment": "this is metadata usage from LLM",
-                    "accessor": lambda arguments: _helper.update_span_from_llm_response(arguments['result'])
                 }
             ]
         }

--- a/src/monocle_apptrace/instrumentation/metamodel/azureaiinference/entities/inference.py
+++ b/src/monocle_apptrace/instrumentation/metamodel/azureaiinference/entities/inference.py
@@ -193,16 +193,6 @@ INFERENCE = {
                 {
                     "attribute": "error_code",
                     "accessor": lambda arguments: get_error_message(arguments)
-                },
-                {
-                    "attribute": "finish_reason",
-                    "accessor": lambda arguments: _helper.extract_finish_reason(arguments)
-                },
-                {
-                    "attribute": "finish_type",
-                    "accessor": lambda arguments: _helper.map_finish_reason_to_finish_type(
-                        _helper.extract_finish_reason(arguments)
-                    )
                 }
             ]
         },
@@ -214,6 +204,16 @@ INFERENCE = {
                     "accessor": lambda arguments: _helper.update_span_from_llm_response(
                         arguments['result'], 
                         arguments.get('instance')
+                    )
+                },
+                {
+                    "attribute": "finish_reason",
+                    "accessor": lambda arguments: _helper.extract_finish_reason(arguments)
+                },
+                {
+                    "attribute": "finish_type",
+                    "accessor": lambda arguments: _helper.map_finish_reason_to_finish_type(
+                        _helper.extract_finish_reason(arguments)
                     )
                 }
             ]

--- a/src/monocle_apptrace/instrumentation/metamodel/botocore/entities/inference.py
+++ b/src/monocle_apptrace/instrumentation/metamodel/botocore/entities/inference.py
@@ -51,16 +51,6 @@ INFERENCE = {
                     "_comment": "this is response from LLM",
                     "attribute": "response",
                     "accessor": lambda arguments: _helper.extract_assistant_message(arguments)
-                },
-                {
-                    "attribute": "finish_reason",
-                    "accessor": lambda arguments: _helper.extract_finish_reason(arguments)
-                },
-                {
-                    "attribute": "finish_type",
-                    "accessor": lambda arguments: _helper.map_finish_reason_to_finish_type(
-                        _helper.extract_finish_reason(arguments)
-                    )
                 }
             ]
         },
@@ -71,6 +61,16 @@ INFERENCE = {
                     "_comment": "this is metadata usage from LLM",
                     "accessor": lambda arguments: _helper.update_span_from_llm_response(arguments['result'],
                                                                                         arguments['instance'])
+                },
+                {
+                    "attribute": "finish_reason",
+                    "accessor": lambda arguments: _helper.extract_finish_reason(arguments)
+                },
+                {
+                    "attribute": "finish_type",
+                    "accessor": lambda arguments: _helper.map_finish_reason_to_finish_type(
+                        _helper.extract_finish_reason(arguments)
+                    )
                 }
             ]
         }

--- a/src/monocle_apptrace/instrumentation/metamodel/finish_types.py
+++ b/src/monocle_apptrace/instrumentation/metamodel/finish_types.py
@@ -5,7 +5,6 @@ for different AI providers (OpenAI, Anthropic, Gemini, LangChain, LlamaIndex, Az
 
 from enum import Enum
 
-
 class FinishType(Enum):
     """Enum for standardized finish types across all AI providers."""
     SUCCESS = "success"
@@ -13,7 +12,7 @@ class FinishType(Enum):
     CONTENT_FILTER = "content_filter"
     ERROR = "error"
     REFUSAL = "refusal"
-
+    RATE_LIMITED = "rate_limited"
 
 # OpenAI finish reason mapping
 OPENAI_FINISH_REASON_MAPPING = {
@@ -225,6 +224,13 @@ LANGCHAIN_FINISH_REASON_MAPPING = {
     "OTHER": FinishType.ERROR.value,
 }
 
+TEAMSAI_FINISH_REASON_MAPPING = {
+    "success": FinishType.SUCCESS.value,
+    "error": FinishType.ERROR.value,
+    "too_long": FinishType.TRUNCATED.value,
+    "rate_limited": FinishType.RATE_LIMITED.value,
+    "invalid_response": FinishType.ERROR.value,
+}
 
 def map_openai_finish_reason_to_finish_type(finish_reason):
     """Map OpenAI finish_reason to standardized finish_type."""
@@ -360,4 +366,22 @@ def map_bedrock_finish_reason_to_finish_type(finish_reason):
     elif any(keyword in finish_reason_lower for keyword in ['error', 'fail', 'exception', 'timeout', 'unavailable', 'rate_limit', 'throttled', 'validation']):
         return FinishType.ERROR.value
     
+    return None
+
+def map_teamsai_finish_reason_to_finish_type(finish_reason):
+    """Map TeamsAI finish_reason to standardized finish_type."""
+    if not finish_reason:
+        return None
+
+    # Convert to lowercase for case-insensitive matching
+    finish_reason_lower = finish_reason.lower() if isinstance(finish_reason, str) else str(finish_reason).lower()
+
+    # Try direct mapping first
+    if finish_reason in TEAMSAI_FINISH_REASON_MAPPING:
+        return TEAMSAI_FINISH_REASON_MAPPING[finish_reason]
+
+    # Try lowercase mapping
+    if finish_reason_lower in TEAMSAI_FINISH_REASON_MAPPING:
+        return TEAMSAI_FINISH_REASON_MAPPING[finish_reason_lower]
+
     return None

--- a/src/monocle_apptrace/instrumentation/metamodel/gemini/entities/inference.py
+++ b/src/monocle_apptrace/instrumentation/metamodel/gemini/entities/inference.py
@@ -53,6 +53,15 @@ INFERENCE = {
                 {
                     "attribute": "response",
                     "accessor": lambda arguments: _helper.extract_assistant_message(arguments)
+                }
+            ]
+        },
+        {
+            "name": "metadata",
+            "attributes": [
+                {
+                    "_comment": "this is metadata usage from LLM",
+                    "accessor": lambda arguments: _helper.update_span_from_llm_response(arguments['result'], arguments['instance'])
                 },
                 {
                     "_comment": "finish reason from Gemini response",
@@ -65,15 +74,6 @@ INFERENCE = {
                     "accessor": lambda arguments: _helper.map_finish_reason_to_finish_type(
                         _helper.extract_finish_reason(arguments)
                     )
-                }
-            ]
-        },
-        {
-            "name": "metadata",
-            "attributes": [
-                {
-                    "_comment": "this is metadata usage from LLM",
-                    "accessor": lambda arguments: _helper.update_span_from_llm_response(arguments['result'], arguments['instance'])
                 }
             ]
         }

--- a/src/monocle_apptrace/instrumentation/metamodel/langchain/entities/inference.py
+++ b/src/monocle_apptrace/instrumentation/metamodel/langchain/entities/inference.py
@@ -59,6 +59,15 @@ INFERENCE = {
                 {
                     "attribute": "response",
                     "accessor": lambda arguments: _helper.extract_assistant_message(arguments)
+                }
+            ]
+        },
+        {
+            "name": "metadata",
+            "attributes": [
+                {
+                    "_comment": "this is metadata usage from LLM",
+                    "accessor": lambda arguments: _helper.update_span_from_llm_response(arguments['result'], arguments['instance'])
                 },
                 {
                     "attribute": "finish_reason",
@@ -69,15 +78,6 @@ INFERENCE = {
                     "accessor": lambda arguments: _helper.map_finish_reason_to_finish_type(
                         _helper.extract_finish_reason(arguments)
                     )
-                }
-            ]
-        },
-        {
-            "name": "metadata",
-            "attributes": [
-                {
-                    "_comment": "this is metadata usage from LLM",
-                    "accessor": lambda arguments: _helper.update_span_from_llm_response(arguments['result'], arguments['instance'])
                 }
             ]
         }

--- a/src/monocle_apptrace/instrumentation/metamodel/llamaindex/entities/inference.py
+++ b/src/monocle_apptrace/instrumentation/metamodel/llamaindex/entities/inference.py
@@ -60,6 +60,15 @@ INFERENCE = {
                 {
                     "attribute": "response",
                     "accessor": lambda arguments: _helper.extract_assistant_message(arguments)
+                }
+            ]
+        },
+        {
+            "name": "metadata",
+            "attributes": [
+                {
+                    "_comment": "this is metadata usage from LLM",
+                    "accessor": lambda arguments: _helper.update_span_from_llm_response(arguments['result'],arguments['instance'])
                 },
                 {
                     "attribute": "finish_reason",
@@ -70,15 +79,6 @@ INFERENCE = {
                     "accessor": lambda arguments: _helper.map_finish_reason_to_finish_type(
                         _helper.extract_finish_reason(arguments)
                     )
-                }
-            ]
-        },
-        {
-            "name": "metadata",
-            "attributes": [
-                {
-                    "_comment": "this is metadata usage from LLM",
-                    "accessor": lambda arguments: _helper.update_span_from_llm_response(arguments['result'],arguments['instance'])
                 }
             ]
         }

--- a/src/monocle_apptrace/instrumentation/metamodel/openai/entities/inference.py
+++ b/src/monocle_apptrace/instrumentation/metamodel/openai/entities/inference.py
@@ -211,6 +211,17 @@ INFERENCE = {
                     "accessor": lambda arguments: _helper.extract_assistant_message(
                         arguments,
                     ),
+                }
+            ],
+        },
+        {
+            "name": "metadata",
+            "attributes": [
+                {
+                    "_comment": "this is metadata usage from LLM",
+                    "accessor": lambda arguments: _helper.update_span_from_llm_response(
+                        arguments["result"]
+                    ),
                 },
                 {
                     "_comment": "finish reason from OpenAI response",
@@ -223,17 +234,6 @@ INFERENCE = {
                     "accessor": lambda arguments: _helper.map_finish_reason_to_finish_type(
                         _helper.extract_finish_reason(arguments)
                     )
-                }
-            ],
-        },
-        {
-            "name": "metadata",
-            "attributes": [
-                {
-                    "_comment": "this is metadata usage from LLM",
-                    "accessor": lambda arguments: _helper.update_span_from_llm_response(
-                        arguments["result"]
-                    ),
                 }
             ],
         },

--- a/src/monocle_apptrace/instrumentation/metamodel/teamsai/entities/inference/teamsai_output_processor.py
+++ b/src/monocle_apptrace/instrumentation/metamodel/teamsai/entities/inference/teamsai_output_processor.py
@@ -54,7 +54,7 @@ TEAMAI_OUTPUT_PROCESSOR = {
             "attributes": [
                 {
                     "attribute": "error_code",
-                    "accessor": lambda arguments: get_error_message(arguments)
+                    "accessor": lambda arguments: _helper.extract_status_code(arguments)
                 },
                 {
                     "attribute": "response",

--- a/tests/integration/test_anthropic_finish_reason_integration.py
+++ b/tests/integration/test_anthropic_finish_reason_integration.py
@@ -30,7 +30,7 @@ setup_monocle_telemetry(
 ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY")
 MODEL = os.environ.get("ANTHROPIC_MODEL", "claude-3-5-haiku-latest")
 
-def find_inference_span_and_event_attributes(spans, event_name="data.output"):
+def find_inference_span_and_event_attributes(spans, event_name="metadata"):
     for span in reversed(spans): # Usually the last span is the inference span
         if span.attributes.get("span.type") == "inference":
             for event in span.events:
@@ -59,7 +59,7 @@ def test_finish_reason_end_turn():
     spans = custom_exporter.get_captured_spans()
     assert spans, "No spans were exported"
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     assert output_event_attrs.get("finish_reason") == "end_turn"
     assert output_event_attrs.get("finish_type") == "success"
 
@@ -79,7 +79,7 @@ def test_finish_reason_max_tokens():
     spans = custom_exporter.get_captured_spans()
     assert spans, "No spans were exported"
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     assert output_event_attrs.get("finish_reason") == "max_tokens"
     assert output_event_attrs.get("finish_type") == "truncated"
 
@@ -100,7 +100,7 @@ def test_finish_reason_refusal():
     spans = custom_exporter.get_captured_spans()
     assert spans, "No spans were exported"
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     
     if resp.stop_reason == "refusal":
         assert output_event_attrs.get("finish_reason") == "refusal"
@@ -127,7 +127,7 @@ def test_finish_reason_stop_sequence():
     spans = custom_exporter.get_captured_spans()
     assert spans, "No spans were exported"
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
 
     if resp.stop_reason == "stop_sequence":
         assert output_event_attrs.get("finish_reason") == "stop_sequence"
@@ -169,7 +169,7 @@ def test_finish_reason_tool_use():
     spans = custom_exporter.get_captured_spans()
     assert spans, "No spans were exported"
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
 
     if resp.stop_reason == "tool_use":
         assert output_event_attrs.get("finish_reason") == "tool_use"

--- a/tests/integration/test_azure_ai_inference_finish_reason_integration.py
+++ b/tests/integration/test_azure_ai_inference_finish_reason_integration.py
@@ -28,7 +28,7 @@ AZURE_AI_INFERENCE_ENDPOINT = os.environ.get("AZURE_AI_INFERENCE_ENDPOINT")
 AZURE_AI_INFERENCE_KEY = os.environ.get("AZURE_AI_INFERENCE_KEY")
 
 
-def find_inference_span_and_event_attributes(spans, event_name="data.output"):
+def find_inference_span_and_event_attributes(spans, event_name="metadata"):
     """Find inference span and return event attributes."""
     for span in reversed(spans):  # Usually the last span is the inference span
         if span.attributes.get("span.type"):
@@ -80,7 +80,7 @@ def test_azure_ai_inference_finish_reason_stop():
     assert spans, "No spans were exported"
     
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     
     # Check that finish_reason and finish_type are captured
     finish_reason = output_event_attrs.get("finish_reason")
@@ -127,7 +127,7 @@ def test_azure_ai_inference_finish_reason_length():
     assert spans, "No spans were exported"
     
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     
     finish_reason = output_event_attrs.get("finish_reason")
     finish_type = output_event_attrs.get("finish_type")
@@ -183,7 +183,7 @@ def test_azure_ai_inference_streaming():
     assert spans, "No spans were exported"
     
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     
     finish_reason = output_event_attrs.get("finish_reason")
     finish_type = output_event_attrs.get("finish_type")
@@ -253,7 +253,7 @@ def test_azure_ai_inference_with_tools():
         assert spans, "No spans were exported"
         
         output_event_attrs = find_inference_span_and_event_attributes(spans)
-        assert output_event_attrs, "data.output event not found in inference span"
+        assert output_event_attrs, "metadata event not found in inference span"
         
         finish_reason = output_event_attrs.get("finish_reason")
         finish_type = output_event_attrs.get("finish_type")
@@ -364,7 +364,7 @@ def test_azure_ai_inference_finish_reason_content_filter():
     assert spans, "No spans were exported"
     
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     
     finish_reason = output_event_attrs.get("finish_reason")
     finish_type = output_event_attrs.get("finish_type")

--- a/tests/integration/test_azure_openai_finish_reason_integration.py
+++ b/tests/integration/test_azure_openai_finish_reason_integration.py
@@ -33,7 +33,7 @@ AZURE_OPENAI_DEPLOYMENT = os.environ.get("AZURE_OPENAI_API_DEPLOYMENT") # This i
 # Fallback or default model if specific Azure deployment not set, though tests should ideally use the deployment
 MODEL = os.environ.get("OPENAI_MODEL", "gpt-4o-mini") # Kept for function_model, but primary tests use deployment
 
-def find_inference_span_and_event_attributes(spans, event_name="data.output"):
+def find_inference_span_and_event_attributes(spans, event_name="metadata"):
     for span in reversed(spans):
         if span.attributes.get("span.type") == "inference":
             for event in span.events:
@@ -64,7 +64,7 @@ def test_finish_reason_stop():
     spans = custom_exporter.get_captured_spans()
     assert spans, "No spans were exported"
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     assert output_event_attrs.get("finish_reason") == "stop"
     assert output_event_attrs.get("finish_type") == "success"
 
@@ -88,7 +88,7 @@ def test_finish_reason_length():
     spans = custom_exporter.get_captured_spans()
     assert spans, "No spans were exported"
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     assert output_event_attrs.get("finish_reason") == "length"
     assert output_event_attrs.get("finish_type") == "truncated"
 
@@ -130,7 +130,7 @@ def test_finish_reason_content_filter():
         spans = custom_exporter.get_captured_spans()
         assert spans, "No spans were exported"
         output_event_attrs = find_inference_span_and_event_attributes(spans)
-        assert output_event_attrs, "data.output event not found in inference span"
+        assert output_event_attrs, "metadata event not found in inference span"
         assert output_event_attrs.get("finish_reason") == "content_filter"
         assert output_event_attrs.get("finish_type") == "content_filter"
 
@@ -184,7 +184,7 @@ def test_finish_reason_function_call():
     spans = custom_exporter.get_captured_spans()
     assert spans, "No spans were exported"
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     assert output_event_attrs.get("finish_reason") == "tool_calls"
     assert output_event_attrs.get("finish_type") == "success"
 

--- a/tests/integration/test_bedrock_finish_reason_integration.py
+++ b/tests/integration/test_bedrock_finish_reason_integration.py
@@ -37,7 +37,7 @@ def get_bedrock_client():
     """Get Bedrock runtime client."""
     return boto3.client("bedrock-runtime", region_name=AWS_REGION)
 
-def find_inference_span_and_event_attributes(spans, event_name="data.output"):
+def find_inference_span_and_event_attributes(spans, event_name="metadata"):
     """Find inference span and extract event attributes."""
     for span in reversed(spans):  # Usually the last span is the inference span
         if span.attributes.get("span.type") == "inference":
@@ -76,7 +76,7 @@ def test_bedrock_finish_reason_end_turn():
     spans = custom_exporter.get_captured_spans()
     assert spans, "No spans were exported"
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     assert output_event_attrs.get("finish_reason") == "end_turn"
     assert output_event_attrs.get("finish_type") == "success"
 
@@ -106,7 +106,7 @@ def test_bedrock_finish_reason_max_tokens():
     spans = custom_exporter.get_captured_spans()
     assert spans, "No spans were exported"
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     assert output_event_attrs.get("finish_reason") == "max_tokens"
     assert output_event_attrs.get("finish_type") == "truncated"
         
@@ -138,7 +138,7 @@ def test_bedrock_finish_reason_stop_sequence():
     spans = custom_exporter.get_captured_spans()
     assert spans, "No spans were exported"
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     
     if response["stopReason"] == "stop_sequence":
         assert output_event_attrs.get("finish_reason") == "stop_sequence"
@@ -197,7 +197,7 @@ def test_bedrock_finish_reason_tool_use():
     spans = custom_exporter.get_captured_spans()
     assert spans, "No spans were exported"
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     
     if response["stopReason"] == "tool_use":
         assert output_event_attrs.get("finish_reason") == "tool_use"
@@ -235,7 +235,7 @@ def test_bedrock_finish_reason_content_filter():
     spans = custom_exporter.get_captured_spans()
     assert spans, "No spans were exported"
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     
     if response["stopReason"] == "content_filter":
         assert output_event_attrs.get("finish_reason") == "content_filter"
@@ -279,7 +279,7 @@ def test_bedrock_finish_reason_error_handling():
         spans = custom_exporter.get_captured_spans()
         assert spans, "No spans were exported"
         output_event_attrs = find_inference_span_and_event_attributes(spans)
-        assert output_event_attrs, "data.output event not found in inference span"
+        assert output_event_attrs, "metadata event not found in inference span"
         
         # Should have error finish_reason and finish_type
         assert output_event_attrs.get("finish_reason") == "error"

--- a/tests/integration/test_gemini_finish_reason_integration.py
+++ b/tests/integration/test_gemini_finish_reason_integration.py
@@ -29,7 +29,7 @@ setup_monocle_telemetry(
 GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY")
 MODEL = os.environ.get("GEMINI_MODEL", "gemini-2.5-flash")
 
-def find_inference_span_and_event_attributes(spans, event_name="data.output"):
+def find_inference_span_and_event_attributes(spans, event_name="metadata"):
     for span in reversed(spans):  # Usually the last span is the inference span
         if span.attributes.get("span.type") == "inference":
             for event in span.events:
@@ -59,7 +59,7 @@ def test_finish_reason_stop():
     spans = custom_exporter.get_captured_spans()
     assert spans, "No spans were exported"
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     assert output_event_attrs.get("finish_reason") == "STOP"
     assert output_event_attrs.get("finish_type") == "success"
 
@@ -82,7 +82,7 @@ def test_finish_reason_max_tokens():
     spans = custom_exporter.get_captured_spans()
     assert spans, "No spans were exported"
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     assert output_event_attrs.get("finish_reason") == "MAX_TOKENS"
     assert output_event_attrs.get("finish_type") == "truncated"
 
@@ -107,7 +107,7 @@ def test_finish_reason_safety():
     spans = custom_exporter.get_captured_spans()
     assert spans, "No spans were exported"
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
 
     if finish_reason.name == "SAFETY":
         assert output_event_attrs.get("finish_reason") == "SAFETY"
@@ -137,7 +137,7 @@ def test_finish_reason_recitation():
     spans = custom_exporter.get_captured_spans()
     assert spans, "No spans were exported"
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
 
     if finish_reason.name == "RECITATION":
         assert output_event_attrs.get("finish_reason") == "RECITATION"
@@ -167,7 +167,7 @@ def test_finish_reason_with_system_instruction():
     spans = custom_exporter.get_captured_spans()
     assert spans, "No spans were exported"
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     assert output_event_attrs.get("finish_reason") == "STOP"
     assert output_event_attrs.get("finish_type") == "success"
 
@@ -187,7 +187,7 @@ def test_finish_reason_with_chat():
     spans = custom_exporter.get_captured_spans()
     assert spans, "No spans were exported"
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     assert output_event_attrs.get("finish_reason") == "STOP"
     assert output_event_attrs.get("finish_type") == "success"
 

--- a/tests/integration/test_langchain_finish_reason_integration.py
+++ b/tests/integration/test_langchain_finish_reason_integration.py
@@ -31,7 +31,7 @@ OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
 ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY")
 
 
-def find_inference_span_and_event_attributes(spans, event_name="data.output"):
+def find_inference_span_and_event_attributes(spans, event_name="metadata"):
     """Find inference span and return event attributes."""
     for span in reversed(spans):  # Usually the last span is the inference span
         if span.attributes.get("span.type") == "inference.framework":
@@ -66,7 +66,7 @@ def test_langchain_openai_finish_reason_stop():
     assert spans, "No spans were exported"
     
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     
     # Check that finish_reason and finish_type are captured
     finish_reason = output_event_attrs.get("finish_reason")
@@ -100,7 +100,7 @@ def test_langchain_openai_finish_reason_length():
     assert spans, "No spans were exported"
     
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     
     finish_reason = output_event_attrs.get("finish_reason")
     finish_type = output_event_attrs.get("finish_type")
@@ -133,7 +133,7 @@ def test_langchain_anthropic_finish_reason():
     assert spans, "No spans were exported"
     
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     
     finish_reason = output_event_attrs.get("finish_reason")
     finish_type = output_event_attrs.get("finish_type")
@@ -166,7 +166,7 @@ def test_langchain_anthropic_finish_reason_max_tokens():
     assert spans, "No spans were exported"
     
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     
     finish_reason = output_event_attrs.get("finish_reason")
     finish_type = output_event_attrs.get("finish_type")
@@ -204,7 +204,7 @@ def test_langchain_chat_with_system_message():
     assert spans, "No spans were exported"
     
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     
     finish_reason = output_event_attrs.get("finish_reason")
     finish_type = output_event_attrs.get("finish_type")
@@ -286,7 +286,7 @@ def test_langchain_openai_finish_reason_content_filter():
     assert spans, "No spans were exported"
     
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     
     finish_reason = output_event_attrs.get("finish_reason")
     finish_type = output_event_attrs.get("finish_type")
@@ -323,7 +323,7 @@ def test_langchain_anthropic_finish_reason_content_filter():
     assert spans, "No spans were exported"
     
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     
     finish_reason = output_event_attrs.get("finish_reason")
     finish_type = output_event_attrs.get("finish_type")

--- a/tests/integration/test_llamaindex_finish_reason_integration.py
+++ b/tests/integration/test_llamaindex_finish_reason_integration.py
@@ -28,10 +28,10 @@ OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
 ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY")
 
 
-def find_inference_span_and_event_attributes(spans, event_name="data.output"):
+def find_inference_span_and_event_attributes(spans, event_name="metadata", span_type="inference.framework"):
     """Find inference span and return event attributes."""
     for span in reversed(spans):  # Usually the last span is the inference span
-        if span.attributes.get("span.type") == "inference.framework":
+        if span.attributes.get("span.type") == span_type:
             for event in span.events:
                 if event.name == event_name:
                     return event.attributes
@@ -70,7 +70,7 @@ def test_llamaindex_openai_finish_reason_stop():
     assert spans, "No spans were exported"
     
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     
     # Check that finish_reason and finish_type are captured
     finish_reason = output_event_attrs.get("finish_reason")
@@ -111,7 +111,7 @@ def test_llamaindex_openai_finish_reason_length():
     assert spans, "No spans were exported"
     
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     
     finish_reason = output_event_attrs.get("finish_reason")
     finish_type = output_event_attrs.get("finish_type")
@@ -151,7 +151,7 @@ def test_llamaindex_anthropic_finish_reason():
     assert spans, "No spans were exported"
     
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     
     finish_reason = output_event_attrs.get("finish_reason")
     finish_type = output_event_attrs.get("finish_type")
@@ -191,7 +191,7 @@ def test_llamaindex_anthropic_finish_reason_max_tokens():
     assert spans, "No spans were exported"
     
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     
     finish_reason = output_event_attrs.get("finish_reason")
     finish_type = output_event_attrs.get("finish_type")
@@ -228,8 +228,8 @@ def test_llamaindex_simple_llm_complete():
     spans = custom_exporter.get_captured_spans()
     assert spans, "No spans were exported"
     
-    output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    output_event_attrs = find_inference_span_and_event_attributes(spans, event_name="metadata", span_type="inference")
+    assert output_event_attrs, "metadata event not found in inference span"
     
     finish_reason = output_event_attrs.get("finish_reason")
     finish_type = output_event_attrs.get("finish_type")
@@ -281,7 +281,7 @@ def test_llamaindex_query_engine():
     assert spans, "No spans were exported"
     
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     
     finish_reason = output_event_attrs.get("finish_reason")
     finish_type = output_event_attrs.get("finish_type")
@@ -371,7 +371,7 @@ def test_llamaindex_openai_finish_reason_content_filter():
     assert spans, "No spans were exported"
     
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     
     finish_reason = output_event_attrs.get("finish_reason")
     finish_type = output_event_attrs.get("finish_type")

--- a/tests/integration/test_openai_finish_reason_integration.py
+++ b/tests/integration/test_openai_finish_reason_integration.py
@@ -28,7 +28,7 @@ setup_monocle_telemetry(
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
 MODEL = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
 
-def find_inference_span_and_event_attributes(spans, event_name="data.output"):
+def find_inference_span_and_event_attributes(spans, event_name="metadata"):
     for span in reversed(spans): # Usually the last span is the inference span
         if span.attributes.get("span.type") == "inference":
             for event in span.events:
@@ -55,7 +55,7 @@ def test_finish_reason_stop():
     spans = custom_exporter.get_captured_spans()
     assert spans, "No spans were exported"
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     assert output_event_attrs.get("finish_reason") == "stop"
     assert output_event_attrs.get("finish_type") == "success"
 
@@ -75,7 +75,7 @@ def test_finish_reason_length():
     spans = custom_exporter.get_captured_spans()
     assert spans, "No spans were exported"
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     assert output_event_attrs.get("finish_reason") == "length"
     # Based on provided mapping, 'length' in OpenAI maps to 'truncated'
     assert output_event_attrs.get("finish_type") == "truncated" 
@@ -99,7 +99,7 @@ def test_finish_reason_content_filter():
     spans = custom_exporter.get_captured_spans()
     assert spans, "No spans were exported"
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
 
     if finish_reason == "content_filter":
         assert output_event_attrs.get("finish_reason") == "content_filter"
@@ -147,7 +147,7 @@ def test_finish_reason_function_call():
     spans = custom_exporter.get_captured_spans()
     assert spans, "No spans were exported"
     output_event_attrs = find_inference_span_and_event_attributes(spans)
-    assert output_event_attrs, "data.output event not found in inference span"
+    assert output_event_attrs, "metadata event not found in inference span"
     assert output_event_attrs.get("finish_reason") == "tool_calls"
     assert output_event_attrs.get("finish_type") == "success"
 


### PR DESCRIPTION
## Proposed changes

- Add support for finish types in teams AI
  - Since teams doesn't capture any of the attributes from underlying openAI API, it populated directly from openAI's span processing (similar to token metadata)
  - Also fixed capturing the openAI error code to be reported as part of teams inference error.
- Move finish type to metadata section

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...