### PR TITLE
Handle propagated parent traces and ensure workflow span closure on child errors

### DIFF
--- a/apptrace/src/monocle_apptrace/instrumentation/common/span_handler.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/common/span_handler.py
@@ -338,6 +338,18 @@ class SpanHandler:
             logger.warning(f"Error finding root span: {e}")
 
     @staticmethod
+    def is_remote_parent_span(curr_span: Span) -> bool:
+        """True when this span's parent lives in another process (W3C context
+        was extracted by *any* layer, not just monocle's extract_http_headers).
+        Used to emit a workflow span for a propagated trace fragment."""
+        try:
+            parent = getattr(curr_span, "parent", None)
+            return parent is not None and getattr(parent, "is_remote", False) is True
+        except Exception as e:
+            logger.warning(f"Error checking remote parent span: {e}")
+            return False
+
+    @staticmethod
     def attach_workflow_type(to_wrap=None, context=None): 
         token = None
         if to_wrap:

--- a/apptrace/src/monocle_apptrace/instrumentation/common/wrapper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/common/wrapper.py
@@ -2,9 +2,7 @@
 import logging
 import os
 from contextlib import contextmanager
-import os
 from typing import AsyncGenerator, Iterator, Optional
-import logging
 from opentelemetry.trace import NonRecordingSpan, Tracer
 from opentelemetry.trace.propagation import set_span_in_context, get_current_span
 from opentelemetry.context import set_value, attach, detach, get_value
@@ -16,7 +14,6 @@ from monocle_apptrace.instrumentation.common.constants import (
     AGENTIC_SPANS,
     SPAN_START_TIME,
     SPAN_END_TIME,
-    WORKFLOW_TYPE_KEY,
 )
 from monocle_apptrace.instrumentation.common.scope_wrapper import monocle_trace_scope
 from monocle_apptrace.instrumentation.common.span_handler import SpanHandler
@@ -28,10 +25,6 @@ from monocle_apptrace.instrumentation.common.utils import (
     set_scope,
     set_scopes,
     with_tracer_wrapper,
-    set_scope,
-    remove_scope,
-    get_current_monocle_span,
-    set_monocle_span_in_context,
 )
 
 logger = logging.getLogger(__name__)
@@ -48,7 +41,7 @@ def get_auto_close_span(to_wrap, kwargs):
 
 def pre_process_span(name, tracer, handler, add_workflow_span, to_wrap, wrapped, instance, args, kwargs, span, source_path):
     SpanHandler.set_default_monocle_attributes(span, source_path)
-    if SpanHandler.is_root_span(span) or add_workflow_span:
+    if SpanHandler.is_root_span(span) or add_workflow_span or SpanHandler.is_remote_parent_span(span):
         # This is a direct API call of a non-framework type
         SpanHandler.set_workflow_properties(span, to_wrap)
     else:
@@ -113,7 +106,7 @@ def monocle_wrapper_span_processor(tracer: Tracer, handler: SpanHandler, to_wrap
     with start_as_monocle_span(tracer, name, auto_close_span) as span:
         pre_process_span(name, tracer, handler, add_workflow_span, to_wrap, wrapped, instance, args, kwargs, span, source_path)
         
-        if SpanHandler.is_root_span(span) or add_workflow_span:
+        if SpanHandler.is_root_span(span) or add_workflow_span or SpanHandler.is_remote_parent_span(span):
             # Recursive call for the actual span
             return_value, span_status = monocle_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, False, args, kwargs)
             span.set_status(StatusCode.OK)
@@ -204,7 +197,7 @@ async def amonocle_wrapper_span_processor(tracer: Tracer, handler: SpanHandler, 
     with start_as_monocle_span(tracer, name, auto_close_span) as span:
         pre_process_span(name, tracer, handler, add_workflow_span, to_wrap, wrapped, instance, args, kwargs, span, source_path)
         
-        if SpanHandler.is_root_span(span) or add_workflow_span:
+        if SpanHandler.is_root_span(span) or add_workflow_span or SpanHandler.is_remote_parent_span(span):
             # Recursive call for the actual span
             return_value, span_status = await amonocle_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, False, args, kwargs)
             span.set_status(StatusCode.OK)
