### PR TITLE
chore(deps): add opentelemetry-exporter-otlp-proto-http as default dependency (#570)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- chore(deps): add `opentelemetry-exporter-otlp-proto-http` as a default dependency so the OTLP exporter works out of the box ([#570](https://github.com/monocle2ai/monocle/issues/570))
 - feat(exporters): add `MONOCLE_CONSOLE` env var to enable console output alongside any configured exporter ([#577](https://github.com/monocle2ai/monocle/pull/577))
 - fix(test_tools): lazy-load `SentenceTransformer` to prevent crash at pytest collection time in network-restricted environments ([#576](https://github.com/monocle2ai/monocle/pull/576))
 

--- a/apptrace/pyproject.toml
+++ b/apptrace/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
    "opentelemetry-api>=1.20.0,<2.0.0",
    "opentelemetry-sdk>=1.20.0,<2.0.0",
    "opentelemetry-instrumentation>=0.41b0",
+   "opentelemetry-exporter-otlp-proto-http>=1.20.0,<2.0.0",
    "pyyaml>=6.0.2",
 ]
 


### PR DESCRIPTION
## Summary

`monocle_exporters.py` advertises an `otlp` exporter wired to
`opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter`,
but the corresponding distribution was missing from `apptrace/pyproject.toml`.
On a clean install, selecting `MONOCLE_EXPORTER=otlp` raises
`ModuleNotFoundError: No module named 'opentelemetry.exporter'`.

This PR adds `opentelemetry-exporter-otlp-proto-http` (the HTTP-only
variant, which matches what monocle actually imports — `proto.http`
in the dotted path) so the OTLP path works out of the box.

## Why HTTP variant rather than the umbrella `opentelemetry-exporter-otlp`

The umbrella package pulls in both HTTP **and** gRPC transports plus their
dependency trees. Monocle only imports the HTTP variant, so the narrower
package keeps the install footprint minimal. If a gRPC OTLP exporter is
added later, the gRPC package can be added at that point.

## Verification

```
$ python -c "from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter; print(OTLPSpanExporter.__name__)"
OTLPSpanExporter

$ MONOCLE_EXPORTER=otlp python -c "from monocle_apptrace.exporters.monocle_exporters import get_monocle_exporter; print(type(get_monocle_exporter()[0]).__name__)"
OTLPSpanExporter
```

Closes #570

---

## Disclosure

This PR was prepared in collaboration with Claude Code (Anthropic).
Author reviewed and verified all changes.