### PR TITLE
Fix incorrect span subtype in inference and extra output in workflow span

### DIFF
--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/msagent/msagent_processor.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/msagent/msagent_processor.py
@@ -227,7 +227,7 @@ class MSAgentRequestHandler(SpanHandler):
 
     def post_task_processing(self, to_wrap, wrapped, instance, args, kwargs, result, ex, span: Span, parent_span: Span):
         self.hydrate_events(to_wrap, wrapped, instance, args, kwargs,
-                            result, span=parent_span, is_post_exec=True)
+                            result, span=span, is_post_exec=True)
 
 class MSAgentAgentHandler(SpanHandler):
     """Handler for Microsoft Agent Framework agent invocations."""

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/openai/_helper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/openai/_helper.py
@@ -362,12 +362,18 @@ def agent_inference_type(arguments):
     """Extract agent inference type from OpenAI response"""
     message = json.loads(extract_assistant_message(arguments))
     # message["tools"][0]["tool_name"]
-    if message and message.get("tools") and isinstance(message["tools"], list) and len(message["tools"]) > 0:
+    if message:
         agent_prefix = get_value(AGENT_PREFIX_KEY)
-        tool_name = message["tools"][0].get("tool_name", "")
-        if tool_name and agent_prefix and tool_name.startswith(agent_prefix):
-            return INFERENCE_AGENT_DELEGATION
-        return INFERENCE_TOOL_CALL
+        if message.get("tools") and isinstance(message["tools"], list) and len(message["tools"]) > 0:
+            tool_name = message["tools"][0].get("tool_name", "")
+        elif message.get("assistant") and isinstance(message["assistant"], list) and len(message["assistant"]) > 0 and 'tool_name' in message["assistant"][0]:
+            tool_name = message["assistant"][0].get("tool_name", "")
+        else:
+            tool_name = None
+        if tool_name:
+            if agent_prefix and tool_name.startswith(agent_prefix):
+                return INFERENCE_AGENT_DELEGATION
+            return INFERENCE_TOOL_CALL
     return INFERENCE_TURN_END
 
 def _get_first_tool_call(response):


### PR DESCRIPTION

- The tool related output format is different with MS agent SDK in the inference span. This is handled for the inference span output formatting. However, the span subtype checking also looks at the same data and that code is not updated. Hence the inference span subtype was not being correct set. The fix takes care of that
- The ms agent span handler for turn span was incorrectly populating parent span's output section.
 
## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...