### PR TITLE
Add Okahu Cloud Browser Sign-In for Monocle Agentic CLI Setup

### DIFF
--- a/apptrace/src/monocle_apptrace/auth/__init__.py
+++ b/apptrace/src/monocle_apptrace/auth/__init__.py
@@ -1,0 +1,13 @@
+"""Browser-based sign-in for the Monocle CLI.
+
+Flow when the user picks "Sign in" during `monocle-apptrace claude-setup`:
+
+  1. CLI opens the browser to Auth0 (auth.okahu.co)
+  2. User signs in (GitHub, etc.)
+  3. Auth0 redirects to a one-shot HTTP server on localhost:18292
+  4. CLI exchanges the auth code for a JWT using PKCE
+  5. CLI calls Okahu's API with the JWT to mint an OKAHU_API_KEY
+  6. Key is written to ~/.monocle/.env; JWT is discarded
+
+Entry point: portal_auth.resolve_okahu_api_key().
+"""

--- a/apptrace/src/monocle_apptrace/auth/_ssl.py
+++ b/apptrace/src/monocle_apptrace/auth/_ssl.py
@@ -1,0 +1,14 @@
+"""Shared SSL context using certifi's CA bundle.
+
+The python.org macOS Python doesn't populate the system trust store, so
+stock urllib HTTPS fails with CERTIFICATE_VERIFY_FAILED on a fresh install.
+certifi ships transitively via `requests` (a declared dependency), so it's
+reliably present. Fall back to system default if it's not.
+"""
+import ssl
+
+try:
+    import certifi
+    SSL_CONTEXT = ssl.create_default_context(cafile=certifi.where())
+except ImportError:
+    SSL_CONTEXT = ssl.create_default_context()

--- a/apptrace/src/monocle_apptrace/auth/callback_server.py
+++ b/apptrace/src/monocle_apptrace/auth/callback_server.py
@@ -1,0 +1,132 @@
+"""One-shot loopback HTTP server that receives the OAuth redirect (RFC 8252).
+
+Port is pinned (default 18292) because Auth0 does exact-string matching on
+the registered redirect_uri. Override via MONOCLE_LOOPBACK_PORT if needed,
+but the Auth0 app's allow-list must also be updated to match.
+"""
+import html
+import os
+import socket
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Optional
+from urllib.parse import parse_qs, urlparse
+
+
+_DEFAULT_LOOPBACK_PORT = 18292
+
+
+_PAGE_CSS = (
+    "html,body{height:100%;margin:0;}"
+    "body{"
+    "font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;"
+    "background:#0a1820;color:#ffffff;"
+    "display:flex;align-items:center;justify-content:center;"
+    "text-align:center;-webkit-font-smoothing:antialiased;"
+    "}"
+    ".wordmark{font-size:36px;font-weight:700;letter-spacing:-0.01em;margin-bottom:28px;}"
+    "h1{font-size:22px;font-weight:500;margin:0 0 6px;}"
+    "p{color:#6b7d8f;margin:0;font-size:14px;line-height:1.5;}"
+)
+
+
+def _render_page(title: str, message_html: str) -> bytes:
+    """Render the callback page. `message_html` is trusted; callers escape input."""
+    document = (
+        "<!doctype html>"
+        "<html lang=\"en\"><head>"
+        "<meta charset=\"utf-8\">"
+        "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">"
+        "<title>{title} · Okahu</title>"
+        "<style>{css}</style>"
+        "</head><body><div>"
+        "<div class=\"wordmark\">Okahu</div>"
+        "<h1>{title}</h1>"
+        "<p>{message}</p>"
+        "</div></body></html>"
+    ).format(title=title, css=_PAGE_CSS, message=message_html)
+    return document.encode("utf-8")
+
+
+_SUCCESS_HTML = _render_page("Signed in", "You can close this tab.")
+
+
+def _error_html(message: str) -> bytes:
+    # `message` is Auth0's error_description — escape before injecting.
+    return _render_page("Sign-in failed", html.escape(message))
+
+
+class CallbackResult:
+    def __init__(self):
+        self.code: Optional[str] = None
+        self.error: Optional[str] = None
+        self.done = threading.Event()
+
+
+def _make_handler(expected_state: str, result: CallbackResult):
+    class _Handler(BaseHTTPRequestHandler):
+        def log_message(self, *_args, **_kwargs):
+            # Silence the default per-request stderr line.
+            pass
+
+        def _respond(self, status: int, body: bytes) -> None:
+            self.send_response(status)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _fail(self, message: str) -> None:
+            result.error = message
+            self._respond(400, _error_html(message))
+            result.done.set()
+
+        def do_GET(self):
+            params = parse_qs(urlparse(self.path).query)
+
+            err = params.get("error", [None])[0]
+            if err:
+                self._fail(params.get("error_description", [err])[0])
+                return
+
+            if params.get("state", [None])[0] != expected_state:
+                self._fail("State mismatch (possible CSRF).")
+                return
+
+            code = params.get("code", [None])[0]
+            if not code:
+                self._fail("No authorization code in callback.")
+                return
+
+            result.code = code
+            self._respond(200, _SUCCESS_HTML)
+            result.done.set()
+
+    return _Handler
+
+
+def _resolve_port() -> int:
+    override = os.environ.get("MONOCLE_LOOPBACK_PORT")
+    if override:
+        return int(override)
+    return _DEFAULT_LOOPBACK_PORT
+
+
+def start(expected_state: str):
+    """Bind a one-shot HTTP server on 127.0.0.1. Returns (port, result,
+    shutdown_fn). Raises OSError if the port is already in use — callers
+    are expected to catch that and fall back (see portal_auth.sign_in_smart).
+    """
+    requested_port = _resolve_port()
+    result = CallbackResult()
+    server = HTTPServer(("127.0.0.1", requested_port), _make_handler(expected_state, result))
+    # If requested_port was 0, the OS picked a free port — surface the real one.
+    actual_port = server.server_address[1]
+
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    def shutdown():
+        server.shutdown()
+        server.server_close()
+
+    return actual_port, result, shutdown

--- a/apptrace/src/monocle_apptrace/auth/callback_server.py
+++ b/apptrace/src/monocle_apptrace/auth/callback_server.py
@@ -1,12 +1,9 @@
 """One-shot loopback HTTP server that receives the OAuth redirect (RFC 8252).
 
-Port is pinned (default 18292) because Auth0 does exact-string matching on
-the registered redirect_uri. Override via MONOCLE_LOOPBACK_PORT if needed,
-but the Auth0 app's allow-list must also be updated to match.
+Port is hard-pinned to 18292 because Auth0 does exact-string matching on the
+registered redirect_uri — there's only one URL on the app's allow-list.
 """
 import html
-import os
-import socket
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Optional
@@ -104,23 +101,13 @@ def _make_handler(expected_state: str, result: CallbackResult):
     return _Handler
 
 
-def _resolve_port() -> int:
-    override = os.environ.get("MONOCLE_LOOPBACK_PORT")
-    if override:
-        return int(override)
-    return _DEFAULT_LOOPBACK_PORT
-
-
 def start(expected_state: str):
-    """Bind a one-shot HTTP server on 127.0.0.1. Returns (port, result,
+    """Bind a one-shot HTTP server on 127.0.0.1:18292. Returns (port, result,
     shutdown_fn). Raises OSError if the port is already in use — callers
     are expected to catch that and fall back (see portal_auth.sign_in_smart).
     """
-    requested_port = _resolve_port()
     result = CallbackResult()
-    server = HTTPServer(("127.0.0.1", requested_port), _make_handler(expected_state, result))
-    # If requested_port was 0, the OS picked a free port — surface the real one.
-    actual_port = server.server_address[1]
+    server = HTTPServer(("127.0.0.1", _DEFAULT_LOOPBACK_PORT), _make_handler(expected_state, result))
 
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -129,4 +116,4 @@ def start(expected_state: str):
         server.shutdown()
         server.server_close()
 
-    return actual_port, result, shutdown
+    return _DEFAULT_LOOPBACK_PORT, result, shutdown

--- a/apptrace/src/monocle_apptrace/auth/config.py
+++ b/apptrace/src/monocle_apptrace/auth/config.py
@@ -1,0 +1,56 @@
+"""Auth0 + Okahu endpoint resolution.
+
+Defaults target prod. The Auth0 client_id, audience, and API hosts must come
+from the same environment — mixing them produces a 401 "signing key not
+found" because the API only trusts JWTs signed by its own Auth0 tenant.
+Override via the MONOCLE_AUTH0_* / MONOCLE_OKAHU_* env vars to point at
+stage.
+"""
+import os
+from dataclasses import dataclass
+
+
+"""Callback server for the Auth0 redirect."""
+_DEFAULT_AUTH0_DOMAIN = "auth.okahu.co"
+_DEFAULT_AUTH0_CLIENT_ID = "w5msUdJgpximQMqo8LqkrLyiQMYbYiDw"
+_DEFAULT_AUTH0_AUDIENCE = "https://api.okahu.co/"
+_DEFAULT_OKAHU_API_HOST = "api.okahu.co"
+_DEFAULT_OKAHU_MGMT_HOST = "management.okahu.co"
+
+
+@dataclass(frozen=True)
+class AuthConfig:
+    auth0_domain: str
+    auth0_client_id: str
+    auth0_audience: str
+    okahu_api_host: str
+    okahu_mgmt_host: str
+
+    @property
+    def authorize_url(self) -> str:
+        return "https://{}/authorize".format(self.auth0_domain)
+
+    @property
+    def token_url(self) -> str:
+        return "https://{}/oauth/token".format(self.auth0_domain)
+
+    @property
+    def tenant_url(self) -> str:
+        return "https://{}/api/v1/tenant".format(self.okahu_api_host)
+
+    @property
+    def mgmt_tenant_url(self) -> str:
+        return "https://{}/api/v1/tenant".format(self.okahu_mgmt_host)
+
+    def keys_url(self, tenant_id: str) -> str:
+        return "https://{}/api/v1/tenants/{}/keys".format(self.okahu_api_host, tenant_id)
+
+
+def load_config() -> AuthConfig:
+    return AuthConfig(
+        auth0_domain=os.environ.get("MONOCLE_AUTH0_DOMAIN", _DEFAULT_AUTH0_DOMAIN),
+        auth0_client_id=os.environ.get("MONOCLE_AUTH0_CLIENT_ID", _DEFAULT_AUTH0_CLIENT_ID),
+        auth0_audience=os.environ.get("MONOCLE_AUTH0_AUDIENCE", _DEFAULT_AUTH0_AUDIENCE),
+        okahu_api_host=os.environ.get("MONOCLE_OKAHU_API_HOST", _DEFAULT_OKAHU_API_HOST),
+        okahu_mgmt_host=os.environ.get("MONOCLE_OKAHU_MGMT_HOST", _DEFAULT_OKAHU_MGMT_HOST),
+    )

--- a/apptrace/src/monocle_apptrace/auth/config.py
+++ b/apptrace/src/monocle_apptrace/auth/config.py
@@ -1,16 +1,13 @@
 """Auth0 + Okahu endpoint resolution.
 
