### PR TITLE
Fix for stitching turns together using the session ID.

### DIFF
--- a/apptrace/src/monocle_apptrace/exporters/file_exporter.py
+++ b/apptrace/src/monocle_apptrace/exporters/file_exporter.py
@@ -14,7 +14,8 @@ from monocle_apptrace.exporters.exporter_processor import ExportTaskProcessor
 
 DEFAULT_FILE_PREFIX:str = "monocle_trace_"
 DEFAULT_TIME_FORMAT:str = "%Y-%m-%d_%H.%M.%S"
-HANDLE_TIMEOUT_SECONDS: int = 60  # 1 minute timeout
+HANDLE_TIMEOUT_SECONDS: int = 60  # 1 minute timeout for individual trace handles
+SESSION_HANDLE_TIMEOUT_SECONDS: int = 600  # 10 minute timeout for session handles (turns can be minutes apart)
 DEFAULT_TRACE_FOLDER = ".monocle"
 # Sentinel so we can tell "caller passed nothing" apart from "caller passed default".
 _UNSET = object()
@@ -35,6 +36,9 @@ class FileSpanExporter(SpanExporterBase):
         super().__init__()
         # Dictionary to store file handles: {trace_id: (file_handle, file_path, creation_time, first_span)}
         self.file_handles: Dict[int, Tuple[TextIOWrapper, str, datetime, bool]] = {}
+        # Session-based handles for multi-turn stitching: {session_id: (file_handle, file_path, creation_time, first_span)}
+        # When a span carries scope.agentic.session, all traces in that session share one file.
+        self._session_handles: Dict[str, Tuple[TextIOWrapper, str, datetime, bool]] = {}
         self.formatter = formatter
         self.service_name = service_name
         self.output_path = os.getenv("MONOCLE_TRACE_OUTPUT_PATH", out_path)
@@ -59,6 +63,16 @@ class FileSpanExporter(SpanExporterBase):
         """Return True if the span has no parent (i.e. it is a root span)."""
         return (not span.parent) or (span.attributes.get("span.type") == "workflow")
 
+    @staticmethod
+    def _get_session_id(spans) -> Optional[str]:
+        """Return the agentic session ID shared by these spans, or None."""
+        for span in spans:
+            session_id = span.attributes.get("scope.agentic.session")
+            if session_id:
+                return str(session_id)
+        return None
+
+
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
         is_root_span = any(FileSpanExporter._is_root_span(span) for span in spans)
         if self.task_processor is not None and callable(getattr(self.task_processor, 'queue_task', None)):
@@ -79,42 +93,88 @@ class FileSpanExporter(SpanExporterBase):
         """Close and remove file handles that have exceeded the timeout."""
         current_time = datetime.now()
         expired_trace_ids = []
-        
+        expired_sessions = []
         for trace_id, (handle, file_path, creation_time, _) in self.file_handles.items():
             if (current_time - creation_time).total_seconds() > HANDLE_TIMEOUT_SECONDS:
                 expired_trace_ids.append(trace_id)
-        
+
+        for session_id, (handle, file_path, creation_time, _) in self._session_handles.items():
+            if (current_time - creation_time).total_seconds() > SESSION_HANDLE_TIMEOUT_SECONDS:
+                expired_sessions.append(session_id)
+
         for trace_id in expired_trace_ids:
             self._close_trace_handle(trace_id)
+        for session_id in expired_sessions:
+            self._close_session_handle(session_id)
 
-    def _get_or_create_handle(self, trace_id: int, service_name: str) -> Tuple[TextIOWrapper, str, bool]:
-        """Get existing handle or create new one for the trace_id."""
+    def _close_session_handle(self, session_id: str) -> None:
+        """Close and remove a session-level file handle."""
+        if session_id in self._session_handles:
+            handle, file_path, creation_time, _ = self._session_handles[session_id]
+            try:
+                if handle is not None:
+                    handle.write("]")
+                    handle.close()
+            except Exception as e:
+                print(f"Error closing session file {file_path}: {e}")
+            finally:
+                del self._session_handles[session_id]
+                self.last_file_processed = file_path
+
+    def _get_or_create_handle(self, trace_id: int, service_name: str, session_id: Optional[str] = None) -> Tuple[TextIOWrapper, str, bool]:
+        """Get existing handle or create new one for the trace_id.
+
+        If session_id is provided, reuse an existing session-level file so that
+        all turns of the same conversation land in one file.  The internal
+        trace_id-keyed bookkeeping is otherwise unchanged.
+        """
         self._cleanup_expired_handles()
