### PR TITLE
removed arbitrary time filtering for okahu eval

### DIFF
--- a/test_tools/src/monocle_test_tools/evals/okahu_eval.py
+++ b/test_tools/src/monocle_test_tools/evals/okahu_eval.py
@@ -316,10 +316,6 @@ class OkahuEval(BaseEval):
         workflow_name = span.attributes.get("workflow.name")
         base = os.getenv("OKAHU_EVALUATION_ENDPOINT", OKAHU_PROD_EVALUATION_ENDPOINT).rstrip("/")
         submit_url = f"{base}/v1/eval/jobs"
-        start_span_ns = span.start_time - 24 * 60 * 60 * 1e9  # 24 hours before the first span's start time, in nanoseconds
-        end_span_ns = span.end_time + 24 * 60 * 60 * 1e9  # 24 hours after the first span's end time, in nanoseconds
-        start = datetime.fromtimestamp(start_span_ns / 1e9, timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
-        end = datetime.fromtimestamp(end_span_ns / 1e9, timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ')
 
         fact_ids = self.enumerate_fact_ids(filtered_spans=filtered_spans, fact_name=fact_name)
         if not fact_ids:
@@ -333,8 +329,6 @@ class OkahuEval(BaseEval):
         for fact_id in fact_ids:
             params = {
                 "workflow_name": workflow_name,
-                "start_time": start,
-                "end_time": end,
                 "breakdown_filter": fact_name,
                 "trace_id": fact_id,
                 "fact_name": fact_name,


### PR DESCRIPTION
## Proposed changes

Minor bug fix that will prevent trace filtering by start/end time for okahu evals. This removes the arbitrary time filtering that was there prior. Now evals can run from json without issue 

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

This is a minor change removing an arbitrary (potential) blocker on monocle pytests. 
Additional Test cases may be included in a separate PR