### PR TITLE
Copilot CLI and VS Code Copilot Instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,19 +168,21 @@ Monocle supports both **in-app initialization** and **wrapper-style execution** 
 This flexibility is especially useful when platform teams want to inject tracing without touching product code, or when you ship multi-tenant AI platforms.
 
 <details>
-  <summary><b>Instrumenting Claude CLI and Codex CLI</b></summary>
+  <summary><b>Instrumenting Claude CLI, Codex CLI, and GitHub Copilot</b></summary>
 
-  Monocle can trace AI coding assistants that run as CLI tools. Wrap your CLI invocation with Monocle's zero-code mode to capture every LLM call, tool use, and agent step:
+  Monocle can trace the major AI coding assistants. Install once, then register hooks for the CLIs you use:
 
   ```bash
-  # Trace Claude CLI sessions
-  python -m monocle_apptrace claude
+  # Install the Monocle package
+  uv tool install monocle_apptrace
 
-  # Trace OpenAI Codex CLI sessions
-  python -m monocle_apptrace codex
+  # Register hooks (run the ones you use — each prompts for Okahu API key, blank = local file only)
+  monocle-apptrace claude-setup     # Claude Code
+  monocle-apptrace codex-setup      # OpenAI Codex CLI
+  monocle-apptrace copilot-setup    # GitHub Copilot (CLI + VS Code Chat)
   ```
 
-  Traces are emitted to the configured exporter (file, console, or cloud), giving you full visibility into how these assistants interact with your codebase.
+  Start a new session — traces flow automatically to whatever exporter you've configured (file, console, or cloud), giving you full visibility into how these assistants interact with your codebase.
 </details>
 
 ## Supported frameworks and providers
@@ -194,7 +196,7 @@ This flexibility is especially useful when platform teams want to inject tracing
 | **LLM frameworks** | 🟢 Langchain · 🟢 Llamaindex · 🟢 Haystack |
 | **Agent Runtime** | 🟢 AWS Bedrock Agentcore |
 | **LLM inference** | 🟢 OpenAI · 🟢 Azure OpenAI · 🟢 Azure AI · 🟢 Nvidia Triton · 🟢 AWS Bedrock · 🟢 AWS Sagemaker · 🟢 Google Vertex · 🟢 Google Gemini · 🟢 Hugging Face · 🟢 Deepseek · 🟢 Anthropic · 🟢 Mistral · 🟢 LiteLLM · 🔜 Azure ML |
-| **AI coding assistants** | 🟢 Claude CLI · 🟢 OpenAI Codex CLI |
+| **AI coding assistants** | 🟢 Claude CLI · 🟢 OpenAI Codex CLI · 🟢 GitHub Copilot (CLI + VS Code Chat) |
 | **Vector stores** | 🟢 FAISS · 🔜 OpenSearch · 🔜 Milvus |
 | **Exporters** | 🟢 stdout · 🟢 file · 🟢 Memory · 🟢 Azure Blob Storage · 🟢 AWS S3 · 🟢 Okahu cloud · 🟢 OTEL collectors · 🟢 Google Cloud Storage |
 

--- a/apptrace/HOOK_SETUP.md
+++ b/apptrace/HOOK_SETUP.md
@@ -1,6 +1,6 @@
 # Monocle Hook Setup Guide
 
-This guide covers setting up Monocle tracing for Claude Code and Codex CLI.
+This guide covers setting up Monocle tracing for Claude Code, Codex CLI, and GitHub Copilot (Copilot CLI + VS Code Copilot Chat).
 
 ## Setup
 
