### PR TITLE
Fix entity type for MCP tool invocation

### DIFF
--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/entities/inference.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/entities/inference.py
@@ -98,6 +98,7 @@ TOOLS = {
               {
                 "_comment": "tool type",
                 "attribute": "type",
+                "phase": "post_execution",
                 "accessor": lambda arguments: _helper.get_tool_type(arguments['span'])
               },
               {


### PR DESCRIPTION
## Proposed changes

Fixed the entity type to 'tool.mcp' for correct MCP tool invocation, replacing the incorrect 'tool.langgraph'.
The issue is that [get_tool_type] is being called in the pre-execution phase (before the MCP child span sets is_mcp),
By adding "phase": "post_execution" to the [type] function will now be called after the tool execution completes and MCP child span sets is_mcp = True

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...