-Defaults target prod. The Auth0 client_id, audience, and API hosts must come
-from the same environment — mixing them produces a 401 "signing key not
-found" because the API only trusts JWTs signed by its own Auth0 tenant.
-Override via the MONOCLE_AUTH0_* / MONOCLE_OKAHU_* env vars to point at
-stage.
+Auth0 client_id, audience, and API hosts must come from the same deployment
+or the API rejects the JWT (401 "signing key not found"). Override via the
+MONOCLE_AUTH0_* / MONOCLE_OKAHU_* env vars.
 """
 import os
 from dataclasses import dataclass
 
 
-"""Callback server for the Auth0 redirect."""
 _DEFAULT_AUTH0_DOMAIN = "auth.okahu.co"
 _DEFAULT_AUTH0_CLIENT_ID = "w5msUdJgpximQMqo8LqkrLyiQMYbYiDw"
 _DEFAULT_AUTH0_AUDIENCE = "https://api.okahu.co/"

--- a/apptrace/src/monocle_apptrace/auth/okahu_api.py
+++ b/apptrace/src/monocle_apptrace/auth/okahu_api.py
@@ -1,0 +1,118 @@
+"""Okahu API calls (Bearer auth): look up tenant, create if missing, mint API key.
+
+The minted API key is what the trace exporter sends as `x-api-key` at
+runtime. The access_token is used only here during setup.
+"""
+import json
+import os
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from typing import Optional
+
+from ._ssl import SSL_CONTEXT
+from .config import AuthConfig
+
+
+# Server-side allow-listed; a value outside the list returns HTTP 400.
+# We use VS Code's value because it's known-accepted by the same backend.
+# Override via MONOCLE_PROVISIONING_SOURCE if the allow-list adds a CLI tag.
+_DEFAULT_PROVISIONING_SOURCE = "Okahu IDE Extension"
+
+
+class OkahuApiError(Exception):
+    def __init__(self, status: int, body: str, message: str = ""):
+        super().__init__(message or "Okahu API error {}: {}".format(status, body[:200]))
+        self.status = status
+        self.body = body
+
+
+def _pick_first(data: dict, *keys: str) -> Optional[str]:
+    # Okahu responses use snake_case, camelCase, or just `id` for the same
+    # field across endpoints. Tolerant lookup hides the inconsistency.
+    for key in keys:
+        value = data.get(key)
+        if value:
+            return value
+    return None
+
+
+def _bearer_request(url: str, access_token: str, method: str = "GET", body: Optional[dict] = None, timeout: float = 30.0) -> dict:
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", "Bearer {}".format(access_token))
+    req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout, context=SSL_CONTEXT) as resp:
+            payload = resp.read().decode("utf-8")
+            return json.loads(payload) if payload.strip() else {}
+    except urllib.error.HTTPError as e:
+        raise OkahuApiError(e.code, e.read().decode("utf-8", errors="replace"))
+
+
+def _is_missing_tenant_claim(error: OkahuApiError) -> bool:
+    # New users have a token with no tenant_id claim → API returns 401 with
+    # this structured error code (NOT a real auth failure — the cue to
+    # take the create-tenant branch).
+    if error.status != 401:
+        return False
+    try:
+        body = json.loads(error.body)
+        return body.get("error", {}).get("code") == "MISSING_TENANT_CLAIM"
+    except (ValueError, AttributeError):
+        return False
+
+
+def is_max_api_keys_reached(error: OkahuApiError) -> bool:
+    """True iff mint_api_key was rejected because the tenant hit its 8-key cap.
+
+    Caller (cli._get_api_key) routes this to a friendly message that points
+    the user at the portal to delete unused keys, rather than dumping the
+    raw HTTP error.
+    """
+    if error.status != 400:
+        return False
+    body_lower = (error.body or "").lower()
+    return "max limit" in body_lower and "api key" in body_lower
+
+
+def fetch_tenant_info(access_token: str, config: AuthConfig) -> Optional[dict]:
+    """Return tenant info if one exists for this user, else None."""
+    try:
+        data = _bearer_request(config.tenant_url, access_token)
+    except OkahuApiError as e:
+        if e.status == 404 or _is_missing_tenant_claim(e):
+            return None
+        raise
+    tenant_id = _pick_first(data, "tenant_id", "id", "tenantId")
+    if not tenant_id:
+        return None
+    return {
+        "tenant_id": tenant_id,
+        "tenant_name": _pick_first(data, "tenant_name", "name", "tenantName"),
+    }
+
+
+def create_tenant(access_token: str, display_name: str, config: AuthConfig) -> dict:
+    source = os.environ.get("MONOCLE_PROVISIONING_SOURCE", _DEFAULT_PROVISIONING_SOURCE)
+    body = {"display_name": display_name, "provisioning_source": source}
+    data = _bearer_request(config.mgmt_tenant_url, access_token, method="POST", body=body)
+    tenant_id = _pick_first(data, "tenant_id", "id", "tenantId")
+    if not tenant_id:
+        raise OkahuApiError(0, json.dumps(data), "Tenant create response missing tenant_id")
+    return {
+        "tenant_id": tenant_id,
+        "tenant_name": _pick_first(data, "tenant_name", "name", "tenantName"),
+    }
+
+
+def mint_api_key(access_token: str, tenant_id: str, config: AuthConfig, key_name: Optional[str] = None) -> str:
+    if key_name is None:
+        # Names must be unique per tenant (409 CONFLICT on duplicates).
+        stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
+        key_name = "monocle-cli-{}".format(stamp)
+    data = _bearer_request(config.keys_url(tenant_id), access_token, method="POST", body={"name": key_name})
+    key = _pick_first(data, "key", "api_key", "apiKey")
+    if not key:
+        raise OkahuApiError(0, json.dumps(data), "Key mint response missing key field")
+    return key

--- a/apptrace/src/monocle_apptrace/auth/okahu_api.py
+++ b/apptrace/src/monocle_apptrace/auth/okahu_api.py
@@ -28,8 +28,8 @@ class OkahuApiError(Exception):
 
 
 def _pick_first(data: dict, *keys: str) -> Optional[str]:
-    # Okahu responses use snake_case, camelCase, or just `id` for the same
-    # field across endpoints. Tolerant lookup hides the inconsistency.
+    # Different Okahu endpoints name the same field differently
+    # (tenant_id vs tenantId vs id) — try each, take the first non-empty.
     for key in keys:
         value = data.get(key)
         if value:

--- a/apptrace/src/monocle_apptrace/auth/pkce.py
+++ b/apptrace/src/monocle_apptrace/auth/pkce.py
@@ -1,0 +1,23 @@
+"""PKCE (RFC 7636) and CSRF-state helpers for the portal sign-in flow."""
+import base64
+import hashlib
+import secrets
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def generate_code_verifier() -> str:
+    # RFC 7636 §4.1: 43-128 chars from [A-Z][a-z][0-9]-._~.
+    # base64url(32 random bytes) yields a 43-char verifier in that alphabet.
+    return _b64url(secrets.token_bytes(32))
+
+
+def generate_code_challenge(verifier: str) -> str:
+    # RFC 7636 §4.2 S256: BASE64URL(SHA256(ASCII(verifier))).
+    return _b64url(hashlib.sha256(verifier.encode("ascii")).digest())
+
+
+def generate_state() -> str:
+    return _b64url(secrets.token_bytes(16))

--- a/apptrace/src/monocle_apptrace/auth/portal_auth.py
+++ b/apptrace/src/monocle_apptrace/auth/portal_auth.py
@@ -304,8 +304,9 @@ def resolve_okahu_api_key(method: str = "smart") -> dict:
         prompt = "No Okahu account found for " + ui.bold(display) + ". Create one?"
         if not ui.confirm(prompt, default_yes=True):
             raise PortalAuthError("Account creation declined.")
+        ui.step("Provisioning your Okahu account...")
         tenant = okahu_api.create_tenant(bundle["access_token"], display, config)
-        ui.check("Tenant created")
+        ui.check("Account created")
         # The original token lacks the new tenant_id claim. Refresh so the
         # mint-key call gets a token Auth0 has reissued with the claim.
         if bundle.get("refresh_token"):

--- a/apptrace/src/monocle_apptrace/auth/portal_auth.py
+++ b/apptrace/src/monocle_apptrace/auth/portal_auth.py
@@ -1,0 +1,321 @@
+"""Okahu sign-in via Auth0 (RFC 8252 loopback + RFC 7636 PKCE).
+
+Public entry points called by cli.py:
+  - sign_in_via_portal()       loopback flow (browser-based)
+  - sign_in_via_device_code()  RFC 8628 device code (no callback URL)
+  - sign_in_smart()            auto-pick: loopback on desktop, device when headless
+  - resolve_okahu_api_key()    sign in + create/find tenant + mint API key
+"""
+import base64
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import webbrowser
+from typing import Optional
+
+from . import callback_server, okahu_api, pkce, ui
+from ._ssl import SSL_CONTEXT
+from .config import AuthConfig, load_config
+
+
+_AUTHORIZE_TIMEOUT_SECONDS = 300
+_OAUTH_SCOPES = "openid profile email offline_access"
+
+
+class PortalAuthError(Exception):
+    pass
+
+
+class LoopbackUnavailable(PortalAuthError):
+    """Distinct from PortalAuthError so the smart cascade can fall back to
+    the device flow on bind failures without swallowing user-driven errors
+    (timeout, cancel, state mismatch)."""
+
+
+def _is_headless() -> bool:
+    if os.environ.get("SSH_TTY") or os.environ.get("SSH_CONNECTION"):
+        return True
+    if sys.platform.startswith("linux"):
+        if not (os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY")):
+            return True
+    return False
+
+
+def _build_authorize_url(config: AuthConfig, redirect_uri: str, state: str, code_challenge: str) -> str:
+    # No `connection` param — let Auth0's universal login show whichever
+    # providers are enabled on the tenant. Pinning to a specific connection
+    # breaks if it's not enabled on this client.
+    params = {
+        "response_type": "code",
+        "client_id": config.auth0_client_id,
+        "redirect_uri": redirect_uri,
+        "scope": _OAUTH_SCOPES,
+        "state": state,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "audience": config.auth0_audience,
+    }
+    return "{}?{}".format(config.authorize_url, urllib.parse.urlencode(params))
+
+
+def _refresh_access_token(config: AuthConfig, refresh_token: str) -> str:
+    # Used after tenant creation: the original token lacks the new tenant_id
+    # claim. Refreshing gets a token the API will accept on the mint-key call.
+    body = urllib.parse.urlencode({
+        "grant_type": "refresh_token",
+        "client_id": config.auth0_client_id,
+        "refresh_token": refresh_token,
+    }).encode("ascii")
+    req = urllib.request.Request(config.token_url, data=body, method="POST")
+    req.add_header("Content-Type", "application/x-www-form-urlencoded")
+    try:
+        with urllib.request.urlopen(req, timeout=30, context=SSL_CONTEXT) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")[:300]
+        raise PortalAuthError("Token refresh failed ({}): {}".format(e.code, detail))
+    new_token = data.get("access_token")
+    if not new_token:
+        raise PortalAuthError("Token refresh response missing access_token.")
+    return new_token
+
+
+def _exchange_code(config: AuthConfig, code: str, code_verifier: str, redirect_uri: str) -> dict:
+    body = urllib.parse.urlencode({
+        "grant_type": "authorization_code",
+        "client_id": config.auth0_client_id,
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "code_verifier": code_verifier,
+    }).encode("ascii")
+    req = urllib.request.Request(config.token_url, data=body, method="POST")
+    req.add_header("Content-Type", "application/x-www-form-urlencoded")
+    try:
+        with urllib.request.urlopen(req, timeout=30, context=SSL_CONTEXT) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")[:300]
+        raise PortalAuthError("Token exchange failed ({}): {}".format(e.code, detail))
+
+
+def _decode_email_from_jwt(access_token: str) -> Optional[str]:
+    # No signature verification — Auth0 just issued the token over TLS.
+    # We only read the email claim for display purposes.
+    try:
+        payload_b64 = access_token.split(".")[1]
+        padding = "=" * ((4 - len(payload_b64) % 4) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload_b64 + padding).decode("utf-8"))
+        return claims.get("email") or claims.get("https://okahu.co/email")
+    except (IndexError, ValueError, UnicodeDecodeError):
+        return None
+
+
+def sign_in_via_portal(timeout: float = _AUTHORIZE_TIMEOUT_SECONDS) -> dict:
+    """Authorization Code + PKCE flow. Returns {access_token, refresh_token,
+    expires_at, email}. Raises PortalAuthError on cancel/timeout/HTTP failure."""
+    config = load_config()
+    verifier = pkce.generate_code_verifier()
+    challenge = pkce.generate_code_challenge(verifier)
+    state = pkce.generate_state()
+
+    try:
+        port, result, shutdown = callback_server.start(expected_state=state)
+    except OSError as e:
+        raise LoopbackUnavailable("Cannot bind loopback callback server: {}".format(e))
+    # Use "localhost" not "127.0.0.1" — Auth0 does literal-string matching on
+    # redirect_uri and the dashboard entry is registered with "localhost".
+    redirect_uri = "http://localhost:{}/callback".format(port)
+    authorize_url = _build_authorize_url(config, redirect_uri, state, challenge)
+
+    try:
+        ui.step("Opening browser to sign in to Okahu...")
+        ui.hint("If it doesn't open automatically, visit:")
+        ui.hint(authorize_url)
+        opened = webbrowser.open(authorize_url)
+        if not opened:
+            ui.hint("(Could not auto-open a browser — paste the URL above manually.)")
+
+        ui.step("Waiting for sign-in... " + ui.dim("(Ctrl-C to cancel)"))
+        try:
+            if not result.done.wait(timeout=timeout):
+                raise PortalAuthError("Sign-in timed out after {}s.".format(int(timeout)))
+        except KeyboardInterrupt:
+            raise PortalAuthError("Sign-in cancelled.")
+
+        if result.error:
+            raise PortalAuthError(result.error)
+        if not result.code:
+            raise PortalAuthError("Sign-in completed without an authorization code.")
+
+        token_response = _exchange_code(config, result.code, verifier, redirect_uri)
+    finally:
+        shutdown()
+
+    access_token = token_response.get("access_token")
+    if not access_token:
+        raise PortalAuthError("Token endpoint returned no access_token.")
+
+    expires_in = int(token_response.get("expires_in", 0))
+    bundle = {
+        "access_token": access_token,
+        "refresh_token": token_response.get("refresh_token"),
+        "expires_at": int(time.time()) + expires_in if expires_in else None,
+        "email": _decode_email_from_jwt(access_token),
+    }
+    if bundle["email"]:
+        ui.check("Signed in as " + ui.bold(bundle["email"]))
+    return bundle
+
+
+def _device_code_url(config: AuthConfig) -> str:
+    return "https://{}/oauth/device/code".format(config.auth0_domain)
+
+
+def sign_in_via_device_code(timeout: float = _AUTHORIZE_TIMEOUT_SECONDS) -> dict:
+    """Device Authorization Grant (RFC 8628). No callback URL — we poll
+    /oauth/token until Auth0 returns tokens. Used when loopback isn't
+    available (SSH, headless, port collision)."""
+    config = load_config()
+
+    body = urllib.parse.urlencode({
+        "client_id": config.auth0_client_id,
+        "scope": _OAUTH_SCOPES,
+        "audience": config.auth0_audience,
+    }).encode("ascii")
+    req = urllib.request.Request(_device_code_url(config), data=body, method="POST")
+    req.add_header("Content-Type", "application/x-www-form-urlencoded")
+    try:
+        with urllib.request.urlopen(req, timeout=30, context=SSL_CONTEXT) as resp:
+            device = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", errors="replace")[:300]
+        raise PortalAuthError("Device-code request failed ({}): {}".format(e.code, detail))
+
+    user_code = device["user_code"]
+    verification_uri = device["verification_uri"]
+    verification_uri_complete = device.get("verification_uri_complete", verification_uri)
+    device_code = device["device_code"]
+    interval = int(device.get("interval", 5))
+    expires_in = int(device.get("expires_in", 900))
+
+    ui.blank()
+    ui.step("To sign in, visit " + ui.brand_alt(verification_uri))
+    ui.step("Enter this code:  " + ui.bold(user_code))
+    ui.hint("Or open the pre-filled URL: " + verification_uri_complete)
+    ui.blank()
+    try:
+        webbrowser.open(verification_uri_complete)
+    except Exception:
+        pass
+    ui.step("Waiting for sign-in... " + ui.dim("(Ctrl-C to cancel)"))
+
+    deadline = time.time() + min(expires_in, timeout)
+    while time.time() < deadline:
+        time.sleep(interval)
+        poll_body = urllib.parse.urlencode({
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            "device_code": device_code,
+            "client_id": config.auth0_client_id,
+        }).encode("ascii")
+        poll_req = urllib.request.Request(config.token_url, data=poll_body, method="POST")
+        poll_req.add_header("Content-Type", "application/x-www-form-urlencoded")
+        try:
+            with urllib.request.urlopen(poll_req, timeout=30, context=SSL_CONTEXT) as resp:
+                token_response = json.loads(resp.read().decode("utf-8"))
+                break
+        except urllib.error.HTTPError as e:
+            err_payload = e.read().decode("utf-8", errors="replace")
+            try:
+                err = json.loads(err_payload).get("error", "")
+            except ValueError:
+                err = ""
+            if err == "authorization_pending":
+                continue
+            if err == "slow_down":
+                interval += 5
+                continue
+            if err == "expired_token":
+                raise PortalAuthError("Device code expired before sign-in completed.")
+            if err == "access_denied":
+                raise PortalAuthError("Sign-in denied.")
+            raise PortalAuthError("Device-flow poll failed ({}): {}".format(e.code, err_payload[:200]))
+        except KeyboardInterrupt:
+            raise PortalAuthError("Sign-in cancelled.")
+    else:
+        raise PortalAuthError("Sign-in timed out after {}s.".format(int(min(expires_in, timeout))))
+
+    access_token = token_response.get("access_token")
+    if not access_token:
+        raise PortalAuthError("Device token endpoint returned no access_token.")
+
+    token_expires_in = int(token_response.get("expires_in", 0))
+    bundle = {
+        "access_token": access_token,
+        "refresh_token": token_response.get("refresh_token"),
+        "expires_at": int(time.time()) + token_expires_in if token_expires_in else None,
+        "email": _decode_email_from_jwt(access_token),
+    }
+    if bundle["email"]:
+        ui.check("Signed in as " + ui.bold(bundle["email"]))
+    return bundle
+
+
+def sign_in_smart() -> dict:
+    """Headless → device flow upfront. Desktop → loopback; if it can't bind,
+    fall back to device. User-driven failures (timeout, cancel, state
+    mismatch) do not auto-fall-back."""
+    if _is_headless():
+        ui.step("Headless environment detected — using code sign-in.")
+        return sign_in_via_device_code()
+    try:
+        return sign_in_via_portal()
+    except LoopbackUnavailable as e:
+        ui.step("{} Falling back to code sign-in.".format(e))
+        return sign_in_via_device_code()
+
+
+def resolve_okahu_api_key(method: str = "smart") -> dict:
+    """Sign in → resolve tenant → mint API key.
+
+    `method`: "smart" (default), "loopback", or "device". The returned api_key
+    is what the trace exporter sends as `x-api-key`; the access_token is
+    used only here during setup.
+    """
+    if method == "device":
+        bundle = sign_in_via_device_code()
+    elif method == "loopback":
+        bundle = sign_in_via_portal()
+    else:
+        bundle = sign_in_smart()
+
+    # Cover the silent gap during the two HTTPS calls below (~5s on stage,
+    # sub-second on prod).
+    ui.step("Setting up your Okahu workspace...")
+
+    config = load_config()
+    tenant = okahu_api.fetch_tenant_info(bundle["access_token"], config)
+    if tenant is None:
+        display = bundle["email"] or "monocle-cli user"
+        ui.blank()
+        prompt = "No Okahu account found for " + ui.bold(display) + ". Create one?"
+        if not ui.confirm(prompt, default_yes=True):
+            raise PortalAuthError("Account creation declined.")
+        tenant = okahu_api.create_tenant(bundle["access_token"], display, config)
+        ui.check("Tenant created")
+        # The original token lacks the new tenant_id claim. Refresh so the
+        # mint-key call gets a token Auth0 has reissued with the claim.
+        if bundle.get("refresh_token"):
+            bundle["access_token"] = _refresh_access_token(config, bundle["refresh_token"])
+
+    api_key = okahu_api.mint_api_key(bundle["access_token"], tenant["tenant_id"], config)
+    ui.check("API key generated")
+    return {
+        "api_key": api_key,
+        "email": bundle["email"],
+        "tenant_id": tenant["tenant_id"],
+        "tenant_name": tenant.get("tenant_name"),
+    }

--- a/apptrace/src/monocle_apptrace/auth/portal_auth.py
+++ b/apptrace/src/monocle_apptrace/auth/portal_auth.py
@@ -134,7 +134,7 @@ def sign_in_via_portal(timeout: float = _AUTHORIZE_TIMEOUT_SECONDS) -> dict:
     try:
         ui.step("Opening browser to sign in to Okahu...")
         ui.hint("If it doesn't open automatically, visit:")
-        ui.hint(authorize_url)
+        print(ui.dim(authorize_url))
         opened = webbrowser.open(authorize_url)
         if not opened:
             ui.hint("(Could not auto-open a browser — paste the URL above manually.)")
@@ -205,7 +205,8 @@ def sign_in_via_device_code(timeout: float = _AUTHORIZE_TIMEOUT_SECONDS) -> dict
     ui.blank()
     ui.step("To sign in, visit " + ui.brand_alt(verification_uri))
     ui.step("Enter this code:  " + ui.bold(user_code))
-    ui.hint("Or open the pre-filled URL: " + verification_uri_complete)
+    ui.hint("Or open the pre-filled URL:")
+    print(ui.dim(verification_uri_complete))
     ui.blank()
     try:
         webbrowser.open(verification_uri_complete)

--- a/apptrace/src/monocle_apptrace/auth/ui.py
+++ b/apptrace/src/monocle_apptrace/auth/ui.py
@@ -104,22 +104,29 @@ def confirm(question: str, default_yes: bool = True) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def select(question: str, options: list, docs_url: str = None) -> str:
+def select(question: str, options: list, links: list = None) -> str:
     """Single-select picker. Each option is a dict with `key`, `label`, and