@@ -25,7 +25,12 @@ monocle-apptrace claude-setup
 monocle-apptrace codex-setup
 ```
 
-Both commands prompt for your Okahu API key and save it to `~/.monocle/.env`. Leave blank to export to a local file only.
+**GitHub Copilot** (covers both Copilot CLI and VS Code Copilot Chat):
+```bash
+monocle-apptrace copilot-setup
+```
+
+All commands prompt for your Okahu API key and save it to `~/.monocle/.env`. Leave blank to export to a local file only.
 
 **Optional overrides** — add to `~/.zshrc` or `~/.bashrc` if you need them:
 
@@ -44,7 +49,7 @@ Start a new session — traces flow automatically.
 Agent session event fires
            │
            ▼
-monocle-apptrace {claude,codex}-hook
+monocle-apptrace {claude,codex,copilot}-hook
            │  (reads event JSON from stdin)
            ▼
 Event Handler — records event to per-session JSONL log
@@ -63,6 +68,11 @@ Exporters — Okahu / file / console
 `PreCompact`, `PostCompact`, `SessionEnd`
 
 **Codex hooks:** `SessionStart`, `SessionStop`
+
+**GitHub Copilot hooks** (10 events, shared by Copilot CLI + VS Code Copilot Chat):
+`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`,
+`PostToolUseFailure`, `SubagentStart`, `SubagentStop`,
+`PreCompact`, `Stop`, `SessionEnd`
 
 **Spans emitted per turn:**
 - `agentic.turn` — the full user turn (prompt → response)

--- a/apptrace/README.md
+++ b/apptrace/README.md
@@ -57,3 +57,20 @@ monocle-apptrace codex-setup
 Start a new Codex session — traces flow automatically.
 
 See [Hook Setup Guide](HOOK_SETUP.md) for complete instructions.
+
+## GitHub Copilot Instrumentation
+
+```bash
+# 1. Install uv (if not already installed)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# 2. Install package
+uv tool install monocle_apptrace
+
+# 3. Register hooks — prompts for Okahu API key (leave blank for local-only)
+monocle-apptrace copilot-setup
+```
+
+Captures traces from both Copilot CLI and VS Code Copilot Chat. Start a session — traces flow automatically.
+
+See [Hook Setup Guide](HOOK_SETUP.md) for complete instructions.

--- a/apptrace/src/monocle_apptrace/cli.py
+++ b/apptrace/src/monocle_apptrace/cli.py
@@ -24,6 +24,83 @@ def _enable_codex_hooks_flag():
     config.write_text(text + sep + "[features]\ncodex_hooks = true\n")
 
 
+def _configure_copilot_otel():
+    """Enable Copilot's native OTel file export for both surfaces (VS Code Chat +
+    Copilot CLI terminal), pointed at one JSON-lines file. We read token usage
+    from it on Stop replay — VS Code Chat doesn't surface tokens via hooks.
+
+    captureContent stays OFF: token counts are emitted as metadata, so we never
+    write prompts/responses/tool args (which is the content-policy-gated part).
+    """
+    otel_dir = Path.home() / ".monocle" / ".copilot_otel"
+    otel_dir.mkdir(parents=True, exist_ok=True)
+    outfile = str(otel_dir / "copilot.jsonl")
+
+    # VS Code Copilot Chat — patch user settings.json.
+    vscode_settings = _vscode_settings_path()
+    if vscode_settings is not None:
+        try:
+            settings = json.loads(vscode_settings.read_text()) if vscode_settings.exists() else {}
+        except Exception:
+            settings = {}
+        settings["github.copilot.chat.otel.enabled"] = True
+        settings["github.copilot.chat.otel.exporterType"] = "file"
+        settings["github.copilot.chat.otel.outfile"] = outfile
+        vscode_settings.parent.mkdir(parents=True, exist_ok=True)
+        vscode_settings.write_text(json.dumps(settings, indent=2) + "\n")
+        print("  VS Code OTel export enabled: {}".format(vscode_settings))
+
+    # Copilot CLI terminal sessions — env vars in the shell rc.
+    rc_path = _shell_rc_path()
+    if rc_path is not None:
+        _ensure_copilot_otel_rc_block(rc_path, outfile)
+        print("  Shell env updated: {}  (open a fresh terminal for CLI sessions)".format(rc_path))
+
+
+def _vscode_settings_path():
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "Code" / "User" / "settings.json"
+    if sys.platform.startswith("linux"):
+        return Path.home() / ".config" / "Code" / "User" / "settings.json"
+    if sys.platform == "win32":
+        appdata = os.environ.get("APPDATA")
+        return Path(appdata) / "Code" / "User" / "settings.json" if appdata else None
+    return None
+
+
+def _shell_rc_path():
+    shell = os.environ.get("SHELL", "")
+    if shell.endswith("zsh"):
+        return Path.home() / ".zshrc"
+    if shell.endswith("bash"):
+        return Path.home() / (".bash_profile" if sys.platform == "darwin" else ".bashrc")
+    return None
+
+
+_OTEL_MARKER = "# >>> monocle copilot otel >>>"
+_OTEL_END_MARKER = "# <<< monocle copilot otel <<<"
+
+
+def _ensure_copilot_otel_rc_block(rc_path, outfile):
+    """Idempotently write the Copilot CLI OTel env block into the shell rc."""
+    block = "\n".join([
+        _OTEL_MARKER,
+        "export COPILOT_OTEL_ENABLED=true",
+        "export COPILOT_OTEL_FILE_EXPORTER_PATH={}".format(outfile),
+        _OTEL_END_MARKER,
+        "",
+    ])
+    existing = rc_path.read_text() if rc_path.exists() else ""
+    if _OTEL_MARKER in existing:
+        before = existing.split(_OTEL_MARKER)[0]
+        after = existing.split(_OTEL_END_MARKER, 1)
+        tail = after[1] if len(after) > 1 else ""
+        rc_path.write_text(before.rstrip() + "\n\n" + block + tail.lstrip())
+    else:
+        sep = "\n" if existing and not existing.endswith("\n") else ""
+        rc_path.write_text(existing + sep + "\n" + block)
+
+
 def _package_version():
     try:
         return importlib.metadata.version("monocle_apptrace")
@@ -186,7 +263,8 @@ def main(argv=None):
     if args.command == "copilot-setup":
         return setup("copilot", "GitHub Copilot",
                      Path.home() / ".copilot" / "hooks" / "monocle.json",
-                     _METAMODEL_DIR / "github_copilot" / "hooks.json")
+                     _METAMODEL_DIR / "github_copilot" / "hooks.json",
+                     _configure_copilot_otel)
     return 1
 
 

--- a/apptrace/src/monocle_apptrace/cli.py
+++ b/apptrace/src/monocle_apptrace/cli.py
@@ -1,4 +1,14 @@
 """Monocle CLI — install hooks for AI coding agents and dispatch hook events.
+
+Subcommands:
+  claude-setup    register Monocle hooks for Claude Code
+  codex-setup     register Monocle hooks for Codex CLI
+  copilot-setup   register Monocle hooks for GitHub Copilot (CLI + VS Code Chat)
+  validate        validate a trace file against the metamodel
+  reset           dev helper — clear local state (REMOVE BEFORE PR)
+
+Hook dispatch (`claude-hook`, `codex-hook`, `copilot-hook`) is invoked as a
+subprocess by each agent when a hook fires — see `main()` for that path.
 """
 import argparse
 import getpass
@@ -9,34 +19,73 @@ import stat
 import sys
 from pathlib import Path
 
-MONOCLE_ENV = Path.home() / ".monocle" / ".env"
+from monocle_apptrace.auth import ui
+
+# Global install → write env config to ~/.monocle/.env (shared across all
+# sessions on this machine). Project install → write to ./.env.monocle in
+# the project root (scoped to that directory only).
+GLOBAL_ENV_FILE = Path.home() / ".monocle" / ".env"
+PROJECT_ENV_FILENAME = ".env.monocle"
+
 _METAMODEL_DIR = Path(__file__).parent / "instrumentation" / "metamodel"
 _HOOK_MARKERS = ("monocle-apptrace", "monocle_apptrace.instrumentation.metamodel")
+_DOCS_URL = "https://docs.okahu.ai/"
+_VSCODE_EXTENSION_URL = "https://marketplace.visualstudio.com/items?itemName=OkahuAI.okahu-ai-observability"
 
 
-def _enable_codex_hooks_flag():
-    config = Path.home() / ".codex" / "config.toml"
-    config.parent.mkdir(parents=True, exist_ok=True)
-    text = config.read_text() if config.exists() else ""
-    if "codex_hooks = true" in text:
-        return
-    sep = "\n" if text and not text.endswith("\n") else ""
-    config.write_text(text + sep + "[features]\ncodex_hooks = true\n")
+# =============================================================================
+# Setup commands  (claude-setup, codex-setup)
+# =============================================================================
 
 
-def _configure_copilot_otel():
-    """Enable Copilot's native OTel file export for both surfaces (VS Code Chat +
-    Copilot CLI terminal), pointed at one JSON-lines file. We read token usage
-    from it on Stop replay — VS Code Chat doesn't surface tokens via hooks.
+def cmd_claude_setup(args):
+    return _run_setup(
+        args,
+        agent="claude",
+        label="Claude Code",
+        hooks_subpath=".claude/settings.json",
+        hooks_template=_METAMODEL_DIR / "claude_cli" / "hooks.json",
+    )
 
-    captureContent stays OFF: token counts are emitted as metadata, so we never
-    write prompts/responses/tool args (which is the content-policy-gated part).
-    """
+
+def cmd_codex_setup(args):
+    return _run_setup(
+        args,
+        agent="codex",
+        label="Codex CLI",
+        hooks_subpath=".codex/hooks.json",
+        hooks_template=_METAMODEL_DIR / "codex_cli" / "hooks.json",
+        post_install=_enable_codex_hooks_flag,
+    )
+
+
+def cmd_copilot_setup(args):
+    return _run_setup(
+        args,
+        agent="copilot",
+        label="GitHub Copilot",
+        # Project → <repo>/.github/hooks/; both Copilot CLI and VS Code Chat discover
+        # .github/hooks/*.json in the workspace by default. Global → ~/.copilot/hooks/.
+        hooks_subpath=".github/hooks/monocle.json",
+        global_hooks_subpath=".copilot/hooks/monocle.json",
+        hooks_template=_METAMODEL_DIR / "github_copilot" / "hooks.json",
+        post_install=_configure_copilot_otel,
+    )
+
+
+def _configure_copilot_otel(scope_root):
+    """Enable Copilot's native OTel file export (VS Code Chat + Copilot CLI) so replay
+    can read token counts. Fixed path (~/.monocle/.copilot_otel/copilot.jsonl) because
+    VS Code only reliably file-exports to a stable outfile."""
     otel_dir = Path.home() / ".monocle" / ".copilot_otel"
     otel_dir.mkdir(parents=True, exist_ok=True)
     outfile = str(otel_dir / "copilot.jsonl")
 
-    # VS Code Copilot Chat — patch user settings.json.
+    # Record the path so replay finds it regardless of cwd/surface (VS Code hooks
+    # don't inherit the shell env, unlike the CLI).
+    env_file = GLOBAL_ENV_FILE if scope_root == Path.home() else scope_root / PROJECT_ENV_FILENAME
+    _save_env(env_file, MONOCLE_COPILOT_OTEL_FILE=outfile)
+
     vscode_settings = _vscode_settings_path()
     if vscode_settings is not None:
         try:
@@ -48,13 +97,12 @@ def _configure_copilot_otel():
         settings["github.copilot.chat.otel.outfile"] = outfile
         vscode_settings.parent.mkdir(parents=True, exist_ok=True)
         vscode_settings.write_text(json.dumps(settings, indent=2) + "\n")
-        print("  VS Code OTel export enabled: {}".format(vscode_settings))
+        ui.hint("VS Code OTel export enabled: " + str(vscode_settings))
 
-    # Copilot CLI terminal sessions — env vars in the shell rc.
     rc_path = _shell_rc_path()
     if rc_path is not None:
         _ensure_copilot_otel_rc_block(rc_path, outfile)
-        print("  Shell env updated: {}  (open a fresh terminal for CLI sessions)".format(rc_path))
+        ui.hint("Shell env updated for Copilot CLI: " + str(rc_path))
 
 
 def _vscode_settings_path():
@@ -77,23 +125,23 @@ def _shell_rc_path():
     return None
 
 
-_OTEL_MARKER = "# >>> monocle copilot otel >>>"
-_OTEL_END_MARKER = "# <<< monocle copilot otel <<<"
+_COPILOT_OTEL_MARKER = "# >>> monocle copilot otel >>>"
+_COPILOT_OTEL_END = "# <<< monocle copilot otel <<<"
 
 
 def _ensure_copilot_otel_rc_block(rc_path, outfile):
-    """Idempotently write the Copilot CLI OTel env block into the shell rc."""
     block = "\n".join([
-        _OTEL_MARKER,
+        _COPILOT_OTEL_MARKER,
         "export COPILOT_OTEL_ENABLED=true",
+        "export COPILOT_OTEL_EXPORTER_TYPE=file",  # CLI ignores the file path without this
         "export COPILOT_OTEL_FILE_EXPORTER_PATH={}".format(outfile),
-        _OTEL_END_MARKER,
+        _COPILOT_OTEL_END,
         "",
     ])
     existing = rc_path.read_text() if rc_path.exists() else ""
-    if _OTEL_MARKER in existing:
-        before = existing.split(_OTEL_MARKER)[0]
-        after = existing.split(_OTEL_END_MARKER, 1)
+    if _COPILOT_OTEL_MARKER in existing:
+        before = existing.split(_COPILOT_OTEL_MARKER)[0]
+        after = existing.split(_COPILOT_OTEL_END, 1)
         tail = after[1] if len(after) > 1 else ""
         rc_path.write_text(before.rstrip() + "\n\n" + block + tail.lstrip())
     else:
@@ -101,16 +149,174 @@ def _ensure_copilot_otel_rc_block(rc_path, outfile):
         rc_path.write_text(existing + sep + "\n" + block)
 
 
-def _package_version():
-    try:
-        return importlib.metadata.version("monocle_apptrace")
-    except importlib.metadata.PackageNotFoundError:
-        return "dev"
+def _run_setup(args, *, agent, label, hooks_subpath, hooks_template, post_install=None, global_hooks_subpath=None):
+    ui.header("Monocle setup", label)
+
+    # 1. Where to install: ~ (global) or cwd (project). global_hooks_subpath
+    #    overrides the global hook dir when it differs from the project one (Copilot).
+    scope = args.scope or _prompt_install_scope(label)
+    if scope == "global":
+        root = Path.home()
+        env_file = GLOBAL_ENV_FILE
+        settings_file = Path.home() / (global_hooks_subpath or hooks_subpath)
+    else:
+        root = Path.cwd()
+        env_file = root / PROJECT_ENV_FILENAME
+        settings_file = root / hooks_subpath
+
+    # 2. Get the API key (or None if the user chose local-only / skip).
+    api_key, aborted = _get_api_key(args)
+    if aborted:
+        return 1
+
+    # 3. Save env and install hooks.
+    if api_key:
+        _save_env(env_file, OKAHU_API_KEY=api_key, MONOCLE_EXPORTER="okahu")
+    else:
+        _save_env(env_file, MONOCLE_EXPORTER="file")
+    _install_hooks(agent, settings_file, hooks_template)
+    if post_install:
+        post_install(root)
+
+    # 4. Done.
+    ui.check("Hooks installed for " + label)
+    ui.blank()
+    ui.hint("Config: " + str(env_file))
+    ui.hint("Hooks:  " + str(settings_file))
+    ui.blank()
+    ui.step(ui.brand("Monocle is ready.") + " Run " + ui.bold(agent) + " to start tracing.")
+    ui.blank()
+    return 0
 
 
-def _save_env(**kwargs):
-    MONOCLE_ENV.parent.mkdir(parents=True, exist_ok=True)
-    lines = MONOCLE_ENV.read_text().splitlines() if MONOCLE_ENV.exists() else ["# Monocle config — edit directly to change settings"]
+# =============================================================================
+# API key resolution
+# =============================================================================
+
+
+def _get_api_key(args):
+    """Decide how to get an OKAHU_API_KEY.
+
+    Returns (api_key, aborted):
+      api_key is the key string, or None for "no key — use file exporter."
+      aborted is True only if the user tried to sign in and it failed.
+    """
+    from monocle_apptrace.auth.okahu_api import OkahuApiError, is_max_api_keys_reached
+    from monocle_apptrace.auth.portal_auth import PortalAuthError, resolve_okahu_api_key
+
+    if args.api_key:
+        return args.api_key, False
+    if args.local_only:
+        return None, False
+
+    existing = _read_existing_key()
+
+    # Pick the sign-in mechanism: explicit flag wins; otherwise reuse the
+    # existing key (with confirmation if interactive); otherwise prompt.
+    if args.portal:
+        method = "loopback"
+    elif args.device:
+        method = "device"
+    elif existing and not sys.stdin.isatty():
+        return existing, False  # CI / scripts: reuse silently
+    elif existing and _confirm_reuse_existing(existing):
+        return existing, False
+    else:
+        method = _prompt_auth_method()
+
+    if method in ("smart", "loopback", "device"):
+        try:
+            result = resolve_okahu_api_key(method=method)
+        except PortalAuthError as e:
+            ui.fail("Sign-in failed: " + str(e))
+            return None, True
+        except OkahuApiError as e:
+            if is_max_api_keys_reached(e):
+                _explain_max_keys_reached()
+            else:
+                ui.fail("Okahu API error: " + str(e))
+            return None, True
+        return result["api_key"], False
+
+    if method == "paste":
+        key = getpass.getpass("  Okahu API key: ").strip()
+        return (key or None), False
+
+    return None, False  # "skip" or anything else falls through here.
+
+
+def _read_existing_key():
+    # Lazy import: get_monocle_env_value transitively pulls in OpenTelemetry,
+    # which we don't want to pay for on `monocle-apptrace --version`.
+    from monocle_apptrace.instrumentation.common.utils import get_monocle_env_value
+    return get_monocle_env_value("OKAHU_API_KEY")
+
+
+def _explain_max_keys_reached():
+    """User-friendly message for the '8 API keys per tenant' cap."""
+    ui.fail("Couldn't generate a new API key — your Okahu tenant has reached the 8-key limit.")
+    ui.blank()
+    ui.hint("Two ways to recover:")
+    ui.hint("  • Reuse one of your existing keys — re-run setup and pick \"Paste an API key\".")
+    ui.hint("  • Delete unused keys at https://portal.okahu.co (Settings → API Keys), then re-run.")
+
+
+def _confirm_reuse_existing(existing_key):
+    masked = existing_key[:6] + "…" + existing_key[-4:] if len(existing_key) > 10 else "…"
+    if ui.confirm("Continue with existing API key " + ui.dim(masked) + "?", default_yes=True):
+        ui.check("Using existing Okahu API key")
+        return True
+    return False
+
+
+# =============================================================================
+# Interactive prompts
+# =============================================================================
+
+
+def _prompt_install_scope(label):
+    if not sys.stdin.isatty():
+        return "global"
+    return ui.select("Where should " + label + " hooks be installed?", [
+        {"key": "global",  "label": "Global",
+         "hint": str(Path.home()) + "  —  all " + label + " sessions on this machine"},
+        {"key": "project", "label": "This project",
+         "hint": str(Path.cwd()) + "  —  only sessions started here"},
+    ])
+
+
+def _prompt_auth_method():
+    if not sys.stdin.isatty():
+        return "skip"
+    return ui.select(
+        "How would you like to authenticate with Okahu?",
+        [
+            {"key": "smart", "label": "Sign in",
+             "hint": "opens your browser, or a code if needed"},
+            {"key": "paste", "label": "Paste an API key",
+             "hint": "if you already have one from the Okahu portal"},
+            {"key": "skip",  "label": "Skip",
+             "hint": "store traces locally and inspect with the VS Code Okahu extension"},
+        ],
+        links=[
+            ("learn more", _DOCS_URL),
+            ("extension", _VSCODE_EXTENSION_URL),
+        ],
+    )
+
+
+# =============================================================================
+# File writers
+# =============================================================================
+
+
+def _save_env(env_file, **kwargs):
+    """Update `env_file`. Each kwarg becomes a `KEY=value` line; existing
+    lines for the same key are replaced in place. File mode is 0600."""
+    env_file.parent.mkdir(parents=True, exist_ok=True)
+    lines = env_file.read_text().splitlines() if env_file.exists() else [
+        "# Monocle config — edit directly to change settings"
+    ]
     for key, value in kwargs.items():
         replaced = False
         for i, line in enumerate(lines):
@@ -123,33 +329,13 @@ def _save_env(**kwargs):
                 break
         if not replaced:
             lines.append("{}={}".format(key, value))
-    MONOCLE_ENV.write_text("\n".join(lines) + "\n")
-    os.chmod(MONOCLE_ENV, stat.S_IRUSR | stat.S_IWUSR)
+    env_file.write_text("\n".join(lines) + "\n")
+    os.chmod(env_file, stat.S_IRUSR | stat.S_IWUSR)
 
 
-def setup(agent, label, settings_file, hooks_template, extra_setup=None):
-    from monocle_apptrace.instrumentation.common.utils import get_monocle_env_value
-
-    api_key = get_monocle_env_value("OKAHU_API_KEY")
-    if api_key:
-        print("Using existing Okahu API key.")
-    else:
-        api_key = getpass.getpass("Okahu API key (leave blank for local-only): ").strip()
-
-    if api_key:
-        _save_env(OKAHU_API_KEY=api_key, MONOCLE_EXPORTER="okahu")
-    else:
-        _save_env(MONOCLE_EXPORTER="file")
-
-    _install_hooks(agent, settings_file, hooks_template, extra_setup)
-
-    print("Monocle hooks installed for {}.".format(label))
-    print("Config: {}".format(MONOCLE_ENV))
-    print("Hooks:  {}".format(settings_file))
-    return 0
-
-
-def _install_hooks(agent, settings_file, hooks_template, extra_setup=None):
+def _install_hooks(agent, settings_file, hooks_template):
+    """Merge Monocle hook entries into the agent's settings file (idempotent —
+    re-running just updates the command if it's already there)."""
     template = json.loads(hooks_template.read_text())["hooks"]
     new_command = "monocle-apptrace {}-hook".format(agent)
 
@@ -163,21 +349,36 @@ def _install_hooks(agent, settings_file, hooks_template, extra_setup=None):
     for event, groups in template.items():
         already_registered = False
         for group in settings["hooks"].get(event, []):
-            # Claude / Codex schema
             for hook in group.get("hooks", []):
                 if any(m in hook.get("command", "") for m in _HOOK_MARKERS):
                     hook["command"] = new_command
                     already_registered = True
-            # Copilot schema
-            if any(m in group.get("command", "") for m in _HOOK_MARKERS):
-                group["command"] = new_command
-                already_registered = True
         if not already_registered:
             settings["hooks"].setdefault(event, []).extend(groups)
 
     settings_file.write_text(json.dumps(settings, indent=2))
-    if extra_setup:
-        extra_setup()
+
+
+def _enable_codex_hooks_flag(scope_root):
+    """Ensure `[features] hooks = true` in Codex's config.toml so hooks fire.
+
+    `hooks` is the canonical key; `codex_hooks` is a deprecated alias that makes
+    Codex print a warning, so migrate it in place when present."""
+    config = scope_root / ".codex" / "config.toml"
+    config.parent.mkdir(parents=True, exist_ok=True)
+    text = config.read_text() if config.exists() else ""
+    if "codex_hooks = true" in text:
+        config.write_text(text.replace("codex_hooks = true", "hooks = true"))
+        return
+    if "hooks = true" in text:
+        return
+    sep = "\n" if text and not text.endswith("\n") else ""
+    config.write_text(text + sep + "[features]\nhooks = true\n")
+
+
+# =============================================================================
+# Hook dispatch  (called by the agent's hook subprocess at runtime)
+# =============================================================================
 
 
 def hook_dispatch(agent):
@@ -194,33 +395,119 @@ def hook_dispatch(agent):
     return 0
 
 
-def cmd_validate(trace_file, level="selective", fail_on_warning=False):
-    """Validate a Monocle trace file"""
+# =============================================================================
+# validate  (lint a trace file against the metamodel)
+# =============================================================================
+
+
+def cmd_validate(args):
     try:
         from monocle_apptrace.linter import MonocleValidator, ValidationReporter
-
         validator = MonocleValidator()
-        results = validator.validate_trace_file(Path(trace_file))
-
-        # Format and print output
+        results = validator.validate_trace_file(Path(args.trace_file))
         reporter = ValidationReporter()
-        output = reporter.format_results(results, fail_on_warning)
-        print(output)
-
-        # Return exit code
-        return reporter.get_exit_code(results, fail_on_warning)
-
+        print(reporter.format_results(results, args.fail_on_warning))
+        return reporter.get_exit_code(results, args.fail_on_warning)
     except FileNotFoundError as e:
-        print(f"ERROR: {e}", file=sys.stderr)
+        print("ERROR: {}".format(e), file=sys.stderr)
         return 1
     except Exception as e:
-        print(f"ERROR: {e}", file=sys.stderr)
+        print("ERROR: {}".format(e), file=sys.stderr)
         return 1
+
+
+# =============================================================================
+# DEV HELPER
+# `monocle-apptrace reset` wipes ~/.monocle/.env, ~/.monocle/auth.json, and
+# the Monocle hook entries in each agent's settings file. Lets us start
+# fresh between test runs during development.
+# =============================================================================
+
+
+def cmd_reset(args):
+    ui.header("Monocle reset")
+
+    cleared = []
+    for path in (
+        GLOBAL_ENV_FILE,
+        Path.home() / ".monocle" / "auth.json",
+        Path.cwd() / PROJECT_ENV_FILENAME,  # project-level env, if reset is run inside a project
+    ):
+        if path.exists():
+            path.unlink()
+            cleared.append(path)
+
+    hook_paths = (
+        Path.home() / ".claude" / "settings.json",
+        Path.cwd()  / ".claude" / "settings.json",
+        Path.home() / ".codex"  / "hooks.json",
+        Path.cwd()  / ".codex"  / "hooks.json",
+    )
+    for path in hook_paths:
+        if path.exists() and _strip_monocle_hooks(path):
+            cleared.append(path)
+
+    if cleared:
+        for p in cleared:
+            ui.check("Cleaned " + str(p))
+    else:
+        ui.step("Nothing to clean.")
+    ui.blank()
+    ui.step(ui.brand("Reset done.") + " Run " + ui.bold("monocle-apptrace claude-setup") + " for a fresh setup.")
+    ui.blank()
+    return 0
+
+
+def _strip_monocle_hooks(settings_file):
+    """Remove Monocle hook entries from a settings file. Returns True if changed."""
+    try:
+        settings = json.loads(settings_file.read_text())
+    except Exception:
+        return False
+    hooks = settings.get("hooks", {})
+    if not hooks:
+        return False
+
+    changed = False
+    for event in list(hooks.keys()):
+        new_groups = []
+        for group in hooks.get(event, []):
+            inner = group.get("hooks", [])
+            kept = [h for h in inner if not any(m in h.get("command", "") for m in _HOOK_MARKERS)]
+            if kept != inner:
+                changed = True
+            if kept:
+                group["hooks"] = kept
+                new_groups.append(group)
+            elif inner:
+                continue  # all inner hooks were monocle — drop the group
+            else:
+                # Copilot-style: command at the group level.
+                if any(m in group.get("command", "") for m in _HOOK_MARKERS):
+                    changed = True
+                else:
+                    new_groups.append(group)
+        if new_groups:
+            hooks[event] = new_groups
+        else:
+            del hooks[event]
+            changed = True
+    if not hooks:
+        settings.pop("hooks", None)
+    if changed:
+        settings_file.write_text(json.dumps(settings, indent=2))
+    return changed
+
+
+# =============================================================================
+# Entry point
+# =============================================================================
 
 
 def main(argv=None):
     argv = sys.argv[1:] if argv is None else list(argv)
 
+    # Hook subprocess paths — invoked by the agent at runtime, no argparse needed.
     if argv and argv[0] == "claude-hook":
         return hook_dispatch("claude")
     if argv and argv[0] == "codex-hook":
@@ -232,40 +519,62 @@ def main(argv=None):
         print("monocle-apptrace {}".format(_package_version()))
         return 0
 
+    args = _build_parser().parse_args(argv)
+
+    if args.command == "claude-setup":
+        return cmd_claude_setup(args)
+    if args.command == "codex-setup":
+        return cmd_codex_setup(args)
+    if args.command == "copilot-setup":
+        return cmd_copilot_setup(args)
+    if args.command == "validate":
+        return cmd_validate(args)
+    if args.command == "reset":
+        return cmd_reset(args)
+    return 1
+
+
+def _package_version():
+    try:
+        return importlib.metadata.version("monocle_apptrace")
+    except importlib.metadata.PackageNotFoundError:
+        return "dev"
+
+
+def _build_parser():
     parser = argparse.ArgumentParser(prog="monocle-apptrace")
     parser.add_argument("--version", action="version",
                         version="monocle-apptrace {}".format(_package_version()))
     sub = parser.add_subparsers(dest="command", required=True, metavar="<command>")
-    sub.add_parser("claude-setup",  help="Register Monocle hooks for Claude Code")
-    sub.add_parser("codex-setup",   help="Register Monocle hooks for Codex CLI")
-    sub.add_parser("copilot-setup", help="Register Monocle hooks for GitHub Copilot (CLI and VS Code agent mode)")
 
-    # Add validate subcommand
-    validate_parser = sub.add_parser("validate", help="Validate Monocle traces against metamodel conformance")
-    validate_parser.add_argument("trace_file", help="Path to trace JSON file")
-    validate_parser.add_argument("--level", choices=["basic", "selective", "strict"],
-                                default="selective", help="Validation level (default: selective)")
-    validate_parser.add_argument("--fail-on-warning", action="store_true",
-                                help="Treat warnings as errors (exit code 1)")
+    # claude-setup and codex-setup share the same flags.
+    for name, help_text in (("claude-setup", "Register Monocle hooks for Claude Code"),
+                            ("codex-setup",  "Register Monocle hooks for Codex CLI"),
+                            ("copilot-setup", "Register Monocle hooks for GitHub Copilot (CLI + VS Code)")):
+        p = sub.add_parser(name, help=help_text)
+        p.add_argument("--api-key", help="Use this API key without prompting")
+        p.add_argument("--portal", action="store_true",
+                       help="Sign in via browser (skip the prompt)")
+        p.add_argument("--device", action="store_true",
+                       help="Sign in with a code (no callback URL; works over SSH)")
+        p.add_argument("--local-only", action="store_true",
+                       help="Write traces to file only, no Okahu key needed")
+        scope_group = p.add_mutually_exclusive_group()
+        scope_group.add_argument("--global", dest="scope", action="store_const", const="global",
+                                 help="Install hooks at ~/.<agent>/ (all sessions on this machine)")
+        scope_group.add_argument("--project", dest="scope", action="store_const", const="project",
+                                 help="Install hooks at ./.<agent>/ (only this directory)")
 
-    args = parser.parse_args(argv)
-    if args.command == "claude-setup":
-        return setup("claude", "Claude Code",
-                     Path.home() / ".claude" / "settings.json",
-                     _METAMODEL_DIR / "claude_cli" / "hooks.json")
-    if args.command == "codex-setup":
-        return setup("codex", "Codex CLI",
-                     Path.home() / ".codex" / "hooks.json",
-                     _METAMODEL_DIR / "codex_cli" / "hooks.json",
-                     _enable_codex_hooks_flag)
-    if args.command == "validate":
-        return cmd_validate(args.trace_file, args.level, args.fail_on_warning)
-    if args.command == "copilot-setup":
-        return setup("copilot", "GitHub Copilot",
-                     Path.home() / ".copilot" / "hooks" / "monocle.json",
-                     _METAMODEL_DIR / "github_copilot" / "hooks.json",
-                     _configure_copilot_otel)
-    return 1
+    sub.add_parser("reset", help="Clear Monocle state (dev helper; will be removed before PR)")
+
+    v = sub.add_parser("validate", help="Validate Monocle traces against metamodel conformance")
+    v.add_argument("trace_file", help="Path to trace JSON file")
+    v.add_argument("--level", choices=["basic", "selective", "strict"],
+                   default="selective", help="Validation level (default: selective)")
+    v.add_argument("--fail-on-warning", action="store_true",
+                   help="Treat warnings as errors (exit code 1)")
+
+    return parser
 
 
 if __name__ == "__main__":

--- a/apptrace/src/monocle_apptrace/cli.py
+++ b/apptrace/src/monocle_apptrace/cli.py
@@ -86,10 +86,15 @@ def _install_hooks(agent, settings_file, hooks_template, extra_setup=None):
     for event, groups in template.items():
         already_registered = False
         for group in settings["hooks"].get(event, []):
+            # Claude / Codex schema
             for hook in group.get("hooks", []):
                 if any(m in hook.get("command", "") for m in _HOOK_MARKERS):
                     hook["command"] = new_command
                     already_registered = True
+            # Copilot schema
+            if any(m in group.get("command", "") for m in _HOOK_MARKERS):
+                group["command"] = new_command
+                already_registered = True
         if not already_registered:
             settings["hooks"].setdefault(event, []).extend(groups)
 
@@ -103,6 +108,8 @@ def hook_dispatch(agent):
         from monocle_apptrace.instrumentation.metamodel.claude_cli.event_handler import main as run
     elif agent == "codex":
         from monocle_apptrace.instrumentation.metamodel.codex_cli.event_handler import main as run
+    elif agent == "copilot":
+        from monocle_apptrace.instrumentation.metamodel.github_copilot.event_handler import main as run
     else:
         print("Unknown agent: {}".format(agent), file=sys.stderr)
         return 1
@@ -141,6 +148,8 @@ def main(argv=None):
         return hook_dispatch("claude")
     if argv and argv[0] == "codex-hook":
         return hook_dispatch("codex")
+    if argv and argv[0] == "copilot-hook":
+        return hook_dispatch("copilot")
 
     if not argv:
         print("monocle-apptrace {}".format(_package_version()))
@@ -150,8 +159,9 @@ def main(argv=None):
     parser.add_argument("--version", action="version",
                         version="monocle-apptrace {}".format(_package_version()))
     sub = parser.add_subparsers(dest="command", required=True, metavar="<command>")
-    sub.add_parser("claude-setup", help="Register Monocle hooks for Claude Code")
-    sub.add_parser("codex-setup",  help="Register Monocle hooks for Codex CLI")
+    sub.add_parser("claude-setup",  help="Register Monocle hooks for Claude Code")
+    sub.add_parser("codex-setup",   help="Register Monocle hooks for Codex CLI")
+    sub.add_parser("copilot-setup", help="Register Monocle hooks for GitHub Copilot (CLI and VS Code agent mode)")
 
     # Add validate subcommand
     validate_parser = sub.add_parser("validate", help="Validate Monocle traces against metamodel conformance")
@@ -173,6 +183,10 @@ def main(argv=None):
                      _enable_codex_hooks_flag)
     if args.command == "validate":
         return cmd_validate(args.trace_file, args.level, args.fail_on_warning)
+    if args.command == "copilot-setup":
+        return setup("copilot", "GitHub Copilot",
+                     Path.home() / ".copilot" / "hooks" / "monocle.json",
+                     _METAMODEL_DIR / "github_copilot" / "hooks.json")
     return 1
 
 

--- a/apptrace/src/monocle_apptrace/instrumentation/common/wrapper_method.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/common/wrapper_method.py
@@ -52,6 +52,8 @@ from monocle_apptrace.instrumentation.metamodel.agentcore.methods import AGENTCO
 from monocle_apptrace.instrumentation.metamodel.claude_cli.methods import CLAUDE_CLI_PROXY_METHODS
 from monocle_apptrace.instrumentation.metamodel.codex_cli.codex_span_handler import CodexSpanHandler
 from monocle_apptrace.instrumentation.metamodel.codex_cli.methods import CODEX_CLI_PROXY_METHODS
+from monocle_apptrace.instrumentation.metamodel.github_copilot.github_copilot_span_handler import GitHubCopilotSpanHandler
+from monocle_apptrace.instrumentation.metamodel.github_copilot.methods import GITHUB_COPILOT_PROXY_METHODS
 
 class WrapperMethod:
     def __init__(
@@ -131,7 +133,8 @@ DEFAULT_METHODS_LIST = (
     STRAND_METHODS +
     AGENTCORE_METHODS +
     CLAUDE_CLI_PROXY_METHODS +
-    CODEX_CLI_PROXY_METHODS
+    CODEX_CLI_PROXY_METHODS +
+    GITHUB_COPILOT_PROXY_METHODS
 )
 
 MONOCLE_SPAN_HANDLERS: Dict[str, SpanHandler] = {
@@ -166,5 +169,6 @@ MONOCLE_SPAN_HANDLERS: Dict[str, SpanHandler] = {
     "adk_handler": AdkSpanHandler(),
     "strands_handler": StrandsSpanHandler(),
     "claude_handler": ClaudeSpanHandler(),
-    "codex_handler": CodexSpanHandler()
+    "codex_handler": CodexSpanHandler(),
+    "github_copilot_handler": GitHubCopilotSpanHandler()
 }

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/__main__.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/__main__.py
@@ -1,0 +1,3 @@
+from monocle_apptrace.cli import hook_dispatch
+
+hook_dispatch("copilot")

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/_helper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/_helper.py
@@ -1,0 +1,58 @@
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+_DESCRIPTION_FIELDS = ("description", "command", "query", "url", "file_path", "filePath", "pattern", "path")
+
+
+def extract_agent_request_input(arguments) -> str:
+    return arguments["kwargs"].get("prompt", "")
+
+
+def extract_agent_response(result) -> str:
+    if isinstance(result, str):
+        return result
+    return str(result) if result else ""
+
+
+def get_tool_type(arguments) -> str:
+    tool_name = arguments["kwargs"].get("tool_name", "")
+    if tool_name.startswith("mcp__"):
+        return "tool.mcp"
+    return "tool.github_copilot"
+
+
+def get_tool_name(arguments) -> str:
+    return arguments["kwargs"].get("tool_name", "")
+
+
+def get_tool_description(arguments) -> str:
+    tool_name = arguments["kwargs"].get("tool_name", "")
+    tool_input = arguments["kwargs"].get("tool_input", {})
+    if tool_name.startswith("mcp__"):
+        parts = tool_name.split("__", 2)
+        return f"{parts[1]} / {parts[2]}" if len(parts) == 3 else tool_name
+    if isinstance(tool_input, dict):
+        for field in _DESCRIPTION_FIELDS:
+            val = tool_input.get(field)
+            if val and isinstance(val, str):
+                return val[:120]
+    if isinstance(tool_input, str) and tool_input:
+        return tool_input[:120]
+    return tool_name
+
+
+def extract_tool_input(arguments) -> str:
+    tool_input = arguments["kwargs"].get("tool_input", {})
+    if isinstance(tool_input, (dict, list)):
+        return json.dumps(tool_input)
+    return str(tool_input) if tool_input else ""
+
+
+def extract_tool_response(result) -> str:
+    if isinstance(result, dict):
+        if "stdout" in result:
+            return result["stdout"]
+        return json.dumps(result)
+    return str(result) if result else ""

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/_otel_tokens.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/_otel_tokens.py
@@ -1,19 +1,28 @@
 """Token usage from Microsoft Copilot's native OTel JSONL export.
 
-VS Code Copilot Chat does not surface token counts through hooks, but its OTel
-file export does — as metadata, so no `captureContent` (and thus no content-policy
-permission) is needed. Each LLM call is a `gen_ai.client.inference.operation.details`
-event carrying `gen_ai.usage.*` and a `spanContext.traceId`.
+Copilot doesn't surface token counts through hooks, but its OTel file export does —
+as metadata, so no `captureContent` (hence no content-policy permission) is needed.
+Two surfaces write to that file in different OTel signal shapes:
 
-Correlation is anchored on the **trace id**: we find the inference events whose
-timestamp falls in the turn's window, take the dominant trace id there, then sum
-every event sharing that trace id. Utility calls (title/summary) carry no trace id
-and are naturally excluded.
+  - VS Code Copilot Chat → an inference *log event*
+    (`gen_ai.client.inference.operation.details`); trace id under `spanContext`,
+    time in `hrTime`.
+  - Copilot CLI → a *chat span* (`type: "span"`, `gen_ai.operation.name: "chat"`);
+    trace id at top level, time in `startTime`.
+
+Both carry identical `gen_ai.usage.*` attributes. `_normalize_record` is the single
+point that collapses either shape into one canonical record; everything downstream
+works on that normalized stream and is surface-agnostic.
+
+Correlation is anchored on the **trace id**: find the inference records whose
+timestamp falls in the turn window, take the dominant trace id, then sum every
+record sharing it. Utility calls (title/summary) carry no trace id and drop out.
 """
 
 import json
 import logging
 import os
+import time
 from collections import Counter
 from datetime import datetime
 from pathlib import Path
@@ -22,12 +31,29 @@ logger = logging.getLogger(__name__)
 
 _INFERENCE_EVENT = "gen_ai.client.inference.operation.details"
 _WINDOW_SLACK_S = 5.0  # tolerate clock/flush skew between hook timestamps and OTel hrTime
+# Copilot's OTel exporter flushes the file asynchronously, so the turn's inference
+# event can land a beat after the Stop hook fires. Poll briefly for it to appear.
+_FLUSH_WAIT_S = 6.0
+_FLUSH_POLL_INTERVAL_S = 0.5
+
+# Keep ~1 day of records, pruned on SessionStart, so the append-only OTel file
+# can't grow unbounded (matches trace_events._TTL_SECONDS).
+_OTEL_TTL_SECONDS = 24 * 60 * 60
 
 
 def _otel_file() -> Path:
-    """Same file the setup points both Copilot surfaces at."""
+    """Where both Copilot surfaces write their OTel export — a FIXED root path,
+    ~/.monocle/.copilot_otel/copilot.jsonl. VS Code only reliably file-exports to a
+    stable outfile, so this must not move per-project. The CLI passes the path via
+    env (wins when present); the recorded env-file value is a secondary fallback."""
     env = os.environ.get("COPILOT_OTEL_FILE_EXPORTER_PATH")
-    return Path(env) if env else Path.home() / ".monocle" / ".copilot_otel" / "copilot.jsonl"
+    if env:
+        return Path(env)
+    from monocle_apptrace.instrumentation.common.utils import get_monocle_env_value
+    configured = get_monocle_env_value("MONOCLE_COPILOT_OTEL_FILE")
+    if configured:
+        return Path(configured)
+    return Path.home() / ".monocle" / ".copilot_otel" / "copilot.jsonl"
 
 
 def _iso_to_epoch(ts: str):
@@ -49,15 +75,41 @@ def _hrtime_to_epoch(hrtime):
         return None
 
 
+def _normalize_record(rec: dict):
+    """The single normalization point: map either Copilot OTel envelope — VS Code
+    Chat's inference *log event* or the CLI's *chat span* — into one canonical token
+    record, or None if the record isn't an inference. Both envelopes carry the same
+    `gen_ai.usage.*` attributes; only the trace-id and timestamp locations differ.
+    """
+    if not isinstance(rec, dict):
+        return None
+    attrs = rec.get("attributes") or {}
+    is_chat_log = attrs.get("event.name") == _INFERENCE_EVENT                        # VS Code Copilot Chat
+    is_chat_span = rec.get("type") == "span" and attrs.get("gen_ai.operation.name") == "chat"  # Copilot CLI
+    if not (is_chat_log or is_chat_span):
+        return None
+    return {
+        "trace_id": rec.get("traceId") or (rec.get("spanContext") or {}).get("traceId") or "",
+        "epoch": _hrtime_to_epoch(rec.get("startTime") or rec.get("hrTime")),
+        "response_id": attrs.get("gen_ai.response.id") or "",
+        "input": attrs.get("gen_ai.usage.input_tokens", 0) or 0,
+        "output": attrs.get("gen_ai.usage.output_tokens", 0) or 0,
+        "cache_read": attrs.get("gen_ai.usage.cache_read.input_tokens", 0) or 0,
+        "reasoning": attrs.get("gen_ai.usage.reasoning.output_tokens", 0) or 0,
+        "model": attrs.get("gen_ai.response.model") or attrs.get("gen_ai.request.model") or "",
+    }
+
+
 def _load_inference_events(path: Path) -> list:
+    """Read the OTel JSONL and return the normalized inference records (both surfaces)."""
     if not path.exists():
         return []
-    events = []
     try:
         lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
     except OSError as e:
         logger.debug("Cannot read Copilot OTel file %s: %s", path, e)
         return []
+    events = []
     for line in lines:
         line = line.strip()
         if not line:
@@ -66,21 +118,9 @@ def _load_inference_events(path: Path) -> list:
             rec = json.loads(line)
         except json.JSONDecodeError:
             continue
-        if not isinstance(rec, dict):
-            continue
-        attrs = rec.get("attributes") or {}
-        if attrs.get("event.name") != _INFERENCE_EVENT:
-            continue
-        events.append({
-            "trace_id": (rec.get("spanContext") or {}).get("traceId") or "",
-            "epoch": _hrtime_to_epoch(rec.get("hrTime")),
-            "response_id": attrs.get("gen_ai.response.id") or "",
-            "input": attrs.get("gen_ai.usage.input_tokens", 0) or 0,
-            "output": attrs.get("gen_ai.usage.output_tokens", 0) or 0,
-            "cache_read": attrs.get("gen_ai.usage.cache_read.input_tokens", 0) or 0,
-            "reasoning": attrs.get("gen_ai.usage.reasoning.output_tokens", 0) or 0,
-            "model": attrs.get("gen_ai.response.model") or attrs.get("gen_ai.request.model") or "",
-        })
+        norm = _normalize_record(rec)
+        if norm is not None:
+            events.append(norm)
     return events
 
 
@@ -97,17 +137,28 @@ def _resolve_trace_id(events: list, start, end) -> str:
     return Counter(e["trace_id"] for e in in_window).most_common(1)[0][0]
 
 
-def lookup_turn_tokens(turn_start: str, turn_end: str):
+def lookup_turn_tokens(turn_start: str, turn_end: str, wait_s: float = _FLUSH_WAIT_S):
     """Return (tokens_dict, trace_id, model) for the turn, or ({}, "", "").
 
     tokens_dict uses Monocle's canonical keys. trace_id is returned so the caller
     can stamp it on the span (provenance for the correlation).
-    """
-    events = _load_inference_events(_otel_file())
-    if not events:
-        return {}, "", ""
 
-    trace_id = _resolve_trace_id(events, _iso_to_epoch(turn_start), _iso_to_epoch(turn_end))
+    Polls the OTel file for up to wait_s seconds: Copilot's exporter flushes
+    asynchronously, so at Stop-hook time the turn's inference event may not be on
+    disk yet. We re-read until an event in the turn window appears (or we give up).
+    """
+    start = _iso_to_epoch(turn_start)
+    end = _iso_to_epoch(turn_end)
+    deadline = time.monotonic() + max(0.0, wait_s)
+    events = []
+    trace_id = ""
+    while True:
+        events = _load_inference_events(_otel_file())
+        trace_id = _resolve_trace_id(events, start, end) if events else ""
+        if trace_id or time.monotonic() >= deadline:
+            break
+        time.sleep(_FLUSH_POLL_INTERVAL_S)
+
     if not trace_id:
         return {}, "", ""
 
@@ -139,3 +190,35 @@ def lookup_turn_tokens(turn_start: str, turn_end: str):
     models = Counter(e["model"] for e in deduped if e["model"])
     model = models.most_common(1)[0][0] if models else ""
     return tokens, trace_id, model
+
+
+def prune_otel_file(ttl_seconds: float = _OTEL_TTL_SECONDS) -> int:
+    """Drop records older than ttl_seconds from the append-only OTel file so it can't
+    grow unbounded. Pruned by record time, not mtime (the file is always being
+    appended to). Called on SessionStart; returns the number of records dropped."""
+    path = _otel_file()
+    if not path.exists():
+        return 0
+    cutoff = time.time() - ttl_seconds
+    kept, dropped = [], 0
+    try:
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            if not line.strip():
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                kept.append(line)  # keep lines we can't parse rather than lose them
+                continue
+            epoch = _hrtime_to_epoch(rec.get("startTime") or rec.get("hrTime"))
+            if epoch is not None and epoch < cutoff:
+                dropped += 1
+            else:
+                kept.append(line)
+        if dropped:
+            tmp = path.with_name(path.name + ".tmp")
+            tmp.write_text("\n".join(kept) + ("\n" if kept else ""), encoding="utf-8")
+            tmp.replace(path)  # atomic swap; a reader never sees a partial file
+    except OSError as e:
+        logger.debug("prune_otel_file: %s", e)
+    return dropped

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/_otel_tokens.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/_otel_tokens.py
@@ -1,0 +1,141 @@
+"""Token usage from Microsoft Copilot's native OTel JSONL export.
+
+VS Code Copilot Chat does not surface token counts through hooks, but its OTel
+file export does — as metadata, so no `captureContent` (and thus no content-policy
+permission) is needed. Each LLM call is a `gen_ai.client.inference.operation.details`
+event carrying `gen_ai.usage.*` and a `spanContext.traceId`.
+
+Correlation is anchored on the **trace id**: we find the inference events whose
+timestamp falls in the turn's window, take the dominant trace id there, then sum
+every event sharing that trace id. Utility calls (title/summary) carry no trace id
+and are naturally excluded.
+"""
+
+import json
+import logging
+import os
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_INFERENCE_EVENT = "gen_ai.client.inference.operation.details"
+_WINDOW_SLACK_S = 5.0  # tolerate clock/flush skew between hook timestamps and OTel hrTime
+
+
+def _otel_file() -> Path:
+    """Same file the setup points both Copilot surfaces at."""
+    env = os.environ.get("COPILOT_OTEL_FILE_EXPORTER_PATH")
+    return Path(env) if env else Path.home() / ".monocle" / ".copilot_otel" / "copilot.jsonl"
+
+
+def _iso_to_epoch(ts: str):
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
+def _hrtime_to_epoch(hrtime):
+    """OTel SDK records time as [seconds, nanoseconds]."""
+    if not isinstance(hrtime, list) or len(hrtime) != 2:
+        return None
+    try:
+        return float(hrtime[0]) + float(hrtime[1]) / 1e9
+    except (TypeError, ValueError):
+        return None
+
+
+def _load_inference_events(path: Path) -> list:
+    if not path.exists():
+        return []
+    events = []
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as e:
+        logger.debug("Cannot read Copilot OTel file %s: %s", path, e)
+        return []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(rec, dict):
+            continue
+        attrs = rec.get("attributes") or {}
+        if attrs.get("event.name") != _INFERENCE_EVENT:
+            continue
+        events.append({
+            "trace_id": (rec.get("spanContext") or {}).get("traceId") or "",
+            "epoch": _hrtime_to_epoch(rec.get("hrTime")),
+            "response_id": attrs.get("gen_ai.response.id") or "",
+            "input": attrs.get("gen_ai.usage.input_tokens", 0) or 0,
+            "output": attrs.get("gen_ai.usage.output_tokens", 0) or 0,
+            "cache_read": attrs.get("gen_ai.usage.cache_read.input_tokens", 0) or 0,
+            "reasoning": attrs.get("gen_ai.usage.reasoning.output_tokens", 0) or 0,
+            "model": attrs.get("gen_ai.response.model") or attrs.get("gen_ai.request.model") or "",
+        })
+    return events
+
+
+def _resolve_trace_id(events: list, start, end) -> str:
+    """The dominant trace id among events whose timestamp is inside the turn window."""
+    in_window = [
+        e for e in events
+        if e["trace_id"] and e["epoch"] is not None
+        and (start is None or e["epoch"] >= start - _WINDOW_SLACK_S)
+        and (end is None or e["epoch"] <= end + _WINDOW_SLACK_S)
+    ]
+    if not in_window:
+        return ""
+    return Counter(e["trace_id"] for e in in_window).most_common(1)[0][0]
+
+
+def lookup_turn_tokens(turn_start: str, turn_end: str):
+    """Return (tokens_dict, trace_id, model) for the turn, or ({}, "", "").
+
+    tokens_dict uses Monocle's canonical keys. trace_id is returned so the caller
+    can stamp it on the span (provenance for the correlation).
+    """
+    events = _load_inference_events(_otel_file())
+    if not events:
+        return {}, "", ""
+
+    trace_id = _resolve_trace_id(events, _iso_to_epoch(turn_start), _iso_to_epoch(turn_end))
+    if not trace_id:
+        return {}, "", ""
+
+    group = [e for e in events if e["trace_id"] == trace_id]
+    # Drop byte-identical duplicate emissions of the same call (same response id
+    # AND same counts); keep distinct rounds even when a response id repeats.
+    seen = set()
+    deduped = []
+    for e in group:
+        key = (e["response_id"], e["input"], e["output"])
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(e)
+
+    inp = sum(e["input"] for e in deduped)
+    out = sum(e["output"] for e in deduped)
+    cache = sum(e["cache_read"] for e in deduped)
+    reasoning = sum(e["reasoning"] for e in deduped)
+    if not inp and not out:
+        return {}, trace_id, ""
+
+    tokens = {"prompt_tokens": inp, "completion_tokens": out, "total_tokens": inp + out}
+    if cache:
+        tokens["cache_read_tokens"] = cache
+    if reasoning:
+        tokens["reasoning_tokens"] = reasoning
+
+    models = Counter(e["model"] for e in deduped if e["model"])
+    model = models.most_common(1)[0][0] if models else ""
+    return tokens, trace_id, model

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/entities/agent.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/entities/agent.py
@@ -59,6 +59,10 @@ INFERENCE = {
                     "attribute": "finish_type",
                     "accessor": lambda arguments: arguments["kwargs"].get("finish_type", ""),
                 },
+                {
+                    "attribute": "otel_trace_id",
+                    "accessor": lambda arguments: arguments["kwargs"].get("otel_trace_id", ""),
+                },
             ],
         },
     ],

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/entities/agent.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/entities/agent.py
@@ -1,0 +1,176 @@
+from monocle_apptrace.instrumentation.common.constants import SPAN_TYPES, SPAN_SUBTYPES
+from monocle_apptrace.instrumentation.common.utils import get_span_id, get_error_message
+from monocle_apptrace.instrumentation.metamodel.github_copilot import _helper
+
+
+def _tool_entity_type(tool_name: str) -> str:
+    if not tool_name:
+        return ""
+    if tool_name.startswith("mcp__"):
+        return "tool.mcp"
+    return "tool.function"
+
+
+INFERENCE = {
+    "type": SPAN_TYPES.INFERENCE,
+    "attributes": [
+        [
+            {"attribute": "type", "accessor": lambda arguments: "inference.github_copilot"},
+            {"attribute": "provider_name", "accessor": lambda arguments: "github_copilot"},
+            {"attribute": "inference_endpoint", "accessor": lambda arguments: "https://githubcopilot.com"},
+        ],
+        [
+            {"attribute": "name", "accessor": lambda arguments: arguments["kwargs"].get("model", "copilot")},
+            {"attribute": "type", "accessor": lambda arguments: "model.llm." + arguments["kwargs"].get("model", "copilot")},
+        ],
+        [
+            {"attribute": "name", "accessor": lambda arguments: arguments["kwargs"].get("tool_name", "")},
+            {"attribute": "type", "accessor": lambda arguments: _tool_entity_type(arguments["kwargs"].get("tool_name", ""))},
+        ],
+    ],
+    "events": [
+        {
+            "name": "data.input",
+            "attributes": [
+                {
+                    "attribute": "input",
+                    "accessor": lambda arguments: arguments["kwargs"].get("input_text", ""),
+                }
+            ],
+        },
+        {
+            "name": "data.output",
+            "attributes": [
+                {
+                    "attribute": "response",
+                    "accessor": lambda arguments: arguments["kwargs"].get("output_text", ""),
+                }
+            ],
+        },
+        {
+            "name": "metadata",
+            "attributes": [
+                {"accessor": lambda arguments: arguments["kwargs"].get("tokens", {})},
+                {
+                    "attribute": "finish_reason",
+                    "accessor": lambda arguments: arguments["kwargs"].get("finish_reason", ""),
+                },
+                {
+                    "attribute": "finish_type",
+                    "accessor": lambda arguments: arguments["kwargs"].get("finish_type", ""),
+                },
+            ],
+        },
+    ],
+}
+
+REQUEST = {
+    "type": SPAN_TYPES.AGENTIC_REQUEST,
+    "subtype": SPAN_SUBTYPES.TURN,
+    "attributes": [
+        [
+            {"attribute": "type", "accessor": lambda arguments: "agent.github_copilot"},
+            {"attribute": "name", "accessor": lambda arguments: "GitHub Copilot"},
+        ]
+    ],
+    "events": [
+        {
+            "name": "data.input",
+            "attributes": [
+                {
+                    "attribute": "input",
+                    "accessor": lambda arguments: _helper.extract_agent_request_input(arguments),
+                }
+            ],
+        },
+        {
+            "name": "data.output",
+            "attributes": [
+                {
+                    "attribute": "response",
+                    "accessor": lambda arguments: _helper.extract_agent_response(arguments["result"]),
+                },
+                {
+                    "attribute": "error_code",
+                    "accessor": lambda arguments: get_error_message(arguments),
+                },
+            ],
+        },
+    ],
+}
+
+INVOCATION = {
+    "type": SPAN_TYPES.AGENTIC_INVOCATION,
+    "subtype": SPAN_SUBTYPES.CONTENT_PROCESSING,
+    "attributes": [
+        [
+            {"attribute": "type", "accessor": lambda arguments: "agent.github_copilot"},
+            {"attribute": "name", "accessor": lambda arguments: "GitHub Copilot"},
+            {"attribute": "from_agent_span_id", "accessor": lambda arguments: get_span_id(arguments["parent_span"])},
+        ]
+    ],
+    "events": [
+        {
+            "name": "data.input",
+            "attributes": [
+                {
+                    "attribute": "input",
+                    "accessor": lambda arguments: arguments["kwargs"].get("prompt", ""),
+                }
+            ],
+        },
+        {
+            "name": "data.output",
+            "attributes": [
+                {
+                    "attribute": "response",
+                    "accessor": lambda arguments: _helper.extract_agent_response(arguments["result"]),
+                },
+                {
+                    "attribute": "error_code",
+                    "accessor": lambda arguments: get_error_message(arguments),
+                },
+            ],
+        },
+    ],
+}
+
+SUBAGENT_INVOCATION = {
+    "type": SPAN_TYPES.AGENTIC_INVOCATION,
+    "subtype": SPAN_SUBTYPES.CONTENT_PROCESSING,
+    "attributes": [
+        [
+            {"attribute": "type", "accessor": lambda arguments: "agent.github_copilot"},
+            {
+                "attribute": "name",
+                "accessor": lambda arguments: arguments["kwargs"].get("agent_type", "agent"),
+            },
+            {
+                "attribute": "description",
+                "accessor": lambda arguments: arguments["kwargs"].get("description", ""),
+            },
+            {"attribute": "from_agent", "accessor": lambda arguments: "GitHub Copilot"},
+            {"attribute": "from_agent_span_id", "accessor": lambda arguments: get_span_id(arguments["parent_span"])},
+        ]
+    ],
+    "events": [
+        {
+            "name": "data.input",
+            "attributes": [
+                {
+                    "attribute": "input",
+                    "accessor": lambda arguments: arguments["kwargs"].get("prompt", ""),
+                }
+            ],
+        },
+        {
+            "name": "data.output",
+            "attributes": [
+                {
+                    "attribute": "response",
+                    "accessor": lambda arguments: _helper.extract_agent_response(arguments["result"]),
+                }
+            ],
+        },
+    ],
+}

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/entities/tool.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/entities/tool.py
@@ -1,0 +1,82 @@
+from monocle_apptrace.instrumentation.common.constants import SPAN_TYPES, SPAN_SUBTYPES
+from monocle_apptrace.instrumentation.common.utils import get_error_message
+from monocle_apptrace.instrumentation.metamodel.github_copilot import _helper
+
+TOOL = {
+    "type": SPAN_TYPES.AGENTIC_TOOL_INVOCATION,
+    "subtype": SPAN_SUBTYPES.CONTENT_GENERATION,
+    "attributes": [
+        [
+            {"attribute": "type", "accessor": lambda arguments: _helper.get_tool_type(arguments)},
+            {"attribute": "name", "accessor": lambda arguments: _helper.get_tool_name(arguments)},
+            {"attribute": "description", "accessor": lambda arguments: _helper.get_tool_description(arguments)},
+        ],
+        [
+            {"attribute": "name", "accessor": lambda arguments: "GitHub Copilot"},
+            {"attribute": "type", "accessor": lambda arguments: "agent.github_copilot"},
+        ],
+    ],
+    "events": [
+        {
+            "name": "data.input",
+            "attributes": [
+                {
+                    "attribute": "input",
+                    "accessor": lambda arguments: _helper.extract_tool_input(arguments),
+                }
+            ],
+        },
+        {
+            "name": "data.output",
+            "attributes": [
+                {
+                    "attribute": "response",
+                    "accessor": lambda arguments: _helper.extract_tool_response(arguments["result"]),
+                },
+                {
+                    "attribute": "error_code",
+                    "accessor": lambda arguments: get_error_message(arguments),
+                },
+            ],
+        },
+    ],
+}
+
+MCP_TOOL = {
+    "type": SPAN_TYPES.AGENTIC_MCP_INVOCATION,
+    "attributes": [
+        [
+            {"attribute": "type", "accessor": lambda arguments: "tool.mcp"},
+            {"attribute": "name", "accessor": lambda arguments: _helper.get_tool_name(arguments)},
+            {"attribute": "description", "accessor": lambda arguments: _helper.get_tool_description(arguments)},
+        ],
+        [
+            {"attribute": "name", "accessor": lambda arguments: "GitHub Copilot"},
+            {"attribute": "type", "accessor": lambda arguments: "agent.github_copilot"},
+        ],
+    ],
+    "events": [
+        {
+            "name": "data.input",
+            "attributes": [
+                {
+                    "attribute": "input",
+                    "accessor": lambda arguments: _helper.extract_tool_input(arguments),
+                }
+            ],
+        },
+        {
+            "name": "data.output",
+            "attributes": [
+                {
+                    "attribute": "response",
+                    "accessor": lambda arguments: _helper.extract_tool_response(arguments["result"]),
+                },
+                {
+                    "attribute": "error_code",
+                    "accessor": lambda arguments: get_error_message(arguments),
+                },
+            ],
+        },
+    ],
+}

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/event_handler.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/event_handler.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Hook entry point for GitHub Copilot (VS Code Copilot Chat + Copilot CLI)."""
+
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+
+from monocle_apptrace.instrumentation.metamodel.github_copilot.trace_events import (
+    _session_log,
+    record_trace_event,
+    mark_subagent_session,
+    is_subagent_session,
+    cleanup_session,
+    sweep_stale_sessions,
+)
+
+logger = logging.getLogger(__name__)
+
+_REPLAY_TRIGGERS = {"Stop"}
+_COMPACTION_TRIGGERS = {"PreCompact"}
+
+
+def _normalize(event: dict) -> dict:
+    """Canonicalize both VS Code Copilot Chat (camelCase, flat tool_response)
+    and Copilot CLI (nested tool_result, agent_name/agent_display_name) into
+    one snake_case shape so the rest of the metamodel is schema-agnostic."""
+    if "session_id" not in event and "sessionId" in event:
+        event["session_id"] = event["sessionId"]
+    if "hook_event_name" not in event and "hookEventName" in event:
+        event["hook_event_name"] = event["hookEventName"]
+    if "tool_use_id" not in event and "toolUseId" in event:
+        event["tool_use_id"] = event["toolUseId"]
+    if "tool_response" not in event and isinstance(event.get("tool_result"), dict):
+        event["tool_response"] = event["tool_result"].get("text_result_for_llm", "")
+    if "agent_id" not in event and "agent_name" in event:
+        event["agent_id"] = event["agent_name"]
+    if "agent_type" not in event and "agent_display_name" in event:
+        event["agent_type"] = event["agent_display_name"]
+    return event
+
+
+def record_event(event_data: dict) -> None:
+    session_id = event_data.get("session_id", "unknown")
+    entry = {"timestamp": datetime.now(timezone.utc).isoformat(), **event_data}
+    with _session_log(session_id).open("a") as fh:
+        fh.write(json.dumps(entry) + "\n")
+    record_trace_event(entry)
+
+
+def _shutdown_emitted_for(session_id: str) -> bool:
+    state_f = _session_log(session_id).with_suffix(".state.json")
+    try:
+        return bool(json.loads(state_f.read_text()).get("shutdown_emitted"))
+    except Exception:
+        return False
+
+
+def _retry_pending_copilot_cli_sessions() -> None:
+    """Copilot CLI writes `session.shutdown` to the transcript a few ms AFTER
+    the SessionEnd hook returns, so the synchronous replay-on-SessionEnd misses
+    it. Catch up here on the next SessionStart, when those transcripts are
+    stable. No-op for VS Code Copilot Chat (replay_session early-exits)."""
+    from monocle_apptrace.instrumentation.metamodel.github_copilot.trace_events import _sessions_dir
+    from monocle_apptrace.instrumentation.metamodel.github_copilot.replay import replay_session
+    sessions = _sessions_dir()
+    if not sessions.exists():
+        return
+    prefix = ".monocle_copilot_"
+    for f in sessions.iterdir():
+        if not (f.is_file() and f.name.startswith(prefix) and f.name.endswith(".jsonl")):
+            continue
+        sid = f.name[len(prefix):-len(".jsonl")]
+        state_f = f.with_suffix(".state.json")
+        if not state_f.exists():
+            continue
+        try:
+            if json.loads(state_f.read_text()).get("shutdown_emitted"):
+                continue
+        except Exception:
+            continue
+        try:
+            replay_session(sid)
+        except Exception as e:
+            logger.debug(f"retry_pending: replay({sid}) failed: {e}")
+            continue
+        if _shutdown_emitted_for(sid):
+            cleanup_session(sid)
+
+
+def main() -> None:
+    raw = sys.stdin.read()
+    try:
+        event_data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.debug(f"ERROR: could not parse stdin as JSON – {exc}")
+        sys.exit(1)
+
+    event_data = _normalize(event_data)
+    session_id = event_data.get("session_id", "unknown")
+    event_name = event_data.get("hook_event_name", "unknown")
+
+    if event_name == "SessionStart":
+        sweep_stale_sessions()
+        _retry_pending_copilot_cli_sessions()
+
+    record_event(event_data)
+    logger.debug(f"Recorded {event_name} for session {session_id}")
+
+    if event_name == "SubagentStart":
+        agent_id = event_data.get("agent_id", "")
+        if agent_id:
+            mark_subagent_session(agent_id)
+
+    if event_name in _REPLAY_TRIGGERS:
+        if is_subagent_session(session_id):
+            logger.debug(f"Skipping replay for subagent session {session_id}")
+        else:
+            from monocle_apptrace.instrumentation.metamodel.github_copilot.replay import replay_session
+            try:
+                replay_session(session_id)
+            except Exception as e:
+                logger.debug(f"Replay error: {e}")
+
+    if event_name in _COMPACTION_TRIGGERS:
+        from monocle_apptrace.instrumentation.metamodel.github_copilot.replay import replay_compaction
+        try:
+            replay_compaction(session_id)
+        except Exception as e:
+            logger.debug(f"Compaction replay error: {e}")
+
+    if event_name == "SessionEnd":
+        try:
+            from monocle_apptrace.instrumentation.metamodel.github_copilot.replay import replay_session
+            replay_session(session_id)
+        except Exception as e:
+            logger.debug(f"Replay-on-SessionEnd error: {e}")
+        # Skip cleanup if shutdown wasn't emitted; next SessionStart retries.
+        if _shutdown_emitted_for(session_id):
+            cleanup_session(session_id)
+
+    sys.stdout.write("{}")
+
+
+if __name__ == "__main__":
+    main()

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/event_handler.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/event_handler.py
@@ -14,6 +14,7 @@ from monocle_apptrace.instrumentation.metamodel.github_copilot.trace_events impo
     cleanup_session,
     sweep_stale_sessions,
 )
+from monocle_apptrace.instrumentation.metamodel.github_copilot._otel_tokens import prune_otel_file
 
 logger = logging.getLogger(__name__)
 
@@ -102,6 +103,7 @@ def main() -> None:
 
     if event_name == "SessionStart":
         sweep_stale_sessions()
+        prune_otel_file()
         _retry_pending_copilot_cli_sessions()
 
     record_event(event_data)

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/github_copilot_span_handler.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/github_copilot_span_handler.py
@@ -1,0 +1,36 @@
+import datetime
+
+from monocle_apptrace.instrumentation.common.span_handler import SpanHandler
+from opentelemetry.context import attach, get_current, set_value, Context
+from monocle_apptrace.instrumentation.common.constants import (
+    SPAN_START_TIME,
+    SPAN_END_TIME,
+    AGENT_SESSION,
+)
+from monocle_apptrace.instrumentation.common.utils import set_scope
+
+
+class GitHubCopilotSpanHandler(SpanHandler):
+    @staticmethod
+    def _iso_to_ns(ts_str: str) -> int:
+        """Convert an ISO 8601 timestamp string to nanoseconds since Unix epoch."""
+        return int(datetime.datetime.fromisoformat(ts_str.replace("Z", "+00:00")).timestamp() * 1e9)
+
+    def _set_span_times(self, kwargs):
+        start_time = end_time = None
+        token_context: Context = None
+        if SPAN_START_TIME in kwargs:
+            start_time = kwargs.pop(SPAN_START_TIME)
+        if SPAN_END_TIME in kwargs:
+            end_time = kwargs.pop(SPAN_END_TIME)
+        if start_time:
+            token_context = set_value(SPAN_START_TIME, GitHubCopilotSpanHandler._iso_to_ns(start_time), token_context)
+        if end_time:
+            token_context = set_value(SPAN_END_TIME, GitHubCopilotSpanHandler._iso_to_ns(end_time), token_context)
+        if AGENT_SESSION in kwargs:
+            token_context = set_value(AGENT_SESSION, kwargs.get(AGENT_SESSION), token_context)
+            return set_scope(AGENT_SESSION, kwargs.get(AGENT_SESSION), token_context)
+        return attach(token_context if token_context is not None else get_current())
+
+    def pre_tracing(self, to_wrap, wrapped, instance, args, kwargs):
+        return self._set_span_times(kwargs), None

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/hooks.json
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/hooks.json
@@ -1,0 +1,64 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "type": "command",
+        "command": "monocle-apptrace copilot-hook"
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "type": "command",
+        "command": "monocle-apptrace copilot-hook"
+      }
+    ],
+    "PreToolUse": [
+      {
+        "type": "command",
+        "command": "monocle-apptrace copilot-hook"
+      }
+    ],
+    "PostToolUse": [
+      {
+        "type": "command",
+        "command": "monocle-apptrace copilot-hook"
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "type": "command",
+        "command": "monocle-apptrace copilot-hook"
+      }
+    ],
+    "SubagentStart": [
+      {
+        "type": "command",
+        "command": "monocle-apptrace copilot-hook"
+      }
+    ],
+    "SubagentStop": [
+      {
+        "type": "command",
+        "command": "monocle-apptrace copilot-hook"
+      }
+    ],
+    "PreCompact": [
+      {
+        "type": "command",
+        "command": "monocle-apptrace copilot-hook"
+      }
+    ],
+    "Stop": [
+      {
+        "type": "command",
+        "command": "monocle-apptrace copilot-hook"
+      }
+    ],
+    "SessionEnd": [
+      {
+        "type": "command",
+        "command": "monocle-apptrace copilot-hook"
+      }
+    ]
+  }
+}

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/hooks.json
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/hooks.json
@@ -2,62 +2,112 @@
   "hooks": {
     "SessionStart": [
       {
-        "type": "command",
-        "command": "monocle-apptrace copilot-hook"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "monocle-apptrace copilot-hook",
+            "statusMessage": "Monocle telemetry"
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [
       {
-        "type": "command",
-        "command": "monocle-apptrace copilot-hook"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "monocle-apptrace copilot-hook",
+            "statusMessage": "Monocle telemetry"
+          }
+        ]
       }
     ],
     "PreToolUse": [
       {
-        "type": "command",
-        "command": "monocle-apptrace copilot-hook"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "monocle-apptrace copilot-hook",
+            "statusMessage": "Monocle telemetry"
+          }
+        ]
       }
     ],
     "PostToolUse": [
       {
-        "type": "command",
-        "command": "monocle-apptrace copilot-hook"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "monocle-apptrace copilot-hook",
+            "statusMessage": "Monocle telemetry"
+          }
+        ]
       }
     ],
     "PostToolUseFailure": [
       {
-        "type": "command",
-        "command": "monocle-apptrace copilot-hook"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "monocle-apptrace copilot-hook",
+            "statusMessage": "Monocle telemetry"
+          }
+        ]
       }
     ],
     "SubagentStart": [
       {
-        "type": "command",
-        "command": "monocle-apptrace copilot-hook"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "monocle-apptrace copilot-hook",
+            "statusMessage": "Monocle telemetry"
+          }
+        ]
       }
     ],
     "SubagentStop": [
       {
-        "type": "command",
-        "command": "monocle-apptrace copilot-hook"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "monocle-apptrace copilot-hook",
+            "statusMessage": "Monocle telemetry"
+          }
+        ]
       }
     ],
     "PreCompact": [
       {
-        "type": "command",
-        "command": "monocle-apptrace copilot-hook"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "monocle-apptrace copilot-hook",
+            "statusMessage": "Monocle telemetry"
+          }
+        ]
       }
     ],
     "Stop": [
       {
-        "type": "command",
-        "command": "monocle-apptrace copilot-hook"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "monocle-apptrace copilot-hook",
+            "statusMessage": "Monocle telemetry"
+          }
+        ]
       }
     ],
     "SessionEnd": [
       {
-        "type": "command",
-        "command": "monocle-apptrace copilot-hook"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "monocle-apptrace copilot-hook",
+            "statusMessage": "Monocle telemetry"
+          }
+        ]
       }
     ]
   }

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/methods.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/methods.py
@@ -1,0 +1,69 @@
+from monocle_apptrace.instrumentation.common.wrapper import task_wrapper
+from monocle_apptrace.instrumentation.metamodel.github_copilot.entities.agent import (
+    INFERENCE,
+    INVOCATION,
+    REQUEST,
+    SUBAGENT_INVOCATION,
+)
+from monocle_apptrace.instrumentation.metamodel.github_copilot.entities.tool import MCP_TOOL, TOOL
+
+_PKG = "monocle_apptrace.instrumentation.metamodel.github_copilot.replay_handlers"
+_OBJ = "ReplayHandler"
+_HANDLER = "github_copilot_handler"
+
+GITHUB_COPILOT_PROXY_METHODS = [
+    {
+        "package": _PKG,
+        "object": _OBJ,
+        "method": "handle_turn",
+        "span_name": "Copilot Agent",
+        "wrapper_method": task_wrapper,
+        "output_processor": REQUEST,
+        "span_handler": _HANDLER,
+    },
+    {
+        "package": _PKG,
+        "object": _OBJ,
+        "method": "handle_invocation",
+        "span_name": "Copilot Invocation",
+        "wrapper_method": task_wrapper,
+        "output_processor": INVOCATION,
+        "span_handler": _HANDLER,
+    },
+    {
+        "package": _PKG,
+        "object": _OBJ,
+        "method": "handle_inference_round",
+        "span_name": "Copilot Inference",
+        "wrapper_method": task_wrapper,
+        "output_processor": INFERENCE,
+        "span_handler": _HANDLER,
+    },
+    {
+        "package": _PKG,
+        "object": _OBJ,
+        "method": "handle_tool_call",
+        "span_name": "Tool",
+        "wrapper_method": task_wrapper,
+        "output_processor": TOOL,
+        "span_handler": _HANDLER,
+    },
+    {
+        "package": _PKG,
+        "object": _OBJ,
+        "method": "handle_mcp_call",
+        "span_name": "MCP Tool",
+        "wrapper_method": task_wrapper,
+        "output_processor": MCP_TOOL,
+        "span_handler": _HANDLER,
+    },
+    {
+        "package": _PKG,
+        "object": _OBJ,
+        "method": "handle_subagent",
+        "span_name": "Sub-Agent",
+        "wrapper_method": task_wrapper,
+        "output_processor": SUBAGENT_INVOCATION,
+        "span_handler": _HANDLER,
+    },
+]

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/replay.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/replay.py
@@ -395,46 +395,6 @@ def _build_subagent_records(interaction: dict, subagent_outputs_by_id: dict) -> 
     return records
 
 
-def _normalize_tokens(usage: dict) -> dict:
-    """Canonicalize Copilot CLI's modelMetrics.usage. prompt_tokens sums
-    input+cacheRead+cacheWrite — raw inputTokens alone undercounts cached
-    prompts on warm sessions."""
-    input_t = usage.get("inputTokens", 0) or 0
-    output_t = usage.get("outputTokens", 0) or 0
-    cache_read = usage.get("cacheReadTokens", 0) or 0
-    cache_write = usage.get("cacheWriteTokens", 0) or 0
-    reasoning = usage.get("reasoningTokens", 0) or 0
-    prompt_t = input_t + cache_read + cache_write
-    if not prompt_t and not output_t:
-        return {}
-    return {
-        "prompt_tokens": prompt_t,
-        "completion_tokens": output_t,
-        "total_tokens": prompt_t + output_t,
-        "input_tokens": input_t,
-        "cache_read_tokens": cache_read,
-        "cache_creation_tokens": cache_write,
-        "reasoning_tokens": reasoning,
-    }
-
-
-def _extract_session_totals(transcript_events: list) -> dict:
-    """Latest session.shutdown event with per-model token totals. Empty for
-    VS Code Copilot Chat (no shutdown event)."""
-    shutdown = next(
-        (e for e in reversed(transcript_events) if e.get("type") == "session.shutdown"),
-        None,
-    )
-    if not shutdown:
-        return {}
-    data = shutdown.get("data") or {}
-    return {
-        "model_metrics": data.get("modelMetrics") or {},
-        "total_api_duration_ms": data.get("totalApiDurationMs", 0) or 0,
-        "shutdown_ts": shutdown.get("timestamp", ""),
-    }
-
-
 def replay_session(session_id: str) -> None:
     if not session_id:
         return
@@ -459,15 +419,13 @@ def _replay_session_locked(session_id: str) -> None:
 
     state = _load_state(session_id)
     already = set(state.get("interactions_processed", []))
-    shutdown_emitted = state.get("shutdown_emitted", False)
     # Skip interactions with no assistant response and not flagged interrupted (still mid-flight).
     new_interactions = [
         i for i in interactions
         if i["id"] not in already and (i.get("assistant_messages") or i.get("interrupted"))
     ]
-    session_totals = _extract_session_totals(transcript_events) if not shutdown_emitted else {}
 
-    if not new_interactions and not session_totals.get("model_metrics"):
+    if not new_interactions:
         return
 
     parent_outputs, subagent_outputs = _index_tool_outputs(hook_events, subagent_intervals)
@@ -488,10 +446,9 @@ def _replay_session_locked(session_id: str) -> None:
         round_dict = _build_inference_round(interaction, prompt)
         turn_tokens = {}
         turn_model = interaction.get("model", "copilot")
-        # VS Code Copilot Chat gives no tokens via hooks. Pull them from Copilot's
-        # own OTel export, anchored by trace id. Skipped for Copilot CLI, which
-        # already reports tokens via its transcript (session.shutdown rollup).
-        if round_dict and not session_totals.get("model_metrics"):
+        # Token counts come from Copilot's own OTel export — both VS Code Chat and
+        # the CLI write it — anchored by trace id within the turn window.
+        if round_dict:
             otel_tokens, otel_trace_id, otel_model = lookup_turn_tokens(
                 round_dict[SPAN_START_TIME], round_dict[SPAN_END_TIME]
             )
@@ -519,32 +476,7 @@ def _replay_session_locked(session_id: str) -> None:
             logger.debug(f"Turn replay failed for {iid}: {e}")
         already.add(iid)
 
-    # Copilot CLI session.shutdown rollup — one inference-shaped span per model.
-    if session_totals.get("model_metrics"):
-        shutdown_ts = session_totals.get("shutdown_ts", "")
-        session_start_ts = interactions[0].get("turn_start") if interactions else shutdown_ts
-        session_end_ts = shutdown_ts or session_start_ts
-        for model_name, metrics in session_totals["model_metrics"].items():
-            tokens = _normalize_tokens(metrics.get("usage") or {})
-            if not tokens:
-                continue
-            try:
-                handler.handle_inference_round(
-                    input_text="",
-                    output_text="",
-                    model=model_name,
-                    tokens=tokens,
-                    tool_name="",
-                    finish_reason="session_summary",
-                    finish_type="aggregate",
-                    **{SPAN_START_TIME: session_start_ts, SPAN_END_TIME: session_end_ts, AGENT_SESSION: session_id},
-                )
-                shutdown_emitted = True
-            except Exception as e:
-                logger.debug(f"Session summary span failed for {model_name}: {e}")
-
     state["interactions_processed"] = list(already)
-    state["shutdown_emitted"] = shutdown_emitted
     _save_state(session_id, state)
 
 

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/replay.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/replay.py
@@ -1,0 +1,564 @@
+"""Replay a GitHub Copilot session's transcript into Monocle spans on Stop."""
+
+import json
+import logging
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Optional
+
+try:
+    import fcntl  # POSIX only
+except ImportError:
+    fcntl = None
+
+from monocle_apptrace.instrumentation.common.constants import (
+    AGENT_SESSION,
+    SPAN_START_TIME,
+    SPAN_END_TIME,
+)
+from monocle_apptrace.instrumentation.metamodel.github_copilot.trace_events import (
+    _session_log,
+    _sessions_dir,
+)
+from monocle_apptrace.instrumentation.metamodel.github_copilot.replay_handlers import ReplayHandler
+
+logger = logging.getLogger(__name__)
+
+_SUBAGENT_LAUNCHER_TOOL_NAMES = {"runSubagent"}  # filtered from parent tool list
+
+_telemetry_ready = False
+
+
+def _configure_telemetry():
+    global _telemetry_ready
+    if _telemetry_ready:
+        return
+    from monocle_apptrace.instrumentation.common.utils import get_monocle_env_value
+    from monocle_apptrace.instrumentation.common.instrumentor import setup_monocle_telemetry
+    workflow_name = get_monocle_env_value("MONOCLE_WORKFLOW_NAME") or Path.cwd().name
+    setup_monocle_telemetry(workflow_name=workflow_name)
+    _telemetry_ready = True
+
+
+@contextmanager
+def _session_lock(session_id: str):
+    """Advisory file lock so concurrent Stop hooks don't double-emit."""
+    sessions = _sessions_dir()
+    sessions.mkdir(parents=True, exist_ok=True)
+    lock_f = (sessions / f".{session_id}.lock").open("w")
+    try:
+        if fcntl is not None:
+            try:
+                fcntl.flock(lock_f.fileno(), fcntl.LOCK_EX)
+            except OSError:
+                pass
+        yield
+    finally:
+        try:
+            if fcntl is not None:
+                fcntl.flock(lock_f.fileno(), fcntl.LOCK_UN)
+        except Exception:
+            pass
+        lock_f.close()
+
+
+def _load_jsonl(path) -> list:
+    p = Path(path) if not isinstance(path, Path) else path
+    if not p.exists():
+        return []
+    events = []
+    try:
+        for line in p.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
+    except Exception as e:
+        logger.debug(f"Error reading {p}: {e}")
+    return events
+
+
+def _state_file(session_id: str) -> Path:
+    return _session_log(session_id).with_suffix(".state.json")
+
+
+def _load_state(session_id: str) -> dict:
+    sf = _state_file(session_id)
+    if sf.exists():
+        try:
+            return json.loads(sf.read_text())
+        except Exception:
+            pass
+    return {"interactions_processed": [], "model": "copilot"}
+
+
+def _save_state(session_id: str, state: dict) -> None:
+    try:
+        _state_file(session_id).write_text(json.dumps(state))
+    except Exception:
+        pass
+
+
+def _latest_transcript_path(hook_events: list) -> Optional[str]:
+    for e in reversed(hook_events):
+        tp = e.get("transcript_path")
+        if tp:
+            return tp
+    return None
+
+
+def _build_subagent_intervals(hook_events: list) -> list:
+    """Pair SubagentStart/SubagentStop into [start_ts, end_ts] windows. Events in
+    those windows belong to the subagent, not the parent turn."""
+    intervals = []
+    pending = {}
+    for e in hook_events:
+        name = e.get("hook_event_name")
+        aid = e.get("agent_id", "")
+        if name == "SubagentStart" and aid:
+            pending[aid] = e
+        elif name == "SubagentStop" and aid and aid in pending:
+            start = pending.pop(aid)
+            intervals.append({
+                "agent_id": aid,
+                "agent_type": start.get("agent_type", "agent") or e.get("agent_type", "agent"),
+                "start_ts": start.get("timestamp", ""),
+                "end_ts": e.get("timestamp", ""),
+            })
+    if pending and hook_events:
+        last_ts = hook_events[-1].get("timestamp", "")
+        for aid, start in pending.items():
+            intervals.append({
+                "agent_id": aid,
+                "agent_type": start.get("agent_type", "agent"),
+                "start_ts": start.get("timestamp", ""),
+                "end_ts": last_ts,
+            })
+    return intervals
+
+
+def _interval_for_ts(ts: str, intervals: list) -> Optional[dict]:
+    if not ts:
+        return None
+    for itv in intervals:
+        if itv["start_ts"] <= ts <= itv["end_ts"]:
+            return itv
+    return None
+
+
+def _index_tool_outputs(hook_events: list, intervals: list) -> tuple:
+    """PreToolUse/PostToolUse `agent_id` is empty in practice, so we route by
+    timestamp into either parent or matching subagent. PostToolUseFailure (Copilot
+    CLI only) carries the error message the transcript doesn't expose."""
+    parent_outputs = []
+    subagent_outputs = {itv["agent_id"]: [] for itv in intervals}
+    for e in hook_events:
+        name = e.get("hook_event_name")
+        if name not in ("PostToolUse", "PostToolUseFailure"):
+            continue
+        ts = e.get("timestamp", "")
+        is_failure = name == "PostToolUseFailure"
+        record = {
+            "tool_name": e.get("tool_name", ""),
+            "tool_response": e.get("tool_response", "") if not is_failure else "",
+            "failed": is_failure,
+            "error": e.get("error", "") if is_failure else "",
+            "timestamp": ts,
+        }
+        itv = _interval_for_ts(ts, intervals)
+        (subagent_outputs[itv["agent_id"]] if itv else parent_outputs).append(record)
+    return parent_outputs, subagent_outputs
+
+
+def _walk_interactions(transcript_events: list, subagent_intervals: list) -> list:
+    """Walk the transcript into interactions, nesting subagent activity inside
+    the parent turn. A `user.message` whose timestamp falls inside a subagent
+    interval is the subagent's task prompt, not a new top-level turn."""
+    interactions = []
+    current = None
+    current_subagent = None
+    pending_tools = {}          # toolCallId -> (container, start_dict)
+    current_model = "copilot"   # updated by session.start.model / session.model_change
+
+    def _container_for_ts(ts: str):
+        nonlocal current_subagent
+        itv = _interval_for_ts(ts, subagent_intervals)
+        if itv is None:
+            current_subagent = None
+            return current, False
+        if current is None:
+            return None, True
+        if current_subagent is None or current_subagent.get("agent_id") != itv["agent_id"]:
+            current_subagent = {
+                "agent_id": itv["agent_id"],
+                "agent_type": itv["agent_type"],
+                "prompt": "",
+                "assistant_messages": [],
+                "tool_calls": [],
+                "model": current_model,
+                "start_ts": itv["start_ts"],
+                "end_ts": itv["end_ts"],
+            }
+            current.setdefault("subagents", []).append(current_subagent)
+        return current_subagent, True
+
+    for event in transcript_events:
+        etype = event.get("type", "")
+        data = event.get("data") or {}
+        ts = event.get("timestamp", "")
+
+        if etype == "session.start":
+            if data.get("model"):
+                current_model = data["model"]
+            continue
+        if etype == "session.model_change":
+            new_model = data.get("newModel") or data.get("model")
+            if new_model:
+                current_model = new_model
+            continue
+
+        if etype == "user.message":
+            itv = _interval_for_ts(ts, subagent_intervals)
+            if itv and current is not None:
+                container, _ = _container_for_ts(ts)
+                if container is not None:
+                    container["prompt"] = data.get("content", "")
+                continue
+            if current:
+                interactions.append(current)
+            current = {
+                "id": event.get("id", ""),
+                "prompt": data.get("content", ""),
+                "assistant_messages": [],
+                "tool_calls": [],
+                "subagents": [],
+                "model": current_model,
+                "turn_start": ts,
+                "turn_end": ts,
+            }
+            current_subagent = None
+
+        elif etype == "assistant.message" and current is not None:
+            container, _ = _container_for_ts(ts)
+            if container is None:
+                continue
+            container.setdefault("assistant_messages", []).append({
+                "content": data.get("content", "") or "",
+                "reasoning": data.get("reasoningText", "") or "",
+                "tool_requests": data.get("toolRequests") or [],
+                "timestamp": ts,
+            })
+            current["turn_end"] = ts
+
+        elif etype == "tool.execution_start" and current is not None:
+            call_id = data.get("toolCallId", "")
+            if not call_id:
+                continue
+            container, _ = _container_for_ts(ts)
+            if container is None:
+                continue
+            pending_tools[call_id] = (container, {
+                "tool_name": data.get("toolName", ""),
+                "arguments": data.get("arguments", ""),
+                "start_ts": ts,
+            })
+
+        elif etype == "tool.execution_complete" and current is not None:
+            call_id = data.get("toolCallId", "")
+            pre = pending_tools.pop(call_id, None)
+            if pre:
+                container, pre_data = pre
+                # Drop launcher tool — Sub-Agent span captures the same content.
+                if pre_data["tool_name"] in _SUBAGENT_LAUNCHER_TOOL_NAMES and container is current:
+                    current["turn_end"] = ts
+                    continue
+                container.setdefault("tool_calls", []).append({
+                    "call_id": call_id,
+                    "tool_name": pre_data["tool_name"],
+                    "arguments": pre_data["arguments"],
+                    "success": bool(data.get("success", True)),
+                    SPAN_START_TIME: pre_data["start_ts"],
+                    SPAN_END_TIME: ts,
+                })
+                current["turn_end"] = ts
+
+        elif etype == "assistant.turn_end" and current is not None:
+            current["turn_end"] = ts
+
+    if current:
+        interactions.append(current)
+    for itr in interactions:
+        if not itr["assistant_messages"]:
+            itr["interrupted"] = True
+    return interactions
+
+
+def _parse_args(raw_args) -> dict:
+    if isinstance(raw_args, dict):
+        return raw_args
+    if isinstance(raw_args, str) and raw_args.strip():
+        try:
+            return json.loads(raw_args)
+        except json.JSONDecodeError:
+            return {"_raw": raw_args}
+    return {}
+
+
+def _build_inference_round(interaction: dict, prompt: str) -> dict:
+    """One inference round per turn — model continuations collapse together."""
+    msgs = interaction.get("assistant_messages", [])
+    if not msgs:
+        return {}
+    first_msg, last_msg = msgs[0], msgs[-1]
+    final_content = next((m["content"] for m in reversed(msgs) if m.get("content")), "")
+    dispatched_tools = [
+        r.get("name") for m in msgs for r in (m.get("tool_requests") or []) if r.get("name")
+    ]
+    finish_reason = "tool_use" if dispatched_tools else "end_turn"
+    finish_type = "tool_call" if dispatched_tools else "success"
+    return {
+        SPAN_START_TIME: interaction.get("turn_start") or first_msg["timestamp"],
+        SPAN_END_TIME: last_msg["timestamp"],
+        "model": interaction.get("model", "copilot"),
+        "tokens": {},
+        "input_text": prompt,
+        "output_text": final_content,
+        "finish_reason": finish_reason,
+        "finish_type": finish_type,
+    }
+
+
+def _hydrate_tool_outputs(tool_calls: list, scope_outputs: list) -> None:
+    """Hook tool_use_ids don't match transcript toolCallIds, so match by name in
+    sequence. PostToolUseFailure propagates `failed`/`error` over the transcript's
+    success flag."""
+    available = list(scope_outputs)
+    for tc in tool_calls:
+        match_idx = next(
+            (i for i, out in enumerate(available) if out["tool_name"] == tc["tool_name"]),
+            None,
+        )
+        if match_idx is not None:
+            out = available.pop(match_idx)
+            tc["tool_output"] = out["tool_response"]
+            if out.get("failed"):
+                tc["failed"] = True
+                tc["error"] = out.get("error", "")
+        else:
+            tc["tool_output"] = ""
+
+
+def _convert_tool_calls(transcript_tool_calls: list, outputs: list) -> list:
+    _hydrate_tool_outputs(transcript_tool_calls, outputs)
+    out = []
+    for tc in transcript_tool_calls:
+        failed = tc.get("failed", False) or not tc.get("success", True)
+        out.append({
+            "tool_name": tc["tool_name"],
+            "tool_input": _parse_args(tc.get("arguments", "")),
+            "tool_output": tc.get("tool_output", ""),
+            "call_id": tc.get("call_id", ""),
+            "failed": failed,
+            "error": tc.get("error", ""),
+            SPAN_START_TIME: tc.get(SPAN_START_TIME),
+            SPAN_END_TIME: tc.get(SPAN_END_TIME),
+        })
+    return out
+
+
+def _build_subagent_records(interaction: dict, subagent_outputs_by_id: dict) -> list:
+    records = []
+    for sa in interaction.get("subagents") or []:
+        outputs = subagent_outputs_by_id.get(sa["agent_id"], [])
+        sa_tool_calls = _convert_tool_calls(sa.get("tool_calls", []), outputs)
+        final_response = next(
+            (m["content"] for m in reversed(sa.get("assistant_messages", [])) if m.get("content")),
+            "",
+        )
+        records.append({
+            "agent_id": sa["agent_id"],
+            "agent_type": sa.get("agent_type", "agent"),
+            "prompt": sa.get("prompt", ""),
+            "description": sa.get("prompt", "")[:120],
+            "response": final_response,
+            "tool_calls": sa_tool_calls,
+            "tokens": {},
+            "model": sa.get("model", "copilot"),
+            SPAN_START_TIME: sa.get("start_ts"),
+            SPAN_END_TIME: sa.get("end_ts"),
+        })
+    return records
+
+
+def _normalize_tokens(usage: dict) -> dict:
+    """Canonicalize Copilot CLI's modelMetrics.usage. prompt_tokens sums
+    input+cacheRead+cacheWrite — raw inputTokens alone undercounts cached
+    prompts on warm sessions."""
+    input_t = usage.get("inputTokens", 0) or 0
+    output_t = usage.get("outputTokens", 0) or 0
+    cache_read = usage.get("cacheReadTokens", 0) or 0
+    cache_write = usage.get("cacheWriteTokens", 0) or 0
+    reasoning = usage.get("reasoningTokens", 0) or 0
+    prompt_t = input_t + cache_read + cache_write
+    if not prompt_t and not output_t:
+        return {}
+    return {
+        "prompt_tokens": prompt_t,
+        "completion_tokens": output_t,
+        "total_tokens": prompt_t + output_t,
+        "input_tokens": input_t,
+        "cache_read_tokens": cache_read,
+        "cache_creation_tokens": cache_write,
+        "reasoning_tokens": reasoning,
+    }
+
+
+def _extract_session_totals(transcript_events: list) -> dict:
+    """Latest session.shutdown event with per-model token totals. Empty for
+    VS Code Copilot Chat (no shutdown event)."""
+    shutdown = next(
+        (e for e in reversed(transcript_events) if e.get("type") == "session.shutdown"),
+        None,
+    )
+    if not shutdown:
+        return {}
+    data = shutdown.get("data") or {}
+    return {
+        "model_metrics": data.get("modelMetrics") or {},
+        "total_api_duration_ms": data.get("totalApiDurationMs", 0) or 0,
+        "shutdown_ts": shutdown.get("timestamp", ""),
+    }
+
+
+def replay_session(session_id: str) -> None:
+    if not session_id:
+        return
+    with _session_lock(session_id):
+        _replay_session_locked(session_id)
+
+
+def _replay_session_locked(session_id: str) -> None:
+    hook_events = _load_jsonl(_session_log(session_id))
+    if not hook_events:
+        return
+    transcript_path = _latest_transcript_path(hook_events)
+    if not transcript_path:
+        logger.debug(f"No transcript_path for {session_id}")
+        return
+    transcript_events = _load_jsonl(transcript_path)
+    if not transcript_events:
+        return
+
+    subagent_intervals = _build_subagent_intervals(hook_events)
+    interactions = _walk_interactions(transcript_events, subagent_intervals)
+
+    state = _load_state(session_id)
+    already = set(state.get("interactions_processed", []))
+    shutdown_emitted = state.get("shutdown_emitted", False)
+    # Skip interactions with no assistant response and not flagged interrupted (still mid-flight).
+    new_interactions = [
+        i for i in interactions
+        if i["id"] not in already and (i.get("assistant_messages") or i.get("interrupted"))
+    ]
+    session_totals = _extract_session_totals(transcript_events) if not shutdown_emitted else {}
+
+    if not new_interactions and not session_totals.get("model_metrics"):
+        return
+
+    parent_outputs, subagent_outputs = _index_tool_outputs(hook_events, subagent_intervals)
+    _configure_telemetry()
+    handler = ReplayHandler()
+
+    for interaction in new_interactions:
+        iid = interaction["id"]
+        prompt = interaction["prompt"]
+        turn_start = interaction.get("turn_start", "")
+        turn_end = interaction.get("turn_end", turn_start)
+        tool_calls = _convert_tool_calls(interaction.get("tool_calls", []), parent_outputs)
+        subagents = _build_subagent_records(interaction, subagent_outputs)
+        response = next(
+            (m["content"] for m in reversed(interaction.get("assistant_messages", [])) if m.get("content")),
+            "",
+        )
+        round_dict = _build_inference_round(interaction, prompt)
+        try:
+            handler.handle_turn(
+                prompt=prompt,
+                response=response,
+                tool_calls=tool_calls,
+                subagents=subagents,
+                inference_rounds=[round_dict] if round_dict else [],
+                model=interaction.get("model", "copilot"),
+                tokens={},
+                _turn_start=turn_start,
+                _turn_end=turn_end,
+                **{SPAN_START_TIME: turn_start, SPAN_END_TIME: turn_end, AGENT_SESSION: session_id},
+            )
+        except Exception as e:
+            logger.debug(f"Turn replay failed for {iid}: {e}")
+        already.add(iid)
+
+    # Copilot CLI session.shutdown rollup — one inference-shaped span per model.
+    if session_totals.get("model_metrics"):
+        shutdown_ts = session_totals.get("shutdown_ts", "")
+        session_start_ts = interactions[0].get("turn_start") if interactions else shutdown_ts
+        session_end_ts = shutdown_ts or session_start_ts
+        for model_name, metrics in session_totals["model_metrics"].items():
+            tokens = _normalize_tokens(metrics.get("usage") or {})
+            if not tokens:
+                continue
+            try:
+                handler.handle_inference_round(
+                    input_text="",
+                    output_text="",
+                    model=model_name,
+                    tokens=tokens,
+                    tool_name="",
+                    finish_reason="session_summary",
+                    finish_type="aggregate",
+                    **{SPAN_START_TIME: session_start_ts, SPAN_END_TIME: session_end_ts, AGENT_SESSION: session_id},
+                )
+                shutdown_emitted = True
+            except Exception as e:
+                logger.debug(f"Session summary span failed for {model_name}: {e}")
+
+    state["interactions_processed"] = list(already)
+    state["shutdown_emitted"] = shutdown_emitted
+    _save_state(session_id, state)
+
+
+def replay_compaction(session_id: str) -> None:
+    """VS Code fires only PreCompact (no PostCompact). Emit zero-duration span."""
+    hook_events = _load_jsonl(_session_log(session_id))
+    pre = next(
+        (e for e in reversed(hook_events) if e.get("hook_event_name") == "PreCompact"),
+        None,
+    )
+    if not pre:
+        return
+    _configure_telemetry()
+    ts = pre.get("timestamp", "")
+    ReplayHandler().handle_inference_round(
+        input_text="",
+        output_text="",
+        model=_load_state(session_id).get("model", "copilot"),
+        tokens={},
+        finish_reason="compaction",
+        finish_type=pre.get("trigger", "auto"),
+        **{SPAN_START_TIME: ts, SPAN_END_TIME: ts, AGENT_SESSION: session_id},
+    )
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        logger.debug("Usage: replay.py <session_id>")
+        sys.exit(1)
+    replay_session(sys.argv[1])
+
+
+if __name__ == "__main__":
+    main()

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/replay.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/replay.py
@@ -189,9 +189,9 @@ def _walk_interactions(transcript_events: list, subagent_intervals: list) -> lis
         itv = _interval_for_ts(ts, subagent_intervals)
         if itv is None:
             current_subagent = None
-            return current, False
+            return current
         if current is None:
-            return None, True
+            return None
         if current_subagent is None or current_subagent.get("agent_id") != itv["agent_id"]:
             current_subagent = {
                 "agent_id": itv["agent_id"],
@@ -204,7 +204,7 @@ def _walk_interactions(transcript_events: list, subagent_intervals: list) -> lis
                 "end_ts": itv["end_ts"],
             }
             current.setdefault("subagents", []).append(current_subagent)
-        return current_subagent, True
+        return current_subagent
 
     for event in transcript_events:
         etype = event.get("type", "")
@@ -224,7 +224,7 @@ def _walk_interactions(transcript_events: list, subagent_intervals: list) -> lis
         if etype == "user.message":
             itv = _interval_for_ts(ts, subagent_intervals)
             if itv and current is not None:
-                container, _ = _container_for_ts(ts)
+                container = _container_for_ts(ts)
                 if container is not None:
                     container["prompt"] = data.get("content", "")
                 continue
@@ -243,7 +243,7 @@ def _walk_interactions(transcript_events: list, subagent_intervals: list) -> lis
             current_subagent = None
 
         elif etype == "assistant.message" and current is not None:
-            container, _ = _container_for_ts(ts)
+            container = _container_for_ts(ts)
             if container is None:
                 continue
             container.setdefault("assistant_messages", []).append({
@@ -258,7 +258,7 @@ def _walk_interactions(transcript_events: list, subagent_intervals: list) -> lis
             call_id = data.get("toolCallId", "")
             if not call_id:
                 continue
-            container, _ = _container_for_ts(ts)
+            container = _container_for_ts(ts)
             if container is None:
                 continue
             pending_tools[call_id] = (container, {

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/replay.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/replay.py
@@ -22,6 +22,7 @@ from monocle_apptrace.instrumentation.metamodel.github_copilot.trace_events impo
     _sessions_dir,
 )
 from monocle_apptrace.instrumentation.metamodel.github_copilot.replay_handlers import ReplayHandler
+from monocle_apptrace.instrumentation.metamodel.github_copilot._otel_tokens import lookup_turn_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -485,6 +486,22 @@ def _replay_session_locked(session_id: str) -> None:
             "",
         )
         round_dict = _build_inference_round(interaction, prompt)
+        turn_tokens = {}
+        turn_model = interaction.get("model", "copilot")
+        # VS Code Copilot Chat gives no tokens via hooks. Pull them from Copilot's
+        # own OTel export, anchored by trace id. Skipped for Copilot CLI, which
+        # already reports tokens via its transcript (session.shutdown rollup).
+        if round_dict and not session_totals.get("model_metrics"):
+            otel_tokens, otel_trace_id, otel_model = lookup_turn_tokens(
+                round_dict[SPAN_START_TIME], round_dict[SPAN_END_TIME]
+            )
+            if otel_tokens:
+                round_dict["tokens"] = otel_tokens
+                round_dict["otel_trace_id"] = otel_trace_id
+                if otel_model:
+                    round_dict["model"] = otel_model
+                turn_tokens = otel_tokens
+                turn_model = round_dict["model"]
         try:
             handler.handle_turn(
                 prompt=prompt,
@@ -492,8 +509,8 @@ def _replay_session_locked(session_id: str) -> None:
                 tool_calls=tool_calls,
                 subagents=subagents,
                 inference_rounds=[round_dict] if round_dict else [],
-                model=interaction.get("model", "copilot"),
-                tokens={},
+                model=turn_model,
+                tokens=turn_tokens,
                 _turn_start=turn_start,
                 _turn_end=turn_end,
                 **{SPAN_START_TIME: turn_start, SPAN_END_TIME: turn_end, AGENT_SESSION: session_id},

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/replay_handlers.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/replay_handlers.py
@@ -1,0 +1,134 @@
+from monocle_apptrace.instrumentation.common.constants import SPAN_START_TIME, SPAN_END_TIME
+
+
+class ToolFailureError(Exception):
+    """Raised so task_wrapper marks the tool span ERROR with this as status.message."""
+    def __init__(self, tool_name: str, error: str):
+        super().__init__(error or f"Tool '{tool_name}' failed")
+        self.tool_name = tool_name
+
+
+class ReplayHandler:
+    """Empty method bodies — methods.py wraps each call into a span via task_wrapper."""
+
+    def handle_turn(self, prompt: str, response: str, **kwargs) -> str:
+        tool_calls = kwargs.get("tool_calls") or []
+        subagents = kwargs.get("subagents") or []
+        inference_rounds = kwargs.get("inference_rounds") or []
+        model = kwargs.get("model", "copilot")
+        tokens = kwargs.get("tokens") or {}
+
+        turn_start = kwargs.get("_turn_start")
+        turn_end = kwargs.get("_turn_end")
+        timing = {}
+        if turn_start:
+            timing[SPAN_START_TIME] = turn_start
+        if turn_end:
+            timing[SPAN_END_TIME] = turn_end
+
+        self.handle_invocation(
+            prompt=prompt,
+            response=response,
+            tool_calls=tool_calls,
+            subagents=subagents,
+            inference_rounds=inference_rounds,
+            model=model,
+            tokens=tokens,
+            _turn_start=turn_start,
+            _turn_end=turn_end,
+            **timing,
+        )
+        return response
+
+    def handle_invocation(self, prompt: str, response: str, **kwargs) -> str:
+        tool_calls = kwargs.get("tool_calls") or []
+        subagents = kwargs.get("subagents") or []
+        inference_rounds = kwargs.get("inference_rounds") or []
+
+        for ir in inference_rounds:
+            output_text = ir.get("output_text", "")
+            # In v1 we synthesize one round per turn from hook timestamps with no
+            # output_text. Emit it anyway so the inference span is always present —
+            # v1.1 (transcript parsing) will fill in the actual model response.
+            self.handle_inference_round(
+                input_text=ir.get("input_text", prompt),
+                output_text=output_text,
+                model=ir.get("model", kwargs.get("model", "copilot")),
+                tokens=ir.get("tokens", {}),
+                tool_name=ir.get("tool_name", ""),
+                finish_reason=ir.get("finish_reason", ""),
+                finish_type=ir.get("finish_type", ""),
+                **{SPAN_START_TIME: ir.get(SPAN_START_TIME), SPAN_END_TIME: ir.get(SPAN_END_TIME)},
+            )
+
+        for tc in tool_calls:
+            self._dispatch_tool(tc)
+
+        for sa in subagents:
+            self.handle_subagent(
+                prompt=sa.get("prompt", ""),
+                response=sa.get("response", ""),
+                agent_id=sa.get("agent_id", ""),
+                agent_type=sa.get("agent_type", "agent"),
+                description=sa.get("description", ""),
+                tool_calls=sa.get("tool_calls", []),
+                tokens=sa.get("tokens", {}),
+                model=sa.get("model", "copilot"),
+                **{SPAN_START_TIME: sa.get(SPAN_START_TIME), SPAN_END_TIME: sa.get(SPAN_END_TIME)},
+            )
+
+        return response
+
+    def _dispatch_tool(self, tc):
+        tool_name = tc["tool_name"]
+        extra = {"failed": True, "error": tc.get("error", "")} if tc.get("failed") else {}
+        try:
+            if tool_name.startswith("mcp__"):
+                self.handle_mcp_call(
+                    tool_name=tool_name,
+                    tool_input=tc["tool_input"],
+                    tool_output=tc["tool_output"],
+                    **extra,
+                    **{SPAN_START_TIME: tc.get(SPAN_START_TIME), SPAN_END_TIME: tc.get(SPAN_END_TIME)},
+                )
+            else:
+                self.handle_tool_call(
+                    tool_name=tool_name,
+                    tool_input=tc["tool_input"],
+                    tool_output=tc["tool_output"],
+                    **extra,
+                    **{SPAN_START_TIME: tc.get(SPAN_START_TIME), SPAN_END_TIME: tc.get(SPAN_END_TIME)},
+                )
+        except ToolFailureError:
+            pass  # span already recorded with ERROR status
+
+    def handle_inference_round(self, input_text: str = "", output_text: str = "", **kwargs) -> str:
+        return output_text
+
+    def handle_tool_call(self, tool_name: str, tool_input: dict, tool_output: dict, **kwargs) -> dict:
+        if kwargs.get("failed"):
+            error_msg = kwargs.get("error", "") or f"Tool '{tool_name}' failed"
+            raise ToolFailureError(tool_name, error_msg)
+        return tool_output
+
+    def handle_mcp_call(self, tool_name: str, tool_input: dict, tool_output: dict, **kwargs) -> dict:
+        if kwargs.get("failed"):
+            error_msg = kwargs.get("error", "") or f"Tool '{tool_name}' failed"
+            raise ToolFailureError(tool_name, error_msg)
+        return tool_output
+
+    def handle_subagent(self, prompt: str = "", response: str = "", **kwargs) -> str:
+        tool_calls = kwargs.get("tool_calls") or []
+        for tc in tool_calls:
+            self._dispatch_tool(tc)
+        if response:
+            self.handle_inference_round(
+                input_text=prompt,
+                output_text=response,
+                model=kwargs.get("model", "copilot"),
+                tokens=kwargs.get("tokens", {}),
+                finish_reason="end_turn",
+                finish_type="success",
+                **{SPAN_START_TIME: kwargs.get(SPAN_START_TIME), SPAN_END_TIME: kwargs.get(SPAN_END_TIME)},
+            )
+        return response

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/replay_handlers.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/replay_handlers.py
@@ -58,6 +58,7 @@ class ReplayHandler:
                 tool_name=ir.get("tool_name", ""),
                 finish_reason=ir.get("finish_reason", ""),
                 finish_type=ir.get("finish_type", ""),
+                otel_trace_id=ir.get("otel_trace_id", ""),
                 **{SPAN_START_TIME: ir.get(SPAN_START_TIME), SPAN_END_TIME: ir.get(SPAN_END_TIME)},
             )
 

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/trace_events.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/github_copilot/trace_events.py
@@ -1,0 +1,96 @@
+import json
+import logging
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Retention for VS Code Copilot Chat sessions. Copilot CLI fires SessionEnd so
+# its sessions clean up via cleanup_session() — this TTL is only the safety net
+# for VS Code Copilot Chat, which has no SessionEnd hook.
+_TTL_SECONDS = 24 * 60 * 60
+
+
+def _state_dir():
+    return Path.cwd() / ".monocle"
+
+
+def _sessions_dir():
+    return _state_dir() / ".copilot_sessions"
+
+
+def _trace_file():
+    return _state_dir() / ".monocle_copilot_trace.jsonl"
+
+
+def _session_log(session_id):
+    sessions = _sessions_dir()
+    sessions.mkdir(parents=True, exist_ok=True)
+    return sessions / ".monocle_copilot_{}.jsonl".format(session_id)
+
+
+def record_trace_event(entry):
+    """Append an enriched event dict as a single JSON line to the trace file."""
+    sessions = _sessions_dir()
+    sessions.mkdir(parents=True, exist_ok=True)
+    with _trace_file().open("a") as fh:
+        fh.write(json.dumps(entry) + "\n")
+
+
+def _subagent_sessions_file():
+    sessions = _sessions_dir()
+    sessions.mkdir(parents=True, exist_ok=True)
+    return sessions / ".subagent_sessions.json"
+
+
+def mark_subagent_session(agent_id):
+    """Record that agent_id is a subagent session so we skip emitting a top-level turn for it."""
+    f = _subagent_sessions_file()
+    try:
+        known = json.loads(f.read_text()) if f.exists() else []
+    except Exception as e:
+        logger.debug("Error reading subagent sessions file: %s", e)
+        known = []
+    if agent_id not in known:
+        known.append(agent_id)
+        f.write_text(json.dumps(known))
+
+
+def is_subagent_session(session_id):
+    """Return True if session_id was spawned as a subagent by some parent session."""
+    f = _subagent_sessions_file()
+    try:
+        return session_id in (json.loads(f.read_text()) if f.exists() else [])
+    except Exception as e:
+        logger.debug("Error reading subagent sessions file: %s", e)
+        return False
+
+
+def cleanup_session(session_id):
+    """Delete the per-session JSONL log + state file. Called from SessionEnd
+    (Copilot CLI fires it; VS Code Copilot Chat doesn't)."""
+    log = _session_log(session_id)
+    state = log.with_suffix(".state.json")
+    for f in (log, state):
+        try:
+            f.unlink()
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            logger.debug("cleanup_session: skip %s (%s)", f, e)
+
+
+def sweep_stale_sessions():
+    """Drop session files older than `_TTL_SECONDS`. Called from SessionStart so
+    leftover VS Code Copilot Chat sessions (no SessionEnd hook) don't accumulate
+    indefinitely. Same pattern codex_cli uses for the same reason."""
+    sessions = _sessions_dir()
+    if not sessions.exists():
+        return
+    cutoff = time.time() - _TTL_SECONDS
+    for f in sessions.iterdir():
+        try:
+            if f.is_file() and f.stat().st_mtime < cutoff:
+                f.unlink()
+        except Exception as e:
+            logger.debug("Sweep skipped %s: %s", f, e)


### PR DESCRIPTION
## Proposed changes
Adds Monocle instrumentation support for GitHub Copilot, including Copilot CLI and VS Code Copilot Chat agent mode. Uses Copilot's built-in hook system to automatically trace sessions, tool calls, subagent invocations, model used, and per-session token consumption for Copilot CLI, then emits them as monocle telemetry.


## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
Token consumption is captured only for Copilot CLI, not VS Code Copilot Chat (VS Code doesn't expose tokens). Tokens are reported per session and only emitted when the session ends.