-        
+
+        if session_id:
+            if session_id in self._session_handles:
+                handle, file_path, creation_time, first_span = self._session_handles[session_id]
+                self.file_handles[trace_id] = (handle, file_path, creation_time, first_span)
+                return handle, file_path, first_span
+
         if trace_id in self.file_handles:
             handle, file_path, creation_time, first_span = self.file_handles[trace_id]
             return handle, file_path, first_span
         
         # Create new handle
+        file_id = session_id.replace("/", "_").replace("\\", "_")[:64] if session_id \
+            else format_trace_id_without_0x(trace_id)
         file_path = path.join(self.output_path,
-                             self.file_prefix + service_name + "_" + format_trace_id_without_0x(trace_id) + "_"
+                             self.file_prefix + service_name + "_" + file_id + "_"
                              + datetime.now().strftime(self.time_format) + ".json")
         
         try:
             handle = open(file_path, "w", encoding='UTF-8')
             handle.write("[")
-            self.file_handles[trace_id] = (handle, file_path, datetime.now(), True)
+            entry = (handle, file_path, datetime.now(), True)
+            self.file_handles[trace_id] = entry
+            if session_id:
+                self._session_handles[session_id] = entry
             return handle, file_path, True
         except Exception as e:
             print(f"Error creating file {file_path}: {e}")
             return None, file_path, True
 
     def _close_trace_handle(self, trace_id: int) -> None:
-        """Close and remove a specific trace handle."""
+        """Close and remove a specific trace handle.
+
+        For session-backed files the underlying file stays open (managed by
+        _session_handles); we only remove the trace_id alias.
+        """
         if trace_id in self.file_handles:
             handle, file_path, creation_time, _ = self.file_handles[trace_id]
+            # Check whether this handle belongs to an open session file.
+            # If so, leave the file open — the session handle owns it.
+            is_session_file = any(
+                sh is handle
+                for (sh, _, _, _) in self._session_handles.values()
+            )
             try:
-                if handle is not None:
+                if handle is not None and not is_session_file:
                     handle.write("]")
                     handle.close()
             except Exception as e:
@@ -134,13 +194,17 @@ class FileSpanExporter(SpanExporterBase):
         """Mark that a span has been written for this trace (no longer first span)."""
         if trace_id in self.file_handles:
             handle, file_path, creation_time, _ = self.file_handles[trace_id]
-            self.file_handles[trace_id] = (handle, file_path, creation_time, False)
+            entry = (handle, file_path, creation_time, False)
+            self.file_handles[trace_id] = entry
+            for session_id, sh_entry in self._session_handles.items():
+                if sh_entry[0] is handle:
+                    self._session_handles[session_id] = entry
+                    break
 
     def _process_spans(self, spans: Sequence[ReadableSpan], is_root_span: bool = False) -> SpanExportResult:
-        # Group spans by trace_id for efficient processing
-        spans_by_trace = {}
-        root_span_traces = set()
-        
+        spans_by_trace: Dict[int, list] = {}
+        root_span_traces: set = set()
+
         for span in spans:
             if self.skip_export(span):
                 continue
@@ -160,8 +224,10 @@ class FileSpanExporter(SpanExporterBase):
                 service_name = self.service_name
             else:
                 service_name = trace_spans[0].resource.attributes.get(SERVICE_NAME, "unknown")