-    optional `hint`. Returns the chosen `key`. Falls back to numeric input
+    optional `hint`. `links` is an optional list of (label, url) tuples shown
+    under the menu. Returns the chosen `key`. Falls back to numeric input
     when not running on an interactive POSIX TTY."""
     if not _INTERACTIVE or not _ARROW_KEYS_AVAILABLE:
-        return _select_numeric(question, options, docs_url)
-    return _select_arrow(question, options, docs_url)
+        return _select_numeric(question, options, links)
+    return _select_arrow(question, options, links)
 
 
-def _select_numeric(question: str, options: list, docs_url: str = None) -> str:
+def _link_label_width(links: list) -> int:
+    return max(len(label) for label, _ in links) if links else 0
+
+
+def _select_numeric(question: str, options: list, links: list = None) -> str:
     section(question)
     for line in _option_lines(options, -1):  # -1 → nothing highlighted in fallback
         print(line)
     print()
-    if docs_url:
-        print("  " + dim("Learn more  ·  ") + brand_alt(docs_url))
+    if links:
+        width = _link_label_width(links)
+        for label, url in links:
+            print("  " + dim(label.ljust(width) + "  ·  ") + brand_alt(url))
         print()
     valid = [str(i) for i in range(1, len(options) + 1)]
     while True:
@@ -151,7 +158,7 @@ def _option_lines(options: list, selected: int) -> list:
     return lines
 
 
-def _select_arrow(question: str, options: list, docs_url: str = None) -> str:
+def _select_arrow(question: str, options: list, links: list = None) -> str:
     selected = 0
     section(question)
     lines = _option_lines(options, selected)
@@ -159,11 +166,13 @@ def _select_arrow(question: str, options: list, docs_url: str = None) -> str:
         print(line)
     print()
     print("  " + dim("↑↓ navigate  ·  enter select  ·  ctrl-c cancel"))
-    if docs_url:
-        print("  " + dim("learn more  ·  ") + brand_alt(docs_url))
+    if links:
+        width = _link_label_width(links)
+        for label, url in links:
+            print("  " + dim(label.ljust(width) + "  ·  ") + brand_alt(url))
 
     menu_height = len(lines)
-    footer_height = 3 if docs_url else 2  # blank + nav (+ docs line)
+    footer_height = 2 + (len(links) if links else 0)  # blank + nav (+ one row per link)
     # Hide cursor while the menu is interactive (avoids blink at footer end).
     sys.stdout.write("\x1b[?25l")
     sys.stdout.flush()

--- a/apptrace/src/monocle_apptrace/auth/ui.py
+++ b/apptrace/src/monocle_apptrace/auth/ui.py
@@ -1,0 +1,220 @@
+"""Terminal styling helpers + arrow-key selection picker.
+
+Stdlib only. ANSI escapes for color, termios/tty for raw input. Falls back
+to numbered input when stdin isn't a TTY, on Windows, or when `NO_COLOR`
+is set. Glyphs: `>` header, `›` cursor, `✓` confirm, `•` step.
+"""
+import os
+import sys
+
+
+_USE_COLOR = sys.stdout.isatty() and os.environ.get("NO_COLOR") is None
+_INTERACTIVE = sys.stdin.isatty() and sys.stdout.isatty()
+
+# Probe once for the raw-keystroke modules used by the arrow-key picker.
+# These ship with every CPython on POSIX but not on Windows.
+try:
+    import termios as _termios
+    import tty as _tty
+    _ARROW_KEYS_AVAILABLE = True
+except ImportError:
+    _ARROW_KEYS_AVAILABLE = False
+
+
+def _style(code: str, text: str) -> str:
+    if not _USE_COLOR:
+        return text
+    return "\033[{}m{}\033[0m".format(code, text)
+
+
+def bold(text: str) -> str: return _style("1", text)
+def dim(text: str) -> str: return _style("2", text)
+def red(text: str) -> str: return _style("31", text)
+
+
+# Monocle brand palette — teal "Mon" + blue "ocle" from the logo.
+# 24-bit truecolor; degrades to plain text on NO_COLOR or non-TTY.
+_BRAND_TEAL = "38;2;77;182;182"   # ~#4DB6B6
+_BRAND_BLUE = "38;2;92;122;184"   # ~#5C7AB8
+
+
+def brand(text: str) -> str: return _style(_BRAND_TEAL, text)
+def brand_alt(text: str) -> str: return _style(_BRAND_BLUE, text)
+
+
+def _monocle_wordmark() -> str:
+    if not _USE_COLOR:
+        return "Monocle"
+    return "\033[1;{}mMon\033[0m\033[1;{}mocle\033[0m".format(_BRAND_TEAL, _BRAND_BLUE)
+
+
+def header(title: str, subtitle: str = "") -> None:
+    # Treat the literal word "Monocle" specially so the wordmark gets the
+    # brand gradient while the rest of the title stays default bold.
+    if title.startswith("Monocle "):
+        styled_title = _monocle_wordmark() + bold(title[len("Monocle"):])
+    else:
+        styled_title = bold(title)
+    line = "> " + styled_title
+    if subtitle:
+        line += "  " + dim("·") + "  " + dim(subtitle)
+    print()
+    print(line)
+    print()
+
+
+def section(text: str) -> None:
+    print("  " + bold(text))
+    print()
+
+
+def step(text: str) -> None:
+    print("  " + dim("•") + " " + text)
+
+
+def check(text: str) -> None:
+    print("  " + brand("✓") + " " + text)
+
+
+def fail(text: str) -> None:
+    # Red is intentional for errors — universal "broke" indicator.
+    print("  " + red("✗") + " " + text)
+
+
+def hint(text: str) -> None:
+    print("    " + dim(text))
+
+
+def blank() -> None:
+    print()
+
+
+def confirm(question: str, default_yes: bool = True) -> bool:
+    if not _INTERACTIVE:
+        return default_yes
+    suffix = "[Y/n]" if default_yes else "[y/N]"
+    response = input("  " + question + " " + dim(suffix) + " " + brand("›") + " ").strip().lower()
+    if not response:
+        return default_yes
+    return response.startswith("y")
+
+
+# ---------------------------------------------------------------------------
+# Interactive selection — arrow keys with numeric fallback.
+# ---------------------------------------------------------------------------
+
+
+def select(question: str, options: list, docs_url: str = None) -> str:
+    """Single-select picker. Each option is a dict with `key`, `label`, and
+    optional `hint`. Returns the chosen `key`. Falls back to numeric input
+    when not running on an interactive POSIX TTY."""
+    if not _INTERACTIVE or not _ARROW_KEYS_AVAILABLE:
+        return _select_numeric(question, options, docs_url)
+    return _select_arrow(question, options, docs_url)
+
+
+def _select_numeric(question: str, options: list, docs_url: str = None) -> str:
+    section(question)
+    for line in _option_lines(options, -1):  # -1 → nothing highlighted in fallback
+        print(line)
+    print()
+    if docs_url:
+        print("  " + dim("Learn more  ·  ") + brand_alt(docs_url))
+        print()
+    valid = [str(i) for i in range(1, len(options) + 1)]
+    while True:
+        choice = input("  Choose " + dim("[" + "/".join(valid) + "]") + " " + brand("›") + " ").strip()
+        if choice in valid:
+            return options[int(choice) - 1]["key"]
+
+
+def _option_lines(options: list, selected: int) -> list:
+    # Labels padded to the widest one so the em-dash before each hint aligns.
+    # `selected = -1` highlights nothing (used by the numeric fallback).
+    label_width = max(len(opt["label"]) for opt in options)
+    lines = []
+    for i, opt in enumerate(options):
+        label = opt["label"]
+        if i == selected:
+            marker = brand("›")
+            num = brand(str(i + 1))
+            styled_label = bold(label)
+        else:
+            marker = " "
+            num = dim(str(i + 1))
+            styled_label = label
+        pad = " " * (label_width - len(label))
+        line = "  " + marker + " " + num + "   " + styled_label + pad
+        if opt.get("hint"):
+            line += "  " + dim("—  " + opt["hint"])
+        lines.append(line)
+    return lines
+
+
+def _select_arrow(question: str, options: list, docs_url: str = None) -> str:
+    selected = 0
+    section(question)
+    lines = _option_lines(options, selected)
+    for line in lines:
+        print(line)
+    print()
+    print("  " + dim("↑↓ navigate  ·  enter select  ·  ctrl-c cancel"))
+    if docs_url:
+        print("  " + dim("learn more  ·  ") + brand_alt(docs_url))
+
+    menu_height = len(lines)
+    footer_height = 3 if docs_url else 2  # blank + nav (+ docs line)
+    # Hide cursor while the menu is interactive (avoids blink at footer end).
+    sys.stdout.write("\x1b[?25l")
+    sys.stdout.flush()
+    fd = sys.stdin.fileno()
+    old_settings = _termios.tcgetattr(fd)
+    try:
+        # `setcbreak` (not setraw): keeps OPOST so \n still translates to
+        # \r\n. Raw mode would cause each redraw line to start mid-row.
+        _tty.setcbreak(fd)
+        while True:
+            ch = sys.stdin.read(1)
+            if ch == "\x1b":
+                seq = sys.stdin.read(2)
+                if seq == "[A":
+                    selected = (selected - 1) % len(options)
+                elif seq == "[B":
+                    selected = (selected + 1) % len(options)
+                else:
+                    continue
+                # Cursor is just past the footer. Walk up over (footer + menu),
+                # rewrite menu lines in place, walk back down to the footer.
+                sys.stdout.write("\x1b[{}A\r".format(footer_height + menu_height))
+                for line in _option_lines(options, selected):
+                    sys.stdout.write("\x1b[2K" + line + "\n")
+                sys.stdout.write("\x1b[{}B\r".format(footer_height))
+                sys.stdout.flush()
+            elif ch in ("\r", "\n"):
+                break
+            elif ch == "\x03":
+                _termios.tcsetattr(fd, _termios.TCSADRAIN, old_settings)
+                sys.stdout.write("\x1b[?25h")
+                sys.stdout.flush()
+                print()
+                raise KeyboardInterrupt
+    finally:
+        _termios.tcsetattr(fd, _termios.TCSADRAIN, old_settings)
+        sys.stdout.write("\x1b[?25h")
+        sys.stdout.flush()
+
+    # Collapse menu+footer into one confirmation line so the screen reads
+    # as a clean trail of resolved choices.
+    #   section header + blank = 2 lines  (always)
+    #   menu                   = menu_height
+    #   blank + nav (+ docs)   = footer_height
+    section_height = 2
+    total_lines = section_height + menu_height + footer_height
+    sys.stdout.write("\x1b[{}A\r".format(total_lines))
+    for _ in range(total_lines):
+        sys.stdout.write("\x1b[2K\n")
+    sys.stdout.write("\x1b[{}A\r".format(total_lines))
+    chosen = options[selected]
+    print("  " + brand("✓") + " " + chosen["label"] + dim("  ·  " + question))
+    sys.stdout.flush()
+    return chosen["key"]

--- a/apptrace/src/monocle_apptrace/cli.py
+++ b/apptrace/src/monocle_apptrace/cli.py
@@ -1,4 +1,13 @@
 """Monocle CLI — install hooks for AI coding agents and dispatch hook events.
