### PR TITLE
Test tools called agent 2nd part

### DIFF
--- a/test_tools/src/monocle_test_tools/fluent_api.py
+++ b/test_tools/src/monocle_test_tools/fluent_api.py
@@ -141,8 +141,26 @@ class TraceAssertion():
     @collect_assertions
     def called_agent(self, agent_name:str, message:Optional[str] = None) -> 'TraceAssertion':
         """Assert that the given agent was called."""
+        # Phase 1: find agentic.invocation spans for the named agent
         self._filtered_spans = self.validator._get_agent_invocation_spans(agent_name, filtered_spans=self._filtered_spans)
         TraceAssertion._assert_on_spans(self._filtered_spans, f"Agent '{agent_name}' was not called", custom_message=message)
+
+        # Phase 2: for each matched invocation span, collect all spans across the
+        # full span list that share the same scope.agentic.invocation id
+        invocation_ids = {
+            span.attributes.get("scope.agentic.invocation")
+            for span in self._filtered_spans
+            if span.attributes.get("scope.agentic.invocation")
+        }
+        if invocation_ids:
+            seen = {id(span) for span in self._filtered_spans}
+            related = [
+                span for span in self.validator.spans
+                if span.attributes.get("scope.agentic.invocation") in invocation_ids
+                and id(span) not in seen
+            ]
+            self._filtered_spans = list(self._filtered_spans) + related
+
         return self
 
     @collect_assertions


### PR DESCRIPTION
## Proposed changes
  Phase 1 (unchanged): calls _get_agent_invocation_spans which finds spans
  where span.type == "agentic.invocation" and entity.1.name == agent_name.
  Asserts at least one was found.

  Phase 2 (new):
  - Collects all unique scope.agentic.invocation IDs from the phase 1 spans
  - Searches self.validator.spans (the full unfiltered span pool) for any span
  that has a matching scope.agentic.invocation value — this pulls in the
  inference spans, tool spans, skill spans, etc. that belong to the same
  invocation
  - Merges them into self._filtered_spans without duplicates (tracked via
  id(span))

  So after called_agent("SomeAgent"), the fluent chain holds the invocation
  span plus all child spans (inference, tool calls, etc.) that were executed
  under that agent's invocation scope — ready for chaining with has_input,
  called_tool, etc.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...