### PR TITLE
Skip litellm inference span if the async flag is true for sync method

### DIFF
--- a/apptrace/src/monocle_apptrace/instrumentation/common/wrapper_method.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/common/wrapper_method.py
@@ -43,6 +43,7 @@ from monocle_apptrace.instrumentation.metamodel.mcp.methods import MCP_METHODS
 from monocle_apptrace.instrumentation.metamodel.mcp.mcp_processor import MCPAgentHandler
 from monocle_apptrace.instrumentation.metamodel.a2a.methods import A2A_CLIENT_METHODS
 from monocle_apptrace.instrumentation.metamodel.litellm.methods import LITELLM_METHODS
+from monocle_apptrace.instrumentation.metamodel.litellm.litellm_span_handler import LiteLLMSyncSpanHandler
 from monocle_apptrace.instrumentation.metamodel.adk.methods import ADK_METHODS
 from monocle_apptrace.instrumentation.metamodel.adk.adk_handler import AdkSpanHandler
 from monocle_apptrace.instrumentation.metamodel.mistral.methods import MISTRAL_METHODS
@@ -170,5 +171,6 @@ MONOCLE_SPAN_HANDLERS: Dict[str, SpanHandler] = {
     "strands_handler": StrandsSpanHandler(),
     "claude_handler": ClaudeSpanHandler(),
     "codex_handler": CodexSpanHandler(),
-    "github_copilot_handler": GitHubCopilotSpanHandler()
+    "github_copilot_handler": GitHubCopilotSpanHandler(),
+    "litellm_sync_handler": LiteLLMSyncSpanHandler()
 }

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/litellm_span_handler.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/litellm_span_handler.py
@@ -1,0 +1,29 @@
+"""
+LiteLLM Async Span Handler for setting async context flags.
+"""
+
+from monocle_apptrace.instrumentation.common.span_handler import SpanHandler
+from opentelemetry.context import attach, get_current, get_value, set_value, Context
+
+class LiteLLMSyncSpanHandler(SpanHandler):
+    """
+    Span handler for LiteLLM sync operations.
+    Skips span creation when LITELLM_ASYNC flag is set to true.
+    """
+
+    def skip_span(self, to_wrap, wrapped, instance, args, kwargs) -> bool:
+        """
+        Skip span creation if LITELLM_ASYNC is set to true in the context.
+        
+        Args:
+            to_wrap: The wrapper configuration
+            wrapped: The wrapped function
+            instance: The instance being wrapped
+            args: Positional arguments
+            kwargs: Keyword arguments
+            
+        Returns:
+            bool: True if the argument acompletion is true, False otherwise
+        """
+        return kwargs.get('acompletion') is True
+

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/methods.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/methods.py
@@ -7,14 +7,16 @@ LITELLM_METHODS = [
         "object": "OpenAIChatCompletion",
         "method": "completion",
         "wrapper_method": task_wrapper,
-        "output_processor": INFERENCE
+        "output_processor": INFERENCE,
+        "span_handler": "litellm_sync_handler"
     },
     {
         "package": "litellm.llms.azure.azure",
         "object": "AzureChatCompletion",
         "method": "completion",
         "wrapper_method": task_wrapper,
-        "output_processor": INFERENCE
+        "output_processor": INFERENCE,
+        "span_handler": "litellm_sync_handler"
     },
     {
         "package": "litellm.llms.openai.openai",


### PR DESCRIPTION
## Proposed changes

In case of Litellm async call, the instrumented sync method gets called first and if that returns a coroutine, then the LiteLLM calls the async method. This results in Monocle generating two spans, with the sync method span getting incomplete events (since the actual underlying method didn't execute at that stage).
The fix is to skip the sync method span if the LiteLLM's async property is set to true.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...