+
+Subcommands:
+  claude-setup    register Monocle hooks for Claude Code
+  codex-setup     register Monocle hooks for Codex CLI
+  validate        validate a trace file against the metamodel
+  reset           dev helper — clear local state (REMOVE BEFORE PR)
+
+Hook dispatch (`claude-hook`, `codex-hook`) is invoked as a subprocess by
+each agent when a hook fires — see `main()` for that path.
 """
 import argparse
 import getpass
@@ -9,31 +18,208 @@ import stat
 import sys
 from pathlib import Path
 
-MONOCLE_ENV = Path.home() / ".monocle" / ".env"
+from monocle_apptrace.auth import ui
+from monocle_apptrace.auth.okahu_api import OkahuApiError, is_max_api_keys_reached
+from monocle_apptrace.auth.portal_auth import PortalAuthError, resolve_okahu_api_key
+
+# Global install → write env config to ~/.monocle/.env (shared across all
+# sessions on this machine). Project install → write to ./.env.monocle in
+# the project root (scoped to that directory only).
+GLOBAL_ENV_FILE = Path.home() / ".monocle" / ".env"
+PROJECT_ENV_FILENAME = ".env.monocle"
+
 _METAMODEL_DIR = Path(__file__).parent / "instrumentation" / "metamodel"
 _HOOK_MARKERS = ("monocle-apptrace", "monocle_apptrace.instrumentation.metamodel")
+_DOCS_URL = "https://docs.okahu.ai/"
 
 
-def _enable_codex_hooks_flag():
-    config = Path.home() / ".codex" / "config.toml"
-    config.parent.mkdir(parents=True, exist_ok=True)
-    text = config.read_text() if config.exists() else ""
-    if "codex_hooks = true" in text:
-        return
-    sep = "\n" if text and not text.endswith("\n") else ""
-    config.write_text(text + sep + "[features]\ncodex_hooks = true\n")
+# =============================================================================
+# Setup commands  (claude-setup, codex-setup)
+# =============================================================================
 
 
-def _package_version():
-    try:
-        return importlib.metadata.version("monocle_apptrace")
-    except importlib.metadata.PackageNotFoundError:
-        return "dev"
+def cmd_claude_setup(args):
+    return _run_setup(
+        args,
+        agent="claude",
+        label="Claude Code",
+        hooks_subpath=".claude/settings.json",
+        hooks_template=_METAMODEL_DIR / "claude_cli" / "hooks.json",
+    )
 
 
-def _save_env(**kwargs):
-    MONOCLE_ENV.parent.mkdir(parents=True, exist_ok=True)
-    lines = MONOCLE_ENV.read_text().splitlines() if MONOCLE_ENV.exists() else ["# Monocle config — edit directly to change settings"]
+def cmd_codex_setup(args):
+    return _run_setup(
+        args,
+        agent="codex",
+        label="Codex CLI",
+        hooks_subpath=".codex/hooks.json",
+        hooks_template=_METAMODEL_DIR / "codex_cli" / "hooks.json",
+        post_install=_enable_codex_hooks_flag,
+    )
+
+
+def _run_setup(args, *, agent, label, hooks_subpath, hooks_template, post_install=None):
+    ui.header("Monocle setup", label)
+
+    # 1. Where to install: ~ (global) or cwd (project). Both the hook file
+    #    and the env file are anchored at the same root.
+    scope = args.scope or _prompt_install_scope(label)
+    if scope == "global":
+        root = Path.home()
+        env_file = GLOBAL_ENV_FILE
+    else:
+        root = Path.cwd()
+        env_file = root / PROJECT_ENV_FILENAME
+    settings_file = root / hooks_subpath
+
+    # 2. Get the API key (or None if the user chose local-only / skip).
+    api_key, aborted = _get_api_key(args)
+    if aborted:
+        return 1
+
+    # 3. Save env and install hooks.
+    if api_key:
+        _save_env(env_file, OKAHU_API_KEY=api_key, MONOCLE_EXPORTER="okahu")
+    else:
+        _save_env(env_file, MONOCLE_EXPORTER="file")
+    _install_hooks(agent, settings_file, hooks_template)
+    if post_install:
+        post_install(root)
+
+    # 4. Done.
+    ui.check("Hooks installed for " + label)
+    ui.blank()
+    ui.hint("Config: " + str(env_file))
+    ui.hint("Hooks:  " + str(settings_file))
+    ui.blank()
+    ui.step(ui.brand("Monocle is ready.") + " Run " + ui.bold(agent) + " to start tracing.")
+    ui.blank()
+    return 0
+
+
+# =============================================================================
+# API key resolution
+# =============================================================================
+
+
+def _get_api_key(args):
+    """Decide how to get an OKAHU_API_KEY.
+
+    Returns (api_key, aborted):
+      api_key is the key string, or None for "no key — use file exporter."
+      aborted is True only if the user tried to sign in and it failed.
+    """
+    if args.api_key:
+        return args.api_key, False
+    if args.local_only:
+        return None, False
+
+    existing = _read_existing_key()
+
+    # Pick the sign-in mechanism: explicit flag wins; otherwise reuse the
+    # existing key (with confirmation if interactive); otherwise prompt.
+    if args.portal:
+        method = "loopback"
+    elif args.device:
+        method = "device"
+    elif existing and not sys.stdin.isatty():
+        return existing, False  # CI / scripts: reuse silently
+    elif existing and _confirm_reuse_existing(existing):
+        return existing, False
+    else:
+        method = _prompt_auth_method()
+
+    if method in ("smart", "loopback", "device"):
+        try:
+            result = resolve_okahu_api_key(method=method)
+        except PortalAuthError as e:
+            ui.fail("Sign-in failed: " + str(e))
+            return None, True
+        except OkahuApiError as e:
+            if is_max_api_keys_reached(e):
+                _explain_max_keys_reached()
+            else:
+                ui.fail("Okahu API error: " + str(e))
+            return None, True
+        return result["api_key"], False
+
+    if method == "paste":
+        key = getpass.getpass("  Okahu API key: ").strip()
+        return (key or None), False
+
+    return None, False  # "skip" or anything else falls through here.
+
+
+def _read_existing_key():
+    # Lazy import: get_monocle_env_value transitively pulls in OpenTelemetry,
+    # which we don't want to pay for on `monocle-apptrace --version`.
+    from monocle_apptrace.instrumentation.common.utils import get_monocle_env_value
+    return get_monocle_env_value("OKAHU_API_KEY")
+
+
+def _explain_max_keys_reached():
+    """User-friendly message for the '8 API keys per tenant' cap."""
+    ui.fail("Couldn't generate a new API key — your Okahu tenant has reached the 8-key limit.")
+    ui.blank()
+    ui.hint("Two ways to recover:")
+    ui.hint("  • Reuse one of your existing keys — re-run setup and pick \"Paste an API key\".")
+    ui.hint("  • Delete unused keys at https://portal.okahu.co (Settings → API Keys), then re-run.")
+
+
+def _confirm_reuse_existing(existing_key):
+    masked = existing_key[:6] + "…" + existing_key[-4:] if len(existing_key) > 10 else "…"
+    if ui.confirm("Continue with existing API key " + ui.dim(masked) + "?", default_yes=True):
+        ui.check("Using existing Okahu API key")
+        return True
+    return False
+
+
+# =============================================================================
+# Interactive prompts
+# =============================================================================
+
+
+def _prompt_install_scope(label):
+    if not sys.stdin.isatty():
+        return "global"
+    return ui.select("Where should " + label + " hooks be installed?", [
+        {"key": "global",  "label": "Global",
+         "hint": str(Path.home()) + "  —  all " + label + " sessions on this machine"},
+        {"key": "project", "label": "This project",
+         "hint": str(Path.cwd()) + "  —  only sessions started here"},
+    ])
+
+
+def _prompt_auth_method():
+    if not sys.stdin.isatty():
+        return "skip"
+    return ui.select(
+        "How would you like to authenticate with Okahu?",
+        [
+            {"key": "smart", "label": "Sign in",
+             "hint": "opens your browser, or a code if needed"},
+            {"key": "paste", "label": "Paste an API key",
+             "hint": "if you already have one from the Okahu portal"},
+            {"key": "skip",  "label": "Skip",
+             "hint": "store traces locally and inspect with the Chrome extension"},
+        ],
+        docs_url=_DOCS_URL,
+    )
+
+
+# =============================================================================
+# File writers
+# =============================================================================
+
+
+def _save_env(env_file, **kwargs):
+    """Update `env_file`. Each kwarg becomes a `KEY=value` line; existing
+    lines for the same key are replaced in place. File mode is 0600."""
+    env_file.parent.mkdir(parents=True, exist_ok=True)
+    lines = env_file.read_text().splitlines() if env_file.exists() else [
+        "# Monocle config — edit directly to change settings"
+    ]
     for key, value in kwargs.items():
         replaced = False
         for i, line in enumerate(lines):
@@ -46,33 +232,13 @@ def _save_env(**kwargs):
                 break
         if not replaced:
             lines.append("{}={}".format(key, value))
-    MONOCLE_ENV.write_text("\n".join(lines) + "\n")
-    os.chmod(MONOCLE_ENV, stat.S_IRUSR | stat.S_IWUSR)
+    env_file.write_text("\n".join(lines) + "\n")
+    os.chmod(env_file, stat.S_IRUSR | stat.S_IWUSR)
 
 
-def setup(agent, label, settings_file, hooks_template, extra_setup=None):
-    from monocle_apptrace.instrumentation.common.utils import get_monocle_env_value
-
-    api_key = get_monocle_env_value("OKAHU_API_KEY")
-    if api_key:
-        print("Using existing Okahu API key.")
-    else:
-        api_key = getpass.getpass("Okahu API key (leave blank for local-only): ").strip()
-
-    if api_key:
-        _save_env(OKAHU_API_KEY=api_key, MONOCLE_EXPORTER="okahu")
-    else:
-        _save_env(MONOCLE_EXPORTER="file")
-
-    _install_hooks(agent, settings_file, hooks_template, extra_setup)
-
-    print("Monocle hooks installed for {}.".format(label))
-    print("Config: {}".format(MONOCLE_ENV))
-    print("Hooks:  {}".format(settings_file))
-    return 0
-
-
-def _install_hooks(agent, settings_file, hooks_template, extra_setup=None):
+def _install_hooks(agent, settings_file, hooks_template):
+    """Merge Monocle hook entries into the agent's settings file (idempotent —
+    re-running just updates the command if it's already there)."""
     template = json.loads(hooks_template.read_text())["hooks"]
     new_command = "monocle-apptrace {}-hook".format(agent)
 