-            handle, file_path, is_first_span = self._get_or_create_handle(trace_id, service_name)
-            
+
+            # Session overlay: pass session_id so all turns share one file
+            session_id = FileSpanExporter._get_session_id(trace_spans)
+            handle, file_path, is_first_span = self._get_or_create_handle(trace_id, service_name, session_id)
             if handle is None:
                 continue
             
@@ -225,6 +291,12 @@ class FileSpanExporter(SpanExporterBase):
                     handle.flush()
             except Exception as e:
                 print(f"Error flushing file {file_path}: {e}")
+        for session_id, (handle, file_path, _, _) in self._session_handles.items():
+            try:
+                if handle is not None:
+                    handle.flush()
+            except Exception as e:
+                print(f"Error flushing session file {file_path}: {e}")
         return True
 
     def shutdown(self) -> None:
@@ -236,3 +308,8 @@ class FileSpanExporter(SpanExporterBase):
         trace_ids_to_close = list(self.file_handles.keys())
         for trace_id in trace_ids_to_close:
             self._close_trace_handle(trace_id)
+
+        # Close any session files that are still open
+        session_ids_to_close = list(self._session_handles.keys())
+        for session_id in session_ids_to_close:
+            self._close_session_handle(session_id)

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/msagent/msagent_processor.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/msagent/msagent_processor.py
@@ -60,20 +60,22 @@ class MSAgentRequestHandler(SpanHandler):
         
         # Extract thread/session ID and set scope
         session_id_token = None
-        thread = kwargs.get("thread")
+        thread = kwargs.get("session") or kwargs.get("thread")
         if thread is not None:
-            # Extract thread ID from thread object
+            # Extract thread/session ID from object — check value is truthy
             thread_id = None
-            if hasattr(thread, "service_thread_id"):
+            if hasattr(thread, "service_session_id") and thread.service_session_id:
+                thread_id = thread.service_session_id
+            elif hasattr(thread, "service_thread_id") and thread.service_thread_id:
                 thread_id = thread.service_thread_id
-            elif hasattr(thread, "id"):
+            elif hasattr(thread, "session_id") and thread.session_id:
+                thread_id = thread.session_id
+            elif hasattr(thread, "id") and thread.id:
                 thread_id = thread.id
-            elif hasattr(thread, "thread_id"):
+            elif hasattr(thread, "thread_id") and thread.thread_id:
                 thread_id = thread.thread_id
-            
             if thread_id:
                 session_id_token = set_scope(AGENT_SESSION, thread_id)
-        
         # Attach agent info context
         context_token = None
         if agent_info:


### PR DESCRIPTION
## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
When using the Microsoft Agent SDK ([agent_framework](vscode-file://vscode-app/Volumes/VS%20Code/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)) with Monocle, each call to [Agent.run()](vscode-file://vscode-app/Volumes/VS%20Code/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) produced a separate trace file. A 3-turn conversation generated 3 unrelated files with 3 different [trace_id](vscode-file://vscode-app/Volumes/VS%20Code/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)s, making it impossible to view the full conversation as one trace in the VS Code extension or any other consumer.
Accept both kwarg names: [kwargs.get("session") or kwargs.get("thread")](vscode-file://vscode-app/Volumes/VS%20Code/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Add truthy checks to every elif branch so None attributes are skipped correctly
On the first turn of a session, save the workflow root span's [SpanContext](vscode-file://vscode-app/Volumes/VS%20Code/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) in a module-level _session_trace_contexts dict keyed by [session_id](vscode-file://vscode-app/Volumes/VS%20Code/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
On subsequent turns, attach a [NonRecordingSpan](vscode-file://vscode-app/Volumes/VS%20Code/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) with the stored context before span creation — this makes all turns inherit the same [trace_id](vscode-file://vscode-app/Volumes/VS%20Code/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and become siblings under the original workflow span
[file_exporter.py](vscode-file://vscode-app/Volumes/VS%20Code/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Add _session_trace_ids set to prevent the 60-second handle timeout from closing the file between turns of a long-running session (uses a [SESSION_HANDLE_TIMEOUT_SECONDS = 600](vscode-file://vscode-app/Volumes/VS%20Code/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) threshold instead)
## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...