@@ -268,7 +261,7 @@ async def amonocle_iter_wrapper_span_processor(tracer: Tracer, handler: SpanHand
     with start_as_monocle_span(tracer, name, auto_close_span) as span:
         pre_process_span(name, tracer, handler, add_workflow_span, to_wrap, wrapped, instance, args, kwargs, span, source_path)
 
-        if SpanHandler.is_root_span(span) or add_workflow_span:
+        if SpanHandler.is_root_span(span) or add_workflow_span or SpanHandler.is_remote_parent_span(span):
             # Recursive call for the actual span
             async for item in amonocle_iter_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, False, args, kwargs):
                 yield item

--- a/apptrace/src/monocle_apptrace/instrumentation/common/wrapper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/common/wrapper.py
@@ -108,10 +108,18 @@ def monocle_wrapper_span_processor(tracer: Tracer, handler: SpanHandler, to_wrap
         
         if SpanHandler.is_root_span(span) or add_workflow_span or SpanHandler.is_remote_parent_span(span):
             # Recursive call for the actual span
-            return_value, span_status = monocle_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, False, args, kwargs)
-            span.set_status(StatusCode.OK)
-            if not auto_close_span:
-                span.end()
+            try:
+                return_value, span_status = monocle_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, False, args, kwargs)
+                span.set_status(StatusCode.OK)
+            except Exception as e:
+                # Record the failure on the workflow span and re-raise. Without this the
+                # workflow span is never ended/exported when the wrapped call raises and
+                # auto_close_span is False (e.g. streaming/agent inference spans).
+                span.set_status(StatusCode.ERROR, str(e))
+                raise
+            finally:
+                if not auto_close_span:
+                    span.end()
         else:
             ex:Exception = None
             to_wrap = get_wrapper_with_next_processor(to_wrap, handler, instance, span, parent_span, args, kwargs)
@@ -199,10 +207,18 @@ async def amonocle_wrapper_span_processor(tracer: Tracer, handler: SpanHandler, 
         
         if SpanHandler.is_root_span(span) or add_workflow_span or SpanHandler.is_remote_parent_span(span):
             # Recursive call for the actual span
-            return_value, span_status = await amonocle_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, False, args, kwargs)
-            span.set_status(StatusCode.OK)
-            if not auto_close_span:
-                span.end()
+            try:
+                return_value, span_status = await amonocle_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, False, args, kwargs)
+                span.set_status(StatusCode.OK)
+            except Exception as e:
+                # Record the failure on the workflow span and re-raise. Without this the
+                # workflow span is never ended/exported when the wrapped call raises and
+                # auto_close_span is False (e.g. streaming/agent inference spans).
+                span.set_status(StatusCode.ERROR, str(e))
+                raise
+            finally:
+                if not auto_close_span:
+                    span.end()
         else:
             ex:Exception = None
             to_wrap = get_wrapper_with_next_processor(to_wrap, handler, instance, span, parent_span,args, kwargs)
@@ -263,15 +279,23 @@ async def amonocle_iter_wrapper_span_processor(tracer: Tracer, handler: SpanHand
 
         if SpanHandler.is_root_span(span) or add_workflow_span or SpanHandler.is_remote_parent_span(span):
             # Recursive call for the actual span
-            async for item in amonocle_iter_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, False, args, kwargs):
-                yield item
-                # Repair monocle context if inner generators leaked theirs (Python 3.11
-                # defers aclose() to GC for non-exhausted async generators).
-                if get_current_monocle_span() is not span:
-                    attach(set_monocle_span_in_context(span))
-            span.set_status(StatusCode.OK)
-            if not auto_close_span:
-                span.end()
+            try:
+                async for item in amonocle_iter_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, False, args, kwargs):
+                    yield item
+                    # Repair monocle context if inner generators leaked theirs (Python 3.11
+                    # defers aclose() to GC for non-exhausted async generators).
+                    if get_current_monocle_span() is not span:
+                        attach(set_monocle_span_in_context(span))
+                span.set_status(StatusCode.OK)
+            except Exception as e:
+                # Record the failure on the workflow span and re-raise. Without this the
+                # workflow span is never ended/exported when the stream raises and
+                # auto_close_span is False (the common case for streaming inference).
+                span.set_status(StatusCode.ERROR, str(e))
+                raise
+            finally:
+                if not auto_close_span:
+                    span.end()
         else:
             ex:Exception = None
             to_wrap = get_wrapper_with_next_processor(to_wrap, handler, instance, span, parent_span, args, kwargs)