@@ -94,8 +260,22 @@ def _install_hooks(agent, settings_file, hooks_template, extra_setup=None):
             settings["hooks"].setdefault(event, []).extend(groups)
 
     settings_file.write_text(json.dumps(settings, indent=2))
-    if extra_setup:
-        extra_setup()
+
+
+def _enable_codex_hooks_flag(scope_root):
+    """Codex needs `[features] codex_hooks = true` in its config.toml to fire hooks."""
+    config = scope_root / ".codex" / "config.toml"
+    config.parent.mkdir(parents=True, exist_ok=True)
+    text = config.read_text() if config.exists() else ""
+    if "codex_hooks = true" in text:
+        return
+    sep = "\n" if text and not text.endswith("\n") else ""
+    config.write_text(text + sep + "[features]\ncodex_hooks = true\n")
+
+
+# =============================================================================
+# Hook dispatch  (called by the agent's hook subprocess at runtime)
+# =============================================================================
 
 
 def hook_dispatch(agent):
@@ -110,33 +290,119 @@ def hook_dispatch(agent):
     return 0
 
 
-def cmd_validate(trace_file, level="selective", fail_on_warning=False):
-    """Validate a Monocle trace file"""
+# =============================================================================
+# validate  (lint a trace file against the metamodel)
+# =============================================================================
+
+
+def cmd_validate(args):
     try:
         from monocle_apptrace.linter import MonocleValidator, ValidationReporter
-
         validator = MonocleValidator()
-        results = validator.validate_trace_file(Path(trace_file))
-
-        # Format and print output
+        results = validator.validate_trace_file(Path(args.trace_file))
         reporter = ValidationReporter()
-        output = reporter.format_results(results, fail_on_warning)
-        print(output)
-
-        # Return exit code
-        return reporter.get_exit_code(results, fail_on_warning)
-
+        print(reporter.format_results(results, args.fail_on_warning))
+        return reporter.get_exit_code(results, args.fail_on_warning)
     except FileNotFoundError as e:
-        print(f"ERROR: {e}", file=sys.stderr)
+        print("ERROR: {}".format(e), file=sys.stderr)
         return 1
     except Exception as e:
-        print(f"ERROR: {e}", file=sys.stderr)
+        print("ERROR: {}".format(e), file=sys.stderr)
         return 1
+
+
+# =============================================================================
+# DEV HELPER
+# `monocle-apptrace reset` wipes ~/.monocle/.env, ~/.monocle/auth.json, and
+# the Monocle hook entries in each agent's settings file. Lets us start
+# fresh between test runs during development.
+# =============================================================================
+
+
+def cmd_reset(args):
+    ui.header("Monocle reset")
+
+    cleared = []
+    for path in (
+        GLOBAL_ENV_FILE,
+        Path.home() / ".monocle" / "auth.json",
+        Path.cwd() / PROJECT_ENV_FILENAME,  # project-level env, if reset is run inside a project
+    ):
+        if path.exists():
+            path.unlink()
+            cleared.append(path)
+
+    hook_paths = (
+        Path.home() / ".claude" / "settings.json",
+        Path.cwd()  / ".claude" / "settings.json",
+        Path.home() / ".codex"  / "hooks.json",
+        Path.cwd()  / ".codex"  / "hooks.json",
+    )
+    for path in hook_paths:
+        if path.exists() and _strip_monocle_hooks(path):
+            cleared.append(path)
+
+    if cleared:
+        for p in cleared:
+            ui.check("Cleaned " + str(p))
+    else:
+        ui.step("Nothing to clean.")
+    ui.blank()
+    ui.step(ui.brand("Reset done.") + " Run " + ui.bold("monocle-apptrace claude-setup") + " for a fresh setup.")
+    ui.blank()
+    return 0
+
+
+def _strip_monocle_hooks(settings_file):
+    """Remove Monocle hook entries from a settings file. Returns True if changed."""
+    try:
+        settings = json.loads(settings_file.read_text())
+    except Exception:
+        return False
+    hooks = settings.get("hooks", {})
+    if not hooks:
+        return False
+
+    changed = False
+    for event in list(hooks.keys()):
+        new_groups = []
+        for group in hooks.get(event, []):
+            inner = group.get("hooks", [])
+            kept = [h for h in inner if not any(m in h.get("command", "") for m in _HOOK_MARKERS)]
+            if kept != inner:
+                changed = True
+            if kept:
+                group["hooks"] = kept
+                new_groups.append(group)
+            elif inner:
+                continue  # all inner hooks were monocle — drop the group
+            else:
+                # Copilot-style: command at the group level.
+                if any(m in group.get("command", "") for m in _HOOK_MARKERS):
+                    changed = True
+                else:
+                    new_groups.append(group)
+        if new_groups:
+            hooks[event] = new_groups
+        else:
+            del hooks[event]
+            changed = True
+    if not hooks:
+        settings.pop("hooks", None)
+    if changed:
+        settings_file.write_text(json.dumps(settings, indent=2))
+    return changed
+
+
+# =============================================================================
+# Entry point
+# =============================================================================
 
 
 def main(argv=None):
     argv = sys.argv[1:] if argv is None else list(argv)
 
+    # Hook subprocess paths — invoked by the agent at runtime, no argparse needed.
     if argv and argv[0] == "claude-hook":
         return hook_dispatch("claude")
     if argv and argv[0] == "codex-hook":
@@ -146,34 +412,59 @@ def main(argv=None):
         print("monocle-apptrace {}".format(_package_version()))
         return 0
 
+    args = _build_parser().parse_args(argv)
+
+    if args.command == "claude-setup":
+        return cmd_claude_setup(args)
+    if args.command == "codex-setup":
+        return cmd_codex_setup(args)
+    if args.command == "validate":
+        return cmd_validate(args)
+    if args.command == "reset":
+        return cmd_reset(args)
+    return 1
+
+
+def _package_version():
+    try:
+        return importlib.metadata.version("monocle_apptrace")
+    except importlib.metadata.PackageNotFoundError:
+        return "dev"
+
+
+def _build_parser():
     parser = argparse.ArgumentParser(prog="monocle-apptrace")
     parser.add_argument("--version", action="version",
                         version="monocle-apptrace {}".format(_package_version()))
     sub = parser.add_subparsers(dest="command", required=True, metavar="<command>")
-    sub.add_parser("claude-setup", help="Register Monocle hooks for Claude Code")
-    sub.add_parser("codex-setup",  help="Register Monocle hooks for Codex CLI")
 
-    # Add validate subcommand
-    validate_parser = sub.add_parser("validate", help="Validate Monocle traces against metamodel conformance")
-    validate_parser.add_argument("trace_file", help="Path to trace JSON file")
-    validate_parser.add_argument("--level", choices=["basic", "selective", "strict"],
-                                default="selective", help="Validation level (default: selective)")
-    validate_parser.add_argument("--fail-on-warning", action="store_true",
-                                help="Treat warnings as errors (exit code 1)")
+    # claude-setup and codex-setup share the same flags.
+    for name, help_text in (("claude-setup", "Register Monocle hooks for Claude Code"),
+                            ("codex-setup",  "Register Monocle hooks for Codex CLI")):
+        p = sub.add_parser(name, help=help_text)
+        p.add_argument("--api-key", help="Use this API key without prompting")
+        p.add_argument("--portal", action="store_true",
+                       help="Sign in via browser (skip the prompt)")
+        p.add_argument("--device", action="store_true",
+                       help="Sign in with a code (no callback URL; works over SSH)")
+        p.add_argument("--local-only", action="store_true",
+                       help="Write traces to file only, no Okahu key needed")
+        scope_group = p.add_mutually_exclusive_group()
+        scope_group.add_argument("--global", dest="scope", action="store_const", const="global",
+                                 help="Install hooks at ~/.<agent>/ (all sessions on this machine)")
+        scope_group.add_argument("--project", dest="scope", action="store_const", const="project",
+                                 help="Install hooks at ./.<agent>/ (only this directory)")
 
-    args = parser.parse_args(argv)
-    if args.command == "claude-setup":
-        return setup("claude", "Claude Code",
-                     Path.home() / ".claude" / "settings.json",
-                     _METAMODEL_DIR / "claude_cli" / "hooks.json")
-    if args.command == "codex-setup":
-        return setup("codex", "Codex CLI",
-                     Path.home() / ".codex" / "hooks.json",
-                     _METAMODEL_DIR / "codex_cli" / "hooks.json",
-                     _enable_codex_hooks_flag)
-    if args.command == "validate":
-        return cmd_validate(args.trace_file, args.level, args.fail_on_warning)
-    return 1
+    sub.add_parser("reset", help="Clear Monocle state (dev helper; will be removed before PR)")
+
+    v = sub.add_parser("validate", help="Validate Monocle traces against metamodel conformance")
+    v.add_argument("trace_file", help="Path to trace JSON file")
+    v.add_argument("--level", choices=["basic", "selective", "strict"],
+                   default="selective", help="Validation level (default: selective)")
+    v.add_argument("--fail-on-warning", action="store_true",
+                   help="Treat warnings as errors (exit code 1)")
+
+    return parser
 
 
 if __name__ == "__main__":

