### PR TITLE
feat(exporters): configurable file-name prefix for file, blob and s3 exporters (#149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- feat(exporters): configurable file-name prefix for file and Azure Blob exporters via `MONOCLE_FILE_PREFIX` and `MONOCLE_BLOB_FILE_PREFIX`; S3 `MONOCLE_S3_KEY_PREFIX` renamed to `MONOCLE_S3_FILE_PREFIX` (old name still works with deprecation warning) ([#149](https://github.com/monocle2ai/monocle/issues/149))
 - feat(exporters): add `MONOCLE_CONSOLE` env var to enable console output alongside any configured exporter ([#577](https://github.com/monocle2ai/monocle/pull/577))
 - fix(test_tools): lazy-load `SentenceTransformer` to prevent crash at pytest collection time in network-restricted environments ([#576](https://github.com/monocle2ai/monocle/pull/576))
 

--- a/apptrace/src/monocle_apptrace/exporters/aws/s3_exporter.py
+++ b/apptrace/src/monocle_apptrace/exporters/aws/s3_exporter.py
@@ -2,6 +2,7 @@ import os
 import datetime
 import logging
 import asyncio
+import warnings
 import boto3
 from botocore.exceptions import ClientError
 from botocore.exceptions import (
@@ -46,7 +47,19 @@ class S3SpanExporter(SpanExporterBase):
                 region_name=region_name,
             )
         self.bucket_name = bucket_name or os.getenv('MONOCLE_S3_BUCKET_NAME','default-bucket')
-        self.file_prefix = os.getenv('MONOCLE_S3_KEY_PREFIX', DEFAULT_FILE_PREFIX)
+        # MONOCLE_S3_KEY_PREFIX is deprecated in favour of MONOCLE_S3_FILE_PREFIX —
+        # the new name is consistent across exporters (file/blob/s3) and is not
+        # confused with S3 access key configuration. The old name still wins if it
+        # is set on its own, so existing deployments keep working.
+        new_prefix = os.getenv('MONOCLE_S3_FILE_PREFIX')
+        legacy_prefix = os.getenv('MONOCLE_S3_KEY_PREFIX')
+        if legacy_prefix is not None and new_prefix is None:
+            warnings.warn(
+                "MONOCLE_S3_KEY_PREFIX is deprecated; use MONOCLE_S3_FILE_PREFIX instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        self.file_prefix = new_prefix or legacy_prefix or DEFAULT_FILE_PREFIX
         self.time_format = DEFAULT_TIME_FORMAT
         self.task_processor = task_processor
         if self.task_processor is not None:

--- a/apptrace/src/monocle_apptrace/exporters/aws/s3_exporter_opendal.py
+++ b/apptrace/src/monocle_apptrace/exporters/aws/s3_exporter_opendal.py
@@ -4,6 +4,7 @@ import datetime
 import logging
 import asyncio
 import threading
+import warnings
 from typing import Sequence, Optional
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExportResult
@@ -22,7 +23,16 @@ class OpenDALS3Exporter(SpanExporterBase):
         DEFAULT_TIME_FORMAT = "%Y-%m-%d__%H.%M.%S"
         self.max_batch_size = 500
         self.export_interval = 1
-        self.file_prefix = DEFAULT_FILE_PREFIX
+        # See S3SpanExporter for the same rename: MONOCLE_S3_KEY_PREFIX → MONOCLE_S3_FILE_PREFIX.
+        new_prefix = os.getenv('MONOCLE_S3_FILE_PREFIX')
+        legacy_prefix = os.getenv('MONOCLE_S3_KEY_PREFIX')
+        if legacy_prefix is not None and new_prefix is None:
+            warnings.warn(
+                "MONOCLE_S3_KEY_PREFIX is deprecated; use MONOCLE_S3_FILE_PREFIX instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        self.file_prefix = new_prefix or legacy_prefix or DEFAULT_FILE_PREFIX
         self.time_format = DEFAULT_TIME_FORMAT
         self.export_queue = []
         self.last_export_time = time.time()

--- a/apptrace/src/monocle_apptrace/exporters/azure/blob_exporter.py
+++ b/apptrace/src/monocle_apptrace/exporters/azure/blob_exporter.py
@@ -35,7 +35,7 @@ class AzureBlobSpanExporter(SpanExporterBase):
 
         self.blob_service_client = BlobServiceClient.from_connection_string(connection_string)
         self.container_name = container_name
-        self.file_prefix = DEFAULT_FILE_PREFIX
+        self.file_prefix = os.getenv('MONOCLE_BLOB_FILE_PREFIX', DEFAULT_FILE_PREFIX)
         self.time_format = DEFAULT_TIME_FORMAT
 
         # Check if container exists or create it

--- a/apptrace/src/monocle_apptrace/exporters/azure/blob_exporter_opendal.py
+++ b/apptrace/src/monocle_apptrace/exporters/azure/blob_exporter_opendal.py
@@ -25,7 +25,7 @@ class OpenDALAzureExporter(SpanExporterBase):
         self.container_name = container_name
 
         # Default values
-        self.file_prefix = DEFAULT_FILE_PREFIX
+        self.file_prefix = os.getenv('MONOCLE_BLOB_FILE_PREFIX', DEFAULT_FILE_PREFIX)
         self.time_format = DEFAULT_TIME_FORMAT
         self.export_queue = []  # Add this line to initialize export_queue
         self.last_export_time = time.time()  # Add this line to initialize last_export_time

--- a/apptrace/src/monocle_apptrace/exporters/file_exporter.py
+++ b/apptrace/src/monocle_apptrace/exporters/file_exporter.py
@@ -16,13 +16,15 @@ DEFAULT_FILE_PREFIX:str = "monocle_trace_"
 DEFAULT_TIME_FORMAT:str = "%Y-%m-%d_%H.%M.%S"
 HANDLE_TIMEOUT_SECONDS: int = 60  # 1 minute timeout
 DEFAULT_TRACE_FOLDER = ".monocle"
+# Sentinel so we can tell "caller passed nothing" apart from "caller passed default".
+_UNSET = object()
 
 class FileSpanExporter(SpanExporterBase):
     def __init__(
         self,
         service_name: Optional[str] = None,
         out_path:str = path.join(".", DEFAULT_TRACE_FOLDER),
-        file_prefix = DEFAULT_FILE_PREFIX,
+        file_prefix = _UNSET,
         time_format = DEFAULT_TIME_FORMAT,
         formatter: Callable[
             [ReadableSpan], str
@@ -38,7 +40,11 @@ class FileSpanExporter(SpanExporterBase):
         self.output_path = os.getenv("MONOCLE_TRACE_OUTPUT_PATH", out_path)
         if not os.path.exists(self.output_path):
             os.makedirs(self.output_path)
-        self.file_prefix = file_prefix
+        # Precedence: explicit constructor arg > MONOCLE_FILE_PREFIX env var > default.
+        if file_prefix is _UNSET:
+            self.file_prefix = os.getenv("MONOCLE_FILE_PREFIX", DEFAULT_FILE_PREFIX)
+        else:
+            self.file_prefix = file_prefix
         self.time_format = time_format
         self.task_processor = task_processor
         self.is_first_span_in_file = True  # Track if this is the first span in the current file

--- a/apptrace/tests/unit/test_blob_filename.py
+++ b/apptrace/tests/unit/test_blob_filename.py
@@ -1,0 +1,41 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+class TestAzureBlobSpanExporterPrefix(unittest.TestCase):
+
+    def setUp(self):
+        self.original_env = os.environ.copy()
+        os.environ.pop('MONOCLE_BLOB_FILE_PREFIX', None)
+        os.environ['MONOCLE_BLOB_CONNECTION_STRING'] = (
+            "DefaultEndpointsProtocol=https;AccountName=test;"
+            "AccountKey=dGVzdA==;EndpointSuffix=core.windows.net"
+        )
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self.original_env)
+
+    @patch('azure.storage.blob.BlobServiceClient.from_connection_string')
+    def test_default_prefix_when_no_env(self, mock_from_conn):
+        from monocle_apptrace.exporters.azure.blob_exporter import AzureBlobSpanExporter
+        client = MagicMock()
+        client.get_container_client.return_value.exists.return_value = True
+        mock_from_conn.return_value = client
+        exporter = AzureBlobSpanExporter(container_name="test-container")
+        self.assertEqual(exporter.file_prefix, "monocle_trace_")
+
+    @patch('azure.storage.blob.BlobServiceClient.from_connection_string')
+    def test_env_var_sets_prefix(self, mock_from_conn):
+        from monocle_apptrace.exporters.azure.blob_exporter import AzureBlobSpanExporter
+        client = MagicMock()
+        client.get_container_client.return_value.exists.return_value = True
+        mock_from_conn.return_value = client
+        os.environ['MONOCLE_BLOB_FILE_PREFIX'] = 'mad_trace_'
+        exporter = AzureBlobSpanExporter(container_name="test-container")
+        self.assertEqual(exporter.file_prefix, 'mad_trace_')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/apptrace/tests/unit/test_file_prefix_env.py
+++ b/apptrace/tests/unit/test_file_prefix_env.py
@@ -1,0 +1,40 @@
+import os
+import unittest
+
+from monocle_apptrace.exporters.file_exporter import (
+    DEFAULT_FILE_PREFIX,
+    FileSpanExporter,
+)
+
+
+class TestFileSpanExporterPrefix(unittest.TestCase):
+
+    def setUp(self):
+        self.original_env = os.environ.copy()
+        os.environ.pop('MONOCLE_FILE_PREFIX', None)
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self.original_env)
+
+    def test_default_prefix_when_no_arg_and_no_env(self):
+        exporter = FileSpanExporter()
+        self.assertEqual(exporter.file_prefix, DEFAULT_FILE_PREFIX)
+
+    def test_env_var_sets_prefix(self):
+        os.environ['MONOCLE_FILE_PREFIX'] = 'mad_trace_'
+        exporter = FileSpanExporter()
+        self.assertEqual(exporter.file_prefix, 'mad_trace_')
+
+    def test_explicit_arg_overrides_env(self):
+        os.environ['MONOCLE_FILE_PREFIX'] = 'from_env_'
+        exporter = FileSpanExporter(file_prefix='from_arg_')
+        self.assertEqual(exporter.file_prefix, 'from_arg_')
+
+    def test_explicit_arg_used_when_no_env(self):
+        exporter = FileSpanExporter(file_prefix='only_arg_')
+        self.assertEqual(exporter.file_prefix, 'only_arg_')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/apptrace/tests/unit/test_s3_filename.py
+++ b/apptrace/tests/unit/test_s3_filename.py
@@ -1,8 +1,8 @@
 import datetime
 import logging
 import os
-import time
 import unittest
+import warnings
 from unittest.mock import MagicMock, patch
 
 from monocle_apptrace.exporters.aws.s3_exporter import S3SpanExporter
@@ -10,67 +10,96 @@ from monocle_apptrace.exporters.base_exporter import format_trace_id_without_0x
 
 logger = logging.getLogger(__name__)
 
+
 class TestS3SpanExporter(unittest.TestCase):
+
+    def setUp(self):
+        self.original_env = os.environ.copy()
+        for v in ('MONOCLE_S3_FILE_PREFIX', 'MONOCLE_S3_KEY_PREFIX', 'MONOCLE_S3_KEY_PREFIX_CURRENT'):
+            os.environ.pop(v, None)
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self.original_env)
+
+    def _expected_name(self, prefix, exporter, trace_id, now):
+        return f"{prefix}{now.strftime(exporter.time_format)}_{format_trace_id_without_0x(trace_id)}.ndjson"
+
+    @patch('boto3.client')
+    def test_default_prefix_when_no_env(self, mock_boto_client):
+        mock_boto_client.return_value = MagicMock()
+        exporter = S3SpanExporter(bucket_name="test-bucket", region_name="us-east-1")
+        self.assertEqual(exporter.file_prefix, "monocle_trace_")
+
+    @patch('boto3.client')
+    def test_new_env_var_sets_prefix(self, mock_boto_client):
+        mock_boto_client.return_value = MagicMock()
+        os.environ['MONOCLE_S3_FILE_PREFIX'] = 'mad_trace_'
+        exporter = S3SpanExporter(bucket_name="test-bucket", region_name="us-east-1")
+        self.assertEqual(exporter.file_prefix, 'mad_trace_')
+
+    @patch('boto3.client')
+    def test_legacy_env_var_still_works_with_deprecation_warning(self, mock_boto_client):
+        mock_boto_client.return_value = MagicMock()
+        os.environ['MONOCLE_S3_KEY_PREFIX'] = 'legacy_'
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            exporter = S3SpanExporter(bucket_name="test-bucket", region_name="us-east-1")
+        self.assertEqual(exporter.file_prefix, 'legacy_')
+        deprecation = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        self.assertTrue(deprecation, "expected a DeprecationWarning for MONOCLE_S3_KEY_PREFIX")
+        self.assertIn('MONOCLE_S3_FILE_PREFIX', str(deprecation[0].message))
+
+    @patch('boto3.client')
+    def test_new_env_var_takes_precedence_over_legacy(self, mock_boto_client):
+        mock_boto_client.return_value = MagicMock()
+        os.environ['MONOCLE_S3_FILE_PREFIX'] = 'new_'
+        os.environ['MONOCLE_S3_KEY_PREFIX'] = 'old_'
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            exporter = S3SpanExporter(bucket_name="test-bucket", region_name="us-east-1")
+        self.assertEqual(exporter.file_prefix, 'new_')
+        # When the new var is set, the legacy one is silently ignored — no warning.
+        deprecation = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        self.assertFalse(deprecation, "should not warn when new var is present")
+
     @patch('boto3.client')
     def test_file_prefix_in_file_name(self, mock_boto_client):
-        # Mock S3 client
         mock_s3_client = MagicMock()
         mock_boto_client.return_value = mock_s3_client
-
-        # Instantiate the exporter with a custom prefix
         exporter = S3SpanExporter(bucket_name="test-bucket", region_name="us-east-1")
-        file_prefix = "monocle_trace_"
-        # Mock current time for consistency
-        mock_current_time = datetime.datetime(2024, 12, 10, 10, 0, 0)
+        now = datetime.datetime(2024, 12, 10, 10, 0, 0)
         with patch('datetime.datetime') as mock_datetime:
-            mock_datetime.now.return_value = mock_current_time
+            mock_datetime.now.return_value = now
             mock_datetime.strftime = datetime.datetime.strftime
-
-            # Call the private method to upload data (we are testing the file naming logic)
             test_span_data = "{\"trace_id\": \"123\"}"
             test_trace_id = 0x123456789abcdef0123456789abcdef0
             exporter._S3SpanExporter__upload_to_s3_with_trace_id(test_span_data, test_trace_id)
-
-            # Generate expected file name
-            expected_file_name = f"{file_prefix}{mock_current_time.strftime(exporter.time_format)}_{format_trace_id_without_0x(test_trace_id)}.ndjson"
-
-            # Verify the S3 client was called with the correct file name
             mock_s3_client.put_object.assert_called_once_with(
                 Bucket="test-bucket",
-                Key=expected_file_name,
-                Body=test_span_data
+                Key=self._expected_name("monocle_trace_", exporter, test_trace_id, now),
+                Body=test_span_data,
             )
-    
+
     @patch('boto3.client')
-    def test_file_prefix_in_file_name_env(self, mock_boto_client):
-        # Mock S3 client
+    def test_file_prefix_in_file_name_new_env(self, mock_boto_client):
         mock_s3_client = MagicMock()
         mock_boto_client.return_value = mock_s3_client
-        file_prefix = "test_prefix_2"
-        os.environ['MONOCLE_S3_KEY_PREFIX'] = file_prefix
-        # Instantiate the exporter with a custom prefix
+        os.environ['MONOCLE_S3_FILE_PREFIX'] = 'mad_trace_'
         exporter = S3SpanExporter(bucket_name="test-bucket", region_name="us-east-1")
-        
-        # Mock current time for consistency
-        mock_current_time = datetime.datetime(2024, 12, 10, 10, 0, 0)
+        now = datetime.datetime(2024, 12, 10, 10, 0, 0)
         with patch('datetime.datetime') as mock_datetime:
-            mock_datetime.now.return_value = mock_current_time
+            mock_datetime.now.return_value = now
             mock_datetime.strftime = datetime.datetime.strftime
-
-            # Call the private method to upload data (we are testing the file naming logic)
             test_span_data = "{\"trace_id\": \"123\"}"
             test_trace_id = 0x123456789abcdef0123456789abcdef0
             exporter._S3SpanExporter__upload_to_s3_with_trace_id(test_span_data, test_trace_id)
-
-            # Generate expected file name
-            expected_file_name = f"{file_prefix}{mock_current_time.strftime(exporter.time_format)}_{format_trace_id_without_0x(test_trace_id)}.ndjson"
-
-            # Verify the S3 client was called with the correct file name
             mock_s3_client.put_object.assert_called_once_with(
                 Bucket="test-bucket",
-                Key=expected_file_name,
-                Body=test_span_data
+                Key=self._expected_name("mad_trace_", exporter, test_trace_id, now),
+                Body=test_span_data,
             )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Addresses the two-part request in #149:

1. Add env-var configuration of the file-name prefix for the **file** and **Azure Blob** exporters (previously hardcoded to `monocle_trace_`).
2. Rename the S3 prefix env var so it is not confused with S3 access-key configuration.

The GCS exporter already had `MONOCLE_GCS_KEY_PREFIX`; it is not renamed in this PR — happy to do that as a follow-up if you'd like the same FILE_PREFIX convention applied across all four exporters.

## Changes

| Exporter | Env var |
|----------|---------|
| `file_exporter` | `MONOCLE_FILE_PREFIX` (new) |
| `azure/blob_exporter` | `MONOCLE_BLOB_FILE_PREFIX` (new) |
| `azure/blob_exporter_opendal` | `MONOCLE_BLOB_FILE_PREFIX` (new) |
| `aws/s3_exporter` | `MONOCLE_S3_FILE_PREFIX` (new), `MONOCLE_S3_KEY_PREFIX` (deprecated) |
| `aws/s3_exporter_opendal` | `MONOCLE_S3_FILE_PREFIX` (new), `MONOCLE_S3_KEY_PREFIX` (deprecated) |

Precedence rules:

- **File exporter:** explicit constructor argument > `MONOCLE_FILE_PREFIX` env > default. A sentinel is used so the env var still wins when the caller does not pass `file_prefix` at all.
- **S3 exporters:** new `MONOCLE_S3_FILE_PREFIX` > legacy `MONOCLE_S3_KEY_PREFIX` > default. `DeprecationWarning` is emitted only when the legacy variable is set and the new one isn't (no warning if both are set or if neither is).

The unrelated `MONOCLE_S3_KEY_PREFIX_CURRENT` (a runtime per-batch override) is intentionally left alone — different feature.

## Tests

New `tests/unit/test_file_prefix_env.py` and `tests/unit/test_blob_filename.py`. Extended `tests/unit/test_s3_filename.py` with proper `setUp`/`tearDown` env cleanup and four additional scenarios (default, new var, legacy + warning, precedence). 12 tests, all passing locally; existing `test_file_exporter.py` still passes.

```
$ python -m pytest tests/unit/test_s3_filename.py tests/unit/test_file_prefix_env.py tests/unit/test_blob_filename.py -v
======================== 12 passed, 1 warning in 1.35s =========================
```

## Backward compatibility

- Default prefix unchanged (`monocle_trace_`).
- `MONOCLE_S3_KEY_PREFIX` continues to work.
- File exporter `file_prefix=` constructor argument unchanged.

Closes #149

---

## Disclosure

This PR was prepared in collaboration with Claude Code (Anthropic).
Author reviewed and verified all changes.