--- a/apptrace/tests/unit/test_wrapper_workflow_span_paths.py
+++ b/apptrace/tests/unit/test_wrapper_workflow_span_paths.py
@@ -1,0 +1,197 @@
+import unittest
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+from opentelemetry.trace.status import StatusCode
+
+from monocle_apptrace.instrumentation.common.span_handler import SpanHandler
+from monocle_apptrace.instrumentation.common import wrapper
+
+
+@contextmanager
+def _noop_workflow_type(*args, **kwargs):
+    yield
+
+
+def _span_context_manager(span):
+    @contextmanager
+    def _cm(*args, **kwargs):
+        yield span
+
+    return _cm()
+
+
+class TestWorkflowSpanPaths(unittest.IsolatedAsyncioTestCase):
+    def _base_to_wrap(self, auto_close=False):
+        return {
+            "package": "pkg",
+            "object": "obj",
+            "method": "method",
+            "output_processor": {
+                "is_auto_close": lambda kwargs: auto_close,
+            },
+        }
+
+    def _common_patches(self):
+        return patch.multiple(
+            "monocle_apptrace.instrumentation.common.wrapper",
+            pre_process_span=MagicMock(),
+            post_process_span=MagicMock(side_effect=lambda *args, **kwargs: args[6]),
+            get_current_monocle_span=MagicMock(return_value=wrapper.INVALID_SPAN),
+        )
+
+    def _span_handler_patches(self, remote_parent_side_effect):
+        return patch.multiple(
+            "monocle_apptrace.instrumentation.common.wrapper.SpanHandler",
+            is_root_span=MagicMock(return_value=False),
+            is_remote_parent_span=MagicMock(side_effect=remote_parent_side_effect),
+            skip_execution=MagicMock(return_value=(False, None)),
+            workflow_type=MagicMock(side_effect=_noop_workflow_type),
+        )
+
+    def test_sync_parent_workflow_span_sets_error_and_ends_on_child_failure(self):
+        workflow_span = MagicMock(name="workflow_span")
+        child_span = MagicMock(name="child_span")
+        spans = iter([workflow_span, child_span])
+        handler = MagicMock()
+
+        def failing_wrapped(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        with (
+            self._common_patches(),
+            self._span_handler_patches(remote_parent_side_effect=[False, False]),
+            patch(
+                "monocle_apptrace.instrumentation.common.wrapper.start_as_monocle_span",
+                side_effect=lambda *args, **kwargs: _span_context_manager(next(spans)),
+            ),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "boom"):
+                wrapper.monocle_wrapper_span_processor(
+                    tracer=MagicMock(),
+                    handler=handler,
+                    to_wrap=self._base_to_wrap(auto_close=False),
+                    wrapped=failing_wrapped,
+                    instance=MagicMock(),
+                    source_path="/tmp/source.py",
+                    add_workflow_span=True,
+                    args=(),
+                    kwargs={},
+                )
+
+        workflow_span.set_status.assert_called_once_with(StatusCode.ERROR, "boom")
+        workflow_span.end.assert_called_once()
+
+    async def test_async_parent_workflow_span_sets_error_and_ends_on_child_failure(self):
+        workflow_span = MagicMock(name="workflow_span")
+        child_span = MagicMock(name="child_span")
+        spans = iter([workflow_span, child_span])
+        handler = MagicMock()
+
+        async def failing_wrapped(*args, **kwargs):
+            raise RuntimeError("boom-async")
+
+        with (
+            self._common_patches(),
+            self._span_handler_patches(remote_parent_side_effect=[False, False]),
+            patch(
+                "monocle_apptrace.instrumentation.common.wrapper.start_as_monocle_span",
+                side_effect=lambda *args, **kwargs: _span_context_manager(next(spans)),
+            ),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "boom-async"):
+                await wrapper.amonocle_wrapper_span_processor(
+                    tracer=MagicMock(),
+                    handler=handler,
+                    to_wrap=self._base_to_wrap(auto_close=False),
+                    wrapped=failing_wrapped,
+                    instance=MagicMock(),
+                    source_path="/tmp/source.py",
+                    add_workflow_span=True,
+                    args=(),
+                    kwargs={},
+                )
+
+        workflow_span.set_status.assert_called_once_with(StatusCode.ERROR, "boom-async")
+        workflow_span.end.assert_called_once()
+
+    async def test_async_iter_parent_workflow_span_sets_error_and_ends_on_child_failure(self):
+        workflow_span = MagicMock(name="workflow_span")
+        child_span = MagicMock(name="child_span")
+        spans = iter([workflow_span, child_span])
+        handler = MagicMock()
+
+        async def failing_stream(*args, **kwargs):
+            raise RuntimeError("boom-stream")
+            yield  # pragma: no cover
+
+        with (
+            self._common_patches(),
+            self._span_handler_patches(remote_parent_side_effect=[False, False]),
+            patch(
+                "monocle_apptrace.instrumentation.common.wrapper.start_as_monocle_span",
+                side_effect=lambda *args, **kwargs: _span_context_manager(next(spans)),
+            ),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "boom-stream"):
+                async for _ in wrapper.amonocle_iter_wrapper_span_processor(
+                    tracer=MagicMock(),
+                    handler=handler,
+                    to_wrap=self._base_to_wrap(auto_close=False),
+                    wrapped=failing_stream,
+                    instance=MagicMock(),
+                    source_path="/tmp/source.py",
+                    add_workflow_span=True,
+                    args=(),
+                    kwargs={},
+                ):
+                    pass
+
+        workflow_span.set_status.assert_called_once_with(StatusCode.ERROR, "boom-stream")
+        workflow_span.end.assert_called_once()
+
+    def test_remote_parent_span_triggers_workflow_recursion_path(self):
+        workflow_span = MagicMock(name="workflow_span")
+        child_span = MagicMock(name="child_span")
+        spans = iter([workflow_span, child_span])
+        handler = MagicMock()
+        wrapped = MagicMock(return_value="ok")
+
+        with (
+            self._common_patches(),
+            self._span_handler_patches(remote_parent_side_effect=[True, False]),
+            patch(
+                "monocle_apptrace.instrumentation.common.wrapper.start_as_monocle_span",
+                side_effect=lambda *args, **kwargs: _span_context_manager(next(spans)),
+            ),
+        ):
+            result, _status = wrapper.monocle_wrapper_span_processor(
+                tracer=MagicMock(),
+                handler=handler,
+                to_wrap=self._base_to_wrap(auto_close=True),
+                wrapped=wrapped,
+                instance=MagicMock(),
+                source_path="/tmp/source.py",
+                add_workflow_span=False,
+                args=(),
+                kwargs={},
+            )
+
+        self.assertEqual(result, "ok")
+        wrapped.assert_called_once()
+        workflow_span.set_status.assert_called_once_with(StatusCode.OK)
+
+    def test_is_remote_parent_span_true_when_parent_is_remote(self):
+        span = MagicMock()
+        span.parent = MagicMock(is_remote=True)
+        self.assertTrue(SpanHandler.is_remote_parent_span(span))
+
+    def test_is_remote_parent_span_false_when_parent_missing_or_not_remote(self):
+        no_parent_span = MagicMock()
+        no_parent_span.parent = None
+
+        local_parent_span = MagicMock()
+        local_parent_span.parent = MagicMock(is_remote=False)
+
+        self.assertFalse(SpanHandler.is_remote_parent_span(no_parent_span))
+        self.assertFalse(SpanHandler.is_remote_parent_span(local_parent_span))


### PR DESCRIPTION
## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

This PR improves workflow span behavior in two important cases:

Treat spans with a remote parent as workflow-entry spans.
Ensure workflow spans are marked as failed and properly ended when child processing raises exceptions.

Previously:

Propagated traces (with remote parents) could miss workflow-level handling.
If child execution failed, workflow spans could remain unended in manual-close paths, causing incomplete export/visibility.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...