--- a/apptrace/src/monocle_apptrace/cli.py
+++ b/apptrace/src/monocle_apptrace/cli.py
@@ -29,6 +29,7 @@ PROJECT_ENV_FILENAME = ".env.monocle"
 _METAMODEL_DIR = Path(__file__).parent / "instrumentation" / "metamodel"
 _HOOK_MARKERS = ("monocle-apptrace", "monocle_apptrace.instrumentation.metamodel")
 _DOCS_URL = "https://docs.okahu.ai/"
+_VSCODE_EXTENSION_URL = "https://marketplace.visualstudio.com/items?itemName=OkahuAI.okahu-ai-observability"
 
 
 # =============================================================================
@@ -203,9 +204,12 @@ def _prompt_auth_method():
             {"key": "paste", "label": "Paste an API key",
              "hint": "if you already have one from the Okahu portal"},
             {"key": "skip",  "label": "Skip",
-             "hint": "store traces locally and inspect with the Chrome extension"},
+             "hint": "store traces locally and inspect with the VS Code Okahu extension"},
         ],
-        docs_url=_DOCS_URL,
+        links=[
+            ("learn more", _DOCS_URL),
+            ("extension", _VSCODE_EXTENSION_URL),
+        ],
     )
 
 

--- a/apptrace/src/monocle_apptrace/cli.py
+++ b/apptrace/src/monocle_apptrace/cli.py
@@ -19,8 +19,6 @@ import sys
 from pathlib import Path
 
 from monocle_apptrace.auth import ui
-from monocle_apptrace.auth.okahu_api import OkahuApiError, is_max_api_keys_reached
-from monocle_apptrace.auth.portal_auth import PortalAuthError, resolve_okahu_api_key
 
 # Global install → write env config to ~/.monocle/.env (shared across all
 # sessions on this machine). Project install → write to ./.env.monocle in
@@ -110,6 +108,9 @@ def _get_api_key(args):
       api_key is the key string, or None for "no key — use file exporter."
       aborted is True only if the user tried to sign in and it failed.
     """
+    from monocle_apptrace.auth.okahu_api import OkahuApiError, is_max_api_keys_reached
+    from monocle_apptrace.auth.portal_auth import PortalAuthError, resolve_okahu_api_key
+
     if args.api_key:
         return args.api_key, False
     if args.local_only:

--- a/apptrace/tests/unit/test_portal_auth.py
+++ b/apptrace/tests/unit/test_portal_auth.py
@@ -1,0 +1,408 @@
+"""Unit tests for the portal OAuth sign-in pipeline.
+
+Exercises the auth package end-to-end without touching real Auth0 or Okahu
+servers — the loopback callback server is driven by a synthetic browser hit,
+and HTTPS calls to Auth0 / Okahu management endpoints are mocked at
+urllib.request.urlopen.
+"""
+import io
+import json
+import os
+import threading
+import time
+import unittest
+import urllib.error
+import urllib.request
+from unittest import mock
+
+from monocle_apptrace.auth import (
+    callback_server,
+    config,
+    okahu_api,
+    portal_auth,
+)
+
+
+class CallbackServerTests(unittest.TestCase):
+    def setUp(self):
+        # Use an OS-assigned port so tests don't collide on the pinned 18292.
+        self._port_patch = mock.patch.dict(os.environ, {"MONOCLE_LOOPBACK_PORT": "0"})
+        self._port_patch.start()
+
+    def tearDown(self):
+        self._port_patch.stop()
+
+    def _drive(self, query):
+        port, result, shutdown = callback_server.start(expected_state="abc")
+        try:
+            def hit():
+                # Tolerate 4xx — server still returns the captured fields.
+                try:
+                    urllib.request.urlopen(
+                        "http://127.0.0.1:{}/callback?{}".format(port, query),
+                        timeout=2,
+                    ).read()
+                except urllib.error.HTTPError:
+                    pass
+            threading.Thread(target=hit, daemon=True).start()
+            self.assertTrue(result.done.wait(timeout=3))
+            return result
+        finally:
+            shutdown()
+
+    def test_captures_code_on_valid_state(self):
+        result = self._drive("code=abc123&state=abc")
+        self.assertEqual(result.code, "abc123")
+        self.assertIsNone(result.error)
+
+    def test_rejects_state_mismatch(self):
+        result = self._drive("code=abc123&state=wrong")
+        self.assertIsNone(result.code)
+        self.assertIn("State mismatch", result.error)
+
+    def test_surfaces_provider_error(self):
+        result = self._drive("error=access_denied&error_description=user+denied")
+        self.assertIsNone(result.code)
+        self.assertIn("user denied", result.error)
+
+    def test_missing_code_param(self):
+        result = self._drive("state=abc")
+        self.assertIsNone(result.code)
+        self.assertIn("No authorization code", result.error)
+
+
+def _fake_http_response(payload, status=200):
+    """Build a context-manager-friendly fake response for urllib.request.urlopen."""
+    body = json.dumps(payload).encode("utf-8")
+    resp = mock.MagicMock()
+    resp.read.return_value = body
+    resp.__enter__.return_value = resp
+    resp.__exit__.return_value = False
+    resp.status = status
+    return resp
+
+
+class OkahuApiTests(unittest.TestCase):
+    def setUp(self):
+        self.config = config.load_config()
+        self.access_token = "fake-token"
+
+    def test_fetch_tenant_returns_normalized_payload(self):
+        with mock.patch.object(urllib.request, "urlopen",
+                               return_value=_fake_http_response({"tenant_id": "t1", "tenant_name": "Acme"})):
+            tenant = okahu_api.fetch_tenant_info(self.access_token, self.config)
+        self.assertEqual(tenant, {"tenant_id": "t1", "tenant_name": "Acme"})
+
+    def test_fetch_tenant_returns_none_on_404(self):
+        err = urllib.error.HTTPError(self.config.tenant_url, 404, "Not Found",
+                                     hdrs={}, fp=io.BytesIO(b"{}"))
+        with mock.patch.object(urllib.request, "urlopen", side_effect=err):
+            self.assertIsNone(okahu_api.fetch_tenant_info(self.access_token, self.config))
+
+    def test_create_tenant_posts_display_name(self):
+        captured = {}
+        def fake_urlopen(req, timeout=None, context=None):
+            captured["url"] = req.full_url
+            captured["body"] = json.loads(req.data.decode("utf-8"))
+            return _fake_http_response({"tenant_id": "t3"})
+        with mock.patch.object(urllib.request, "urlopen", side_effect=fake_urlopen):
+            okahu_api.create_tenant(self.access_token, "alice@example.com", self.config)
+        self.assertEqual(captured["body"]["display_name"], "alice@example.com")
+        self.assertEqual(captured["body"]["provisioning_source"], "Okahu IDE Extension")
+
+    def test_mint_api_key_extracts_key_field(self):
+        with mock.patch.object(urllib.request, "urlopen",
+                               return_value=_fake_http_response({"key": "k-123"})):
+            key = okahu_api.mint_api_key(self.access_token, "t1", self.config)
+        self.assertEqual(key, "k-123")
+
+    def test_fetch_tenant_returns_none_on_missing_tenant_claim(self):
+        # New users: the API responds 401 with a structured body. fetch_tenant_info
+        # should treat that as "no tenant" (same as 404), letting the caller
+        # take the create-tenant branch.
+        body = b'{"error": {"code": "MISSING_TENANT_CLAIM", "message": "claim missing"}}'
+        err = urllib.error.HTTPError(self.config.tenant_url, 401, "Unauthorized",
+                                     hdrs={}, fp=io.BytesIO(body))
+        with mock.patch.object(urllib.request, "urlopen", side_effect=err):
+            self.assertIsNone(okahu_api.fetch_tenant_info(self.access_token, self.config))
+
+
+class ConfigTests(unittest.TestCase):
+    def test_env_var_overrides_defaults(self):
+        with mock.patch.dict(os.environ, {
+            "MONOCLE_AUTH0_DOMAIN": "dev.example.com",
+            "MONOCLE_AUTH0_CLIENT_ID": "test-id",
+            "MONOCLE_OKAHU_API_HOST": "api.example.com",
+        }):
+            cfg = config.load_config()
+        self.assertEqual(cfg.auth0_domain, "dev.example.com")
+        self.assertEqual(cfg.auth0_client_id, "test-id")
+        self.assertEqual(cfg.authorize_url, "https://dev.example.com/authorize")
+        self.assertEqual(cfg.keys_url("t1"), "https://api.example.com/api/v1/tenants/t1/keys")
+
+    def test_prod_defaults_when_env_unset(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            for key in ("MONOCLE_AUTH0_DOMAIN", "MONOCLE_AUTH0_CLIENT_ID",
+                        "MONOCLE_AUTH0_AUDIENCE", "MONOCLE_OKAHU_API_HOST",
+                        "MONOCLE_OKAHU_MGMT_HOST"):
+                os.environ.pop(key, None)
+            cfg = config.load_config()
+        # Defaults point at the prod Auth0 app (PKCE-only, loopback callback
+        # registered) and the prod API hosts that trust its signing keys.
+        # Stage is opt-in via env-var overrides.
+        self.assertEqual(cfg.auth0_domain, "auth.okahu.co")
+        self.assertEqual(cfg.auth0_client_id, "w5msUdJgpximQMqo8LqkrLyiQMYbYiDw")
+        self.assertEqual(cfg.okahu_api_host, "api.okahu.co")
+        self.assertEqual(cfg.okahu_mgmt_host, "management.okahu.co")
+
+
+class PortalAuthFlowTests(unittest.TestCase):
+    def test_authorize_url_contains_pkce_and_state(self):
+        cfg = config.load_config()
+        url = portal_auth._build_authorize_url(
+            cfg, "http://127.0.0.1:12345/callback", "STATE123", "CHALLENGE123",
+        )
+        self.assertIn("response_type=code", url)
+        self.assertIn("code_challenge=CHALLENGE123", url)
+        self.assertIn("code_challenge_method=S256", url)
+        self.assertIn("state=STATE123", url)
+        self.assertIn("redirect_uri=http%3A%2F%2F127.0.0.1%3A12345%2Fcallback", url)
+
+    def test_jwt_email_extraction(self):
+        # Hand-craft a JWT-like string: header.payload.sig — only payload matters.
+        import base64
+        payload = base64.urlsafe_b64encode(
+            json.dumps({"email": "alice@example.com", "sub": "auth0|x"}).encode("utf-8")
+        ).rstrip(b"=").decode("ascii")
+        fake_jwt = "header.{}.sig".format(payload)
+        self.assertEqual(portal_auth._decode_email_from_jwt(fake_jwt), "alice@example.com")
+
+
+class DeviceFlowTests(unittest.TestCase):
+    """Cover the Device Authorization Grant polling state machine."""
+
+    def _build_jwt_with_email(self, email):
+        import base64
+        payload = base64.urlsafe_b64encode(
+            json.dumps({"email": email, "sub": "auth0|x"}).encode("utf-8")
+        ).rstrip(b"=").decode("ascii")
+        return "header.{}.sig".format(payload)
+
+    def test_device_request_body_carries_client_id_scope_audience(self):
+        captured = {"requests": []}
+
+        def fake_urlopen(req, timeout=None, context=None):
+            captured["requests"].append((req.full_url, req.data, req.method))
+            url = req.full_url
+            if "/device/code" in url:
+                return _fake_http_response({
+                    "device_code": "DEVCODE",
+                    "user_code": "ABCD-EFGH",
+                    "verification_uri": "https://auth.okahu.co/activate",
+                    "verification_uri_complete": "https://auth.okahu.co/activate?user_code=ABCD-EFGH",
+                    "expires_in": 600,
+                    "interval": 0,
+                })
+            # Token endpoint: succeed immediately
+            return _fake_http_response({
+                "access_token": self._build_jwt_with_email("bob@example.com"),
+                "expires_in": 3600,
+            })
+
+        with mock.patch.object(urllib.request, "urlopen", side_effect=fake_urlopen), \
+             mock.patch("time.sleep"):  # interval=0 anyway, but be safe
+            bundle = portal_auth.sign_in_via_device_code()
+
+        # First request hit /device/code with the right form-encoded body.
+        first_url, first_body, first_method = captured["requests"][0]
+        self.assertIn("/oauth/device/code", first_url)
+        self.assertEqual(first_method, "POST")
+        from urllib.parse import parse_qs
+        parsed = parse_qs(first_body.decode("ascii"))
+        self.assertIn("client_id", parsed)
+        self.assertIn("audience", parsed)
+        self.assertIn("openid", parsed["scope"][0])
+        self.assertEqual(bundle["email"], "bob@example.com")
+
+    def test_device_polling_handles_authorization_pending_then_success(self):
+        # First poll returns 400 authorization_pending, second returns tokens.
+        call_count = {"n": 0}
+
+        def fake_urlopen(req, timeout=None, context=None):
+            if "/device/code" in req.full_url:
+                return _fake_http_response({
+                    "device_code": "DC", "user_code": "AB-CD",
+                    "verification_uri": "x", "verification_uri_complete": "y",
+                    "expires_in": 600, "interval": 0,
+                })
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise urllib.error.HTTPError(
+                    req.full_url, 400, "Bad", hdrs={},
+                    fp=io.BytesIO(b'{"error":"authorization_pending"}'),
+                )
+            return _fake_http_response({
+                "access_token": self._build_jwt_with_email("carol@example.com"),
+                "expires_in": 3600,
+            })
+
+        with mock.patch.object(urllib.request, "urlopen", side_effect=fake_urlopen), \
+             mock.patch("time.sleep"):
+            bundle = portal_auth.sign_in_via_device_code()
+
+        self.assertEqual(call_count["n"], 2)  # one pending, one success
+        self.assertEqual(bundle["email"], "carol@example.com")
+
+    def test_device_polling_raises_on_access_denied(self):
+        def fake_urlopen(req, timeout=None, context=None):
+            if "/device/code" in req.full_url:
+                return _fake_http_response({
+                    "device_code": "DC", "user_code": "AB-CD",
+                    "verification_uri": "x", "verification_uri_complete": "y",
+                    "expires_in": 600, "interval": 0,
+                })
+            raise urllib.error.HTTPError(
+                req.full_url, 403, "Forbidden", hdrs={},
+                fp=io.BytesIO(b'{"error":"access_denied"}'),
+            )
+
+        with mock.patch.object(urllib.request, "urlopen", side_effect=fake_urlopen), \
+             mock.patch("time.sleep"):
+            with self.assertRaises(portal_auth.PortalAuthError) as ctx:
+                portal_auth.sign_in_via_device_code()
+        self.assertIn("denied", str(ctx.exception).lower())
+
+    def test_device_polling_raises_on_expired_token(self):
+        def fake_urlopen(req, timeout=None, context=None):
+            if "/device/code" in req.full_url:
+                return _fake_http_response({
+                    "device_code": "DC", "user_code": "AB-CD",
+                    "verification_uri": "x", "verification_uri_complete": "y",
+                    "expires_in": 600, "interval": 0,
+                })
+            raise urllib.error.HTTPError(
+                req.full_url, 400, "Bad", hdrs={},
+                fp=io.BytesIO(b'{"error":"expired_token"}'),
+            )
+
+        with mock.patch.object(urllib.request, "urlopen", side_effect=fake_urlopen), \
+             mock.patch("time.sleep"):
+            with self.assertRaises(portal_auth.PortalAuthError) as ctx:
+                portal_auth.sign_in_via_device_code()
+        self.assertIn("expired", str(ctx.exception).lower())
+
+    def test_resolve_uses_device_flow_when_method_is_device(self):
+        with mock.patch.object(portal_auth, "sign_in_via_device_code") as device, \
+             mock.patch.object(portal_auth, "sign_in_via_portal") as loopback, \
+             mock.patch.object(portal_auth.okahu_api, "fetch_tenant_info",
+                               return_value={"tenant_id": "t", "tenant_name": "T"}), \
+             mock.patch.object(portal_auth.okahu_api, "mint_api_key", return_value="k"):
+            device.return_value = {"access_token": "tok", "refresh_token": None,
+                                   "expires_at": None, "email": "x@y"}
+            portal_auth.resolve_okahu_api_key(method="device")
+        device.assert_called_once()
+        loopback.assert_not_called()
+
+
+class HeadlessDetectionTests(unittest.TestCase):
+    def _clear(self):
+        for k in ("SSH_TTY", "SSH_CONNECTION", "DISPLAY", "WAYLAND_DISPLAY"):
+            os.environ.pop(k, None)
+
+    def test_ssh_tty_triggers_headless(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            self._clear()
+            os.environ["SSH_TTY"] = "/dev/pts/0"
+            self.assertTrue(portal_auth._is_headless())
+
+    def test_linux_without_display_is_headless(self):
+        with mock.patch.dict(os.environ, {}, clear=False), \
+             mock.patch.object(portal_auth.sys, "platform", "linux"):
+            self._clear()
+            self.assertTrue(portal_auth._is_headless())
+
+    def test_linux_with_display_is_not_headless(self):
+        with mock.patch.dict(os.environ, {}, clear=False), \
+             mock.patch.object(portal_auth.sys, "platform", "linux"):
+            self._clear()
+            os.environ["DISPLAY"] = ":0"
+            self.assertFalse(portal_auth._is_headless())
+
+
+class SmartCascadeTests(unittest.TestCase):
+    def test_smart_uses_device_when_headless(self):
+        with mock.patch.dict(os.environ, {"SSH_TTY": "/dev/pts/0"}, clear=False), \
+             mock.patch.object(portal_auth, "sign_in_via_device_code") as device, \
+             mock.patch.object(portal_auth, "sign_in_via_portal") as loopback:
+            device.return_value = {"access_token": "from-device", "refresh_token": None,
+                                   "expires_at": None, "email": "x@y"}
+            portal_auth.sign_in_smart()
+        device.assert_called_once()
+        loopback.assert_not_called()
+
+    def test_smart_uses_loopback_on_desktop(self):
+        with mock.patch.dict(os.environ, {}, clear=False), \
+             mock.patch.object(portal_auth, "sign_in_via_device_code") as device, \
+             mock.patch.object(portal_auth, "sign_in_via_portal") as loopback:
+            for k in ("SSH_TTY", "SSH_CONNECTION", "DISPLAY", "WAYLAND_DISPLAY"):
+                os.environ.pop(k, None)
+            with mock.patch.object(portal_auth.sys, "platform", "darwin"):
+                loopback.return_value = {"access_token": "from-loopback", "refresh_token": None,
+                                         "expires_at": None, "email": "x@y"}
+                portal_auth.sign_in_smart()
+        loopback.assert_called_once()
+        device.assert_not_called()
+
+    def test_smart_falls_back_to_device_when_loopback_cannot_bind(self):
+        with mock.patch.dict(os.environ, {}, clear=False), \
+             mock.patch.object(portal_auth, "sign_in_via_device_code") as device, \
+             mock.patch.object(portal_auth, "sign_in_via_portal",
+                               side_effect=portal_auth.LoopbackUnavailable("port busy")) as loopback:
+            for k in ("SSH_TTY", "SSH_CONNECTION", "DISPLAY", "WAYLAND_DISPLAY"):
+                os.environ.pop(k, None)
+            with mock.patch.object(portal_auth.sys, "platform", "darwin"):
+                device.return_value = {"access_token": "from-device", "refresh_token": None,
+                                       "expires_at": None, "email": "x@y"}
+                portal_auth.sign_in_smart()
+        loopback.assert_called_once()
+        device.assert_called_once()
+
+    def test_smart_does_not_fall_back_on_user_driven_failure(self):
+        # Timeout / cancel / state mismatch must surface, not silently switch flows.
+        with mock.patch.dict(os.environ, {}, clear=False), \
+             mock.patch.object(portal_auth, "sign_in_via_device_code") as device, \
+             mock.patch.object(portal_auth, "sign_in_via_portal",
+                               side_effect=portal_auth.PortalAuthError("Sign-in timed out.")):
+            for k in ("SSH_TTY", "SSH_CONNECTION", "DISPLAY", "WAYLAND_DISPLAY"):
+                os.environ.pop(k, None)
+            with mock.patch.object(portal_auth.sys, "platform", "darwin"):
+                with self.assertRaises(portal_auth.PortalAuthError):
+                    portal_auth.sign_in_smart()
+        device.assert_not_called()
+
+    def test_resolve_uses_smart_by_default(self):
+        with mock.patch.object(portal_auth, "sign_in_smart") as smart, \
+             mock.patch.object(portal_auth.okahu_api, "fetch_tenant_info",
+                               return_value={"tenant_id": "t", "tenant_name": "T"}), \
+             mock.patch.object(portal_auth.okahu_api, "mint_api_key", return_value="k"):
+            smart.return_value = {"access_token": "tok", "refresh_token": None,
+                                  "expires_at": None, "email": "x@y"}
+            result = portal_auth.resolve_okahu_api_key()  # default method
+        smart.assert_called_once()
+        self.assertEqual(result["api_key"], "k")
+
+    def test_resolve_with_loopback_method_skips_fallback(self):
+        with mock.patch.object(portal_auth, "sign_in_via_portal") as loopback, \
+             mock.patch.object(portal_auth, "sign_in_smart") as smart, \
+             mock.patch.object(portal_auth.okahu_api, "fetch_tenant_info",
+                               return_value={"tenant_id": "t", "tenant_name": "T"}), \
+             mock.patch.object(portal_auth.okahu_api, "mint_api_key", return_value="k"):
+            loopback.return_value = {"access_token": "tok", "refresh_token": None,
+                                     "expires_at": None, "email": "x@y"}
+            portal_auth.resolve_okahu_api_key(method="loopback")
+        loopback.assert_called_once()
+        smart.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apptrace/tests/unit/test_portal_auth.py
+++ b/apptrace/tests/unit/test_portal_auth.py
@@ -1,15 +1,8 @@
-"""Unit tests for the portal OAuth sign-in pipeline.
-
-Exercises the auth package end-to-end without touching real Auth0 or Okahu
-servers — the loopback callback server is driven by a synthetic browser hit,
-and HTTPS calls to Auth0 / Okahu management endpoints are mocked at
-urllib.request.urlopen.
-"""
+"""Unit tests for the auth package. HTTPS calls mocked at urlopen — no network."""
 import io
 import json
 import os
 import threading
-import time
 import unittest
 import urllib.error
 import urllib.request
@@ -24,14 +17,6 @@ from monocle_apptrace.auth import (
 
 
 class CallbackServerTests(unittest.TestCase):
-    def setUp(self):
-        # Use an OS-assigned port so tests don't collide on the pinned 18292.
-        self._port_patch = mock.patch.dict(os.environ, {"MONOCLE_LOOPBACK_PORT": "0"})
-        self._port_patch.start()
-
-    def tearDown(self):
-        self._port_patch.stop()
-
     def _drive(self, query):
         port, result, shutdown = callback_server.start(expected_state="abc")
         try:
@@ -60,19 +45,8 @@ class CallbackServerTests(unittest.TestCase):
         self.assertIsNone(result.code)
         self.assertIn("State mismatch", result.error)
 
-    def test_surfaces_provider_error(self):
-        result = self._drive("error=access_denied&error_description=user+denied")
-        self.assertIsNone(result.code)
-        self.assertIn("user denied", result.error)
-
-    def test_missing_code_param(self):
-        result = self._drive("state=abc")
-        self.assertIsNone(result.code)
-        self.assertIn("No authorization code", result.error)
-
 
 def _fake_http_response(payload, status=200):
-    """Build a context-manager-friendly fake response for urllib.request.urlopen."""
     body = json.dumps(payload).encode("utf-8")
     resp = mock.MagicMock()
     resp.read.return_value = body
@@ -93,16 +67,9 @@ class OkahuApiTests(unittest.TestCase):
             tenant = okahu_api.fetch_tenant_info(self.access_token, self.config)
         self.assertEqual(tenant, {"tenant_id": "t1", "tenant_name": "Acme"})
 
-    def test_fetch_tenant_returns_none_on_404(self):
-        err = urllib.error.HTTPError(self.config.tenant_url, 404, "Not Found",
-                                     hdrs={}, fp=io.BytesIO(b"{}"))
-        with mock.patch.object(urllib.request, "urlopen", side_effect=err):
-            self.assertIsNone(okahu_api.fetch_tenant_info(self.access_token, self.config))
-
     def test_create_tenant_posts_display_name(self):
         captured = {}
         def fake_urlopen(req, timeout=None, context=None):
-            captured["url"] = req.full_url
             captured["body"] = json.loads(req.data.decode("utf-8"))
             return _fake_http_response({"tenant_id": "t3"})
         with mock.patch.object(urllib.request, "urlopen", side_effect=fake_urlopen):
@@ -117,43 +84,11 @@ class OkahuApiTests(unittest.TestCase):
         self.assertEqual(key, "k-123")
 
     def test_fetch_tenant_returns_none_on_missing_tenant_claim(self):
-        # New users: the API responds 401 with a structured body. fetch_tenant_info
-        # should treat that as "no tenant" (same as 404), letting the caller
-        # take the create-tenant branch.
         body = b'{"error": {"code": "MISSING_TENANT_CLAIM", "message": "claim missing"}}'
         err = urllib.error.HTTPError(self.config.tenant_url, 401, "Unauthorized",
                                      hdrs={}, fp=io.BytesIO(body))
         with mock.patch.object(urllib.request, "urlopen", side_effect=err):
             self.assertIsNone(okahu_api.fetch_tenant_info(self.access_token, self.config))
-
-
-class ConfigTests(unittest.TestCase):
-    def test_env_var_overrides_defaults(self):
-        with mock.patch.dict(os.environ, {
-            "MONOCLE_AUTH0_DOMAIN": "dev.example.com",
-            "MONOCLE_AUTH0_CLIENT_ID": "test-id",
-            "MONOCLE_OKAHU_API_HOST": "api.example.com",
-        }):
-            cfg = config.load_config()
-        self.assertEqual(cfg.auth0_domain, "dev.example.com")
-        self.assertEqual(cfg.auth0_client_id, "test-id")
-        self.assertEqual(cfg.authorize_url, "https://dev.example.com/authorize")
-        self.assertEqual(cfg.keys_url("t1"), "https://api.example.com/api/v1/tenants/t1/keys")
-
-    def test_prod_defaults_when_env_unset(self):
-        with mock.patch.dict(os.environ, {}, clear=False):
-            for key in ("MONOCLE_AUTH0_DOMAIN", "MONOCLE_AUTH0_CLIENT_ID",
-                        "MONOCLE_AUTH0_AUDIENCE", "MONOCLE_OKAHU_API_HOST",
-                        "MONOCLE_OKAHU_MGMT_HOST"):
-                os.environ.pop(key, None)
-            cfg = config.load_config()
-        # Defaults point at the prod Auth0 app (PKCE-only, loopback callback
-        # registered) and the prod API hosts that trust its signing keys.
-        # Stage is opt-in via env-var overrides.
-        self.assertEqual(cfg.auth0_domain, "auth.okahu.co")
-        self.assertEqual(cfg.auth0_client_id, "w5msUdJgpximQMqo8LqkrLyiQMYbYiDw")
-        self.assertEqual(cfg.okahu_api_host, "api.okahu.co")
-        self.assertEqual(cfg.okahu_mgmt_host, "management.okahu.co")
 
 
 class PortalAuthFlowTests(unittest.TestCase):
@@ -169,7 +104,6 @@ class PortalAuthFlowTests(unittest.TestCase):
         self.assertIn("redirect_uri=http%3A%2F%2F127.0.0.1%3A12345%2Fcallback", url)
 
     def test_jwt_email_extraction(self):
-        # Hand-craft a JWT-like string: header.payload.sig — only payload matters.
         import base64
         payload = base64.urlsafe_b64encode(
             json.dumps({"email": "alice@example.com", "sub": "auth0|x"}).encode("utf-8")
@@ -179,8 +113,6 @@ class PortalAuthFlowTests(unittest.TestCase):
 
 
 class DeviceFlowTests(unittest.TestCase):
-    """Cover the Device Authorization Grant polling state machine."""
-
     def _build_jwt_with_email(self, email):
         import base64
         payload = base64.urlsafe_b64encode(
@@ -188,44 +120,7 @@ class DeviceFlowTests(unittest.TestCase):
         ).rstrip(b"=").decode("ascii")
         return "header.{}.sig".format(payload)
 
-    def test_device_request_body_carries_client_id_scope_audience(self):
-        captured = {"requests": []}
-
-        def fake_urlopen(req, timeout=None, context=None):
-            captured["requests"].append((req.full_url, req.data, req.method))
-            url = req.full_url
-            if "/device/code" in url:
-                return _fake_http_response({
-                    "device_code": "DEVCODE",
-                    "user_code": "ABCD-EFGH",
-                    "verification_uri": "https://auth.okahu.co/activate",
-                    "verification_uri_complete": "https://auth.okahu.co/activate?user_code=ABCD-EFGH",
-                    "expires_in": 600,
-                    "interval": 0,
-                })
-            # Token endpoint: succeed immediately
-            return _fake_http_response({
-                "access_token": self._build_jwt_with_email("bob@example.com"),
-                "expires_in": 3600,
-            })
-
-        with mock.patch.object(urllib.request, "urlopen", side_effect=fake_urlopen), \
-             mock.patch("time.sleep"):  # interval=0 anyway, but be safe
-            bundle = portal_auth.sign_in_via_device_code()
-
-        # First request hit /device/code with the right form-encoded body.
-        first_url, first_body, first_method = captured["requests"][0]
-        self.assertIn("/oauth/device/code", first_url)
-        self.assertEqual(first_method, "POST")
-        from urllib.parse import parse_qs
-        parsed = parse_qs(first_body.decode("ascii"))
-        self.assertIn("client_id", parsed)
-        self.assertIn("audience", parsed)
-        self.assertIn("openid", parsed["scope"][0])
-        self.assertEqual(bundle["email"], "bob@example.com")
-
     def test_device_polling_handles_authorization_pending_then_success(self):
-        # First poll returns 400 authorization_pending, second returns tokens.
         call_count = {"n": 0}
 
         def fake_urlopen(req, timeout=None, context=None):
@@ -247,86 +142,12 @@ class DeviceFlowTests(unittest.TestCase):
             })
 
         with mock.patch.object(urllib.request, "urlopen", side_effect=fake_urlopen), \
+             mock.patch.object(portal_auth.webbrowser, "open"), \
              mock.patch("time.sleep"):
             bundle = portal_auth.sign_in_via_device_code()
 
-        self.assertEqual(call_count["n"], 2)  # one pending, one success
+        self.assertEqual(call_count["n"], 2)
         self.assertEqual(bundle["email"], "carol@example.com")
-
-    def test_device_polling_raises_on_access_denied(self):
-        def fake_urlopen(req, timeout=None, context=None):
-            if "/device/code" in req.full_url:
-                return _fake_http_response({
-                    "device_code": "DC", "user_code": "AB-CD",
-                    "verification_uri": "x", "verification_uri_complete": "y",
-                    "expires_in": 600, "interval": 0,
-                })
-            raise urllib.error.HTTPError(
-                req.full_url, 403, "Forbidden", hdrs={},
-                fp=io.BytesIO(b'{"error":"access_denied"}'),
-            )
-
-        with mock.patch.object(urllib.request, "urlopen", side_effect=fake_urlopen), \
-             mock.patch("time.sleep"):
-            with self.assertRaises(portal_auth.PortalAuthError) as ctx:
-                portal_auth.sign_in_via_device_code()
-        self.assertIn("denied", str(ctx.exception).lower())
-
-    def test_device_polling_raises_on_expired_token(self):
-        def fake_urlopen(req, timeout=None, context=None):
-            if "/device/code" in req.full_url:
-                return _fake_http_response({
-                    "device_code": "DC", "user_code": "AB-CD",
-                    "verification_uri": "x", "verification_uri_complete": "y",
-                    "expires_in": 600, "interval": 0,
-                })
-            raise urllib.error.HTTPError(
-                req.full_url, 400, "Bad", hdrs={},
-                fp=io.BytesIO(b'{"error":"expired_token"}'),
-            )
-
-        with mock.patch.object(urllib.request, "urlopen", side_effect=fake_urlopen), \
-             mock.patch("time.sleep"):
-            with self.assertRaises(portal_auth.PortalAuthError) as ctx:
-                portal_auth.sign_in_via_device_code()
-        self.assertIn("expired", str(ctx.exception).lower())
-
-    def test_resolve_uses_device_flow_when_method_is_device(self):
-        with mock.patch.object(portal_auth, "sign_in_via_device_code") as device, \
-             mock.patch.object(portal_auth, "sign_in_via_portal") as loopback, \
-             mock.patch.object(portal_auth.okahu_api, "fetch_tenant_info",
-                               return_value={"tenant_id": "t", "tenant_name": "T"}), \
-             mock.patch.object(portal_auth.okahu_api, "mint_api_key", return_value="k"):
-            device.return_value = {"access_token": "tok", "refresh_token": None,
-                                   "expires_at": None, "email": "x@y"}
-            portal_auth.resolve_okahu_api_key(method="device")
-        device.assert_called_once()
-        loopback.assert_not_called()
-
-
-class HeadlessDetectionTests(unittest.TestCase):
-    def _clear(self):
-        for k in ("SSH_TTY", "SSH_CONNECTION", "DISPLAY", "WAYLAND_DISPLAY"):
-            os.environ.pop(k, None)
-
-    def test_ssh_tty_triggers_headless(self):
-        with mock.patch.dict(os.environ, {}, clear=False):
-            self._clear()
-            os.environ["SSH_TTY"] = "/dev/pts/0"
-            self.assertTrue(portal_auth._is_headless())
-
-    def test_linux_without_display_is_headless(self):
-        with mock.patch.dict(os.environ, {}, clear=False), \
-             mock.patch.object(portal_auth.sys, "platform", "linux"):
-            self._clear()
-            self.assertTrue(portal_auth._is_headless())
-
-    def test_linux_with_display_is_not_headless(self):
-        with mock.patch.dict(os.environ, {}, clear=False), \
-             mock.patch.object(portal_auth.sys, "platform", "linux"):
-            self._clear()
-            os.environ["DISPLAY"] = ":0"
-            self.assertFalse(portal_auth._is_headless())
 
 
 class SmartCascadeTests(unittest.TestCase):
@@ -339,19 +160,6 @@ class SmartCascadeTests(unittest.TestCase):
             portal_auth.sign_in_smart()
         device.assert_called_once()
         loopback.assert_not_called()
-
-    def test_smart_uses_loopback_on_desktop(self):
-        with mock.patch.dict(os.environ, {}, clear=False), \
-             mock.patch.object(portal_auth, "sign_in_via_device_code") as device, \
-             mock.patch.object(portal_auth, "sign_in_via_portal") as loopback:
-            for k in ("SSH_TTY", "SSH_CONNECTION", "DISPLAY", "WAYLAND_DISPLAY"):
-                os.environ.pop(k, None)
-            with mock.patch.object(portal_auth.sys, "platform", "darwin"):
-                loopback.return_value = {"access_token": "from-loopback", "refresh_token": None,
-                                         "expires_at": None, "email": "x@y"}
-                portal_auth.sign_in_smart()
-        loopback.assert_called_once()
-        device.assert_not_called()
 
     def test_smart_falls_back_to_device_when_loopback_cannot_bind(self):
         with mock.patch.dict(os.environ, {}, clear=False), \
@@ -368,7 +176,6 @@ class SmartCascadeTests(unittest.TestCase):
         device.assert_called_once()
 
     def test_smart_does_not_fall_back_on_user_driven_failure(self):
-        # Timeout / cancel / state mismatch must surface, not silently switch flows.
         with mock.patch.dict(os.environ, {}, clear=False), \
              mock.patch.object(portal_auth, "sign_in_via_device_code") as device, \
              mock.patch.object(portal_auth, "sign_in_via_portal",
@@ -379,29 +186,6 @@ class SmartCascadeTests(unittest.TestCase):
                 with self.assertRaises(portal_auth.PortalAuthError):
                     portal_auth.sign_in_smart()
         device.assert_not_called()
-
-    def test_resolve_uses_smart_by_default(self):
-        with mock.patch.object(portal_auth, "sign_in_smart") as smart, \
-             mock.patch.object(portal_auth.okahu_api, "fetch_tenant_info",
-                               return_value={"tenant_id": "t", "tenant_name": "T"}), \
-             mock.patch.object(portal_auth.okahu_api, "mint_api_key", return_value="k"):
-            smart.return_value = {"access_token": "tok", "refresh_token": None,
-                                  "expires_at": None, "email": "x@y"}
-            result = portal_auth.resolve_okahu_api_key()  # default method
-        smart.assert_called_once()
-        self.assertEqual(result["api_key"], "k")
-
-    def test_resolve_with_loopback_method_skips_fallback(self):
-        with mock.patch.object(portal_auth, "sign_in_via_portal") as loopback, \
-             mock.patch.object(portal_auth, "sign_in_smart") as smart, \
-             mock.patch.object(portal_auth.okahu_api, "fetch_tenant_info",
-                               return_value={"tenant_id": "t", "tenant_name": "T"}), \
-             mock.patch.object(portal_auth.okahu_api, "mint_api_key", return_value="k"):
-            loopback.return_value = {"access_token": "tok", "refresh_token": None,
-                                     "expires_at": None, "email": "x@y"}
-            portal_auth.resolve_okahu_api_key(method="loopback")
-        loopback.assert_called_once()
-        smart.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Proposed changes
This PR adds browser-based cloud sign-in for Monocle agentic CLI instrumentations. Users no longer need to manually create an account and generate an API key. The entire cloud setup and authentication flow is now handled through a single command, making onboarding simpler.

<img width="1696" height="346" alt="image" src="https://github.com/user-attachments/assets/5dd144e2-6f60-4eec-81eb-bba3bcb2c995" />


## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

None