### PR TITLE
feat: add token-summary CLI command for local trace files

### DIFF
--- a/apptrace/src/README.md
+++ b/apptrace/src/README.md
@@ -12,6 +12,38 @@ Spans are the individual steps executed by the application to perform a GenAI re
 
 Examples of spans include app retrieving vectors from DB, app querying LLM for inference etc. The span includes the type of operation, start time, duration and metadata relevant to that step eg Model name, parameters and model endpoint/server for an inference request.
 
+## Token Usage Summary
+
+The `token-summary` command reads local Monocle trace files and prints a daily summary of token usage per model.
+
+```bash
+# Summarize all trace files in the default location (~/.monocle)
+monocle-apptrace token-summary
+
+# Filter by time window
+monocle-apptrace token-summary today
+monocle-apptrace token-summary "this week"
+monocle-apptrace token-summary "7 days"
+monocle-apptrace token-summary "15 days"
+
+# Use traces from a specific project directory (reads <dir>/.monocle/)
+monocle-apptrace token-summary --dir /path/to/project
+
+# Use a specific trace directory directly
+monocle-apptrace token-summary --trace-dir /path/to/.monocle
+```
+
+Example output:
+
+```
++-----------+---------------------+-------+------------+--------------+--------+-------+
+| Date      | Model               | Input | Cache Read | Cache Create | Output | Total |
++-----------+---------------------+-------+------------+--------------+--------+-------+
+| 2025-11-30| claude-3-5-sonnet   | 1200  | 400        | 0            | 350    | 1950  |
+| 2025-11-30| gpt-4o              | 800   | 0          | 0            | 200    | 1000  |
++-----------+---------------------+-------+------------+--------------+--------+-------+
+```
+
 ## Contribute to Monocle 
 
 Monocle includes:

--- a/apptrace/src/monocle_apptrace/cli.py
+++ b/apptrace/src/monocle_apptrace/cli.py
@@ -426,7 +426,16 @@ def cmd_validate(args):
 
 def cmd_token_summary(args):
     from monocle_apptrace.token_summary import format_table, summarize
-    rows = summarize(time_window=args.time_window)
+    from pathlib import Path
+
+    if args.trace_dir_direct:
+        monocle_dir = Path(args.trace_dir_direct)
+    elif args.trace_dir:
+        monocle_dir = Path(args.trace_dir) / ".monocle"
+    else:
+        monocle_dir = None  # uses default ~/.monocle
+
+    rows = summarize(time_window=args.time_window, monocle_dir=monocle_dir)
     print(format_table(rows))
     return 0
 
@@ -593,6 +602,20 @@ def _build_parser():
         default="all",
         metavar="TIME_WINDOW",
         help="today | 'this week' | '7 days' | '15 days' | all  (default: all)",
+    )
+    ts.add_argument(
+        "--dir",
+        dest="trace_dir",
+        default=None,
+        metavar="DIR",
+        help="Project directory containing .monocle/ folder (default: current dir)",
+    )
+    ts.add_argument(
+        "--trace-dir",
+        dest="trace_dir_direct",
+        default=None,
+        metavar="TRACE_DIR",
+        help="Direct path to trace directory (overrides --dir)",
     )
 
     return parser

--- a/apptrace/src/monocle_apptrace/cli.py
+++ b/apptrace/src/monocle_apptrace/cli.py
@@ -424,6 +424,13 @@ def cmd_validate(args):
 # =============================================================================
 
 
+def cmd_token_summary(args):
+    from monocle_apptrace.token_summary import format_table, summarize
+    rows = summarize(time_window=args.time_window)
+    print(format_table(rows))
+    return 0
+
+
 def cmd_reset(args):
     ui.header("Monocle reset")
 
@@ -531,6 +538,8 @@ def main(argv=None):
         return cmd_validate(args)
     if args.command == "reset":
         return cmd_reset(args)
+    if args.command == "token-summary":
+        return cmd_token_summary(args)
     return 1
 
 
@@ -573,6 +582,18 @@ def _build_parser():
                    default="selective", help="Validation level (default: selective)")
     v.add_argument("--fail-on-warning", action="store_true",
                    help="Treat warnings as errors (exit code 1)")
+
+    ts = sub.add_parser(
+        "token-summary",
+        help="Show daily token usage from local .monocle/ trace files",
+    )
+    ts.add_argument(
+        "time_window",
+        nargs="?",
+        default="all",
+        metavar="TIME_WINDOW",
+        help="today | 'this week' | '7 days' | '15 days' | all  (default: all)",
+    )
 
     return parser
 

--- a/apptrace/src/monocle_apptrace/token_summary.py
+++ b/apptrace/src/monocle_apptrace/token_summary.py
@@ -1,0 +1,167 @@
+"""Token usage summary from local Monocle trace files.
+
+Reads .monocle/monocle_trace_*.json files and aggregates token counts
+per date and model, displayed as a table in the terminal.
+"""
+
+import json
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+from typing import List, Dict
+
+MONOCLE_DIR = Path.home() / ".monocle"
+
+# Token attribute keys extracted from the "metadata" event
+_TOKEN_KEYS = [
+    "prompt_tokens",
+    "cache_read_input_tokens",
+    "cache_creation_input_tokens",
+    "completion_tokens",
+    "total_tokens",
+]
+
+# Column header labels (same order as _TOKEN_KEYS)
+_HEADERS = ["Date", "Model", "Input", "Cache Read", "Cache Create", "Output", "Total"]
+
+
+def _parse_timestamp_from_filename(name):
+    # type: (str) -> Optional[datetime]
+    """Extract a UTC datetime from a filename ending like _2025-11-30_19.47.49.json"""
+    # strip extension
+    if name.endswith(".json"):
+        stem = name[:-5]
+    else:
+        stem = name
+    # last two underscore segments are the date and time parts
+    parts = stem.rsplit("_", 2)
+    if len(parts) < 3:
+        return None
+    try:
+        return datetime.strptime(
+            "{}_{}".format(parts[-2], parts[-1]), "%Y-%m-%d_%H.%M.%S"
+        ).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def _window_cutoff(time_window):
+    # type: (str) -> Optional[datetime]
+    """Return the earliest datetime to include, or None for 'all'."""
+    now = datetime.now(tz=timezone.utc)
+    w = time_window.lower().strip()
+    if w == "today":
+        return now.replace(hour=0, minute=0, second=0, microsecond=0)
+    if w == "this week":
+        return (now - timedelta(days=now.weekday())).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+    if "days" in w:
+        try:
+            n = int(w.split()[0])
+            return now - timedelta(days=n)
+        except (ValueError, IndexError):
+            pass
+    return None  # "all" or unrecognised → no cutoff
+
+
+def _load_spans(path):
+    # type: (Path) -> List[Dict]
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, list) else []
+    except Exception:
+        return []
+
+
+def summarize(time_window="all", monocle_dir=None):
+    # type: (str, Optional[Path]) -> List[Dict]
+    """Aggregate token usage from trace files in *monocle_dir*.
+
+    Returns a list of row dicts sorted by date then model, each with keys:
+    date, model, prompt_tokens, cache_read_input_tokens,
+    cache_creation_input_tokens, completion_tokens, total_tokens.
+    """
+    if monocle_dir is None:
+        monocle_dir = MONOCLE_DIR
+
+    cutoff = _window_cutoff(time_window)
+
+    # aggregated[date_str][model][token_key] = cumulative int
+    aggregated = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
+
+    if not monocle_dir.exists():
+        return []
+
+    for trace_file in sorted(monocle_dir.glob("monocle_trace_*.json")):
+        ts = _parse_timestamp_from_filename(trace_file.name)
+        if ts is None:
+            continue
+        if cutoff is not None and ts < cutoff:
+            continue
+
+        date_str = ts.strftime("%Y-%m-%d")
+
+        for span in _load_spans(trace_file):
+            model = span.get("attributes", {}).get("entity.2.name")
+            if not model:
+                continue
+
+            for event in span.get("events", []):
+                if event.get("name") != "metadata":
+                    continue
+                attrs = event.get("attributes", {})
+                for key in _TOKEN_KEYS:
+                    val = attrs.get(key, 0)
+                    if isinstance(val, (int, float)):
+                        aggregated[date_str][model][key] += int(val)
+
+    rows = []
+    for date_str in sorted(aggregated.keys()):
+        for model in sorted(aggregated[date_str].keys()):
+            tokens = aggregated[date_str][model]
+            rows.append(
+                {
+                    "date": date_str,
+                    "model": model,
+                    "prompt_tokens": tokens["prompt_tokens"],
+                    "cache_read_input_tokens": tokens["cache_read_input_tokens"],
+                    "cache_creation_input_tokens": tokens["cache_creation_input_tokens"],
+                    "completion_tokens": tokens["completion_tokens"],
+                    "total_tokens": tokens["total_tokens"],
+                }
+            )
+    return rows
+
+
+def format_table(rows):
+    # type: (List[Dict]) -> str
+    """Render *rows* as a plain-text ASCII table."""
+    if not rows:
+        return "No trace files found for the given time window."
+
+    col_keys = [
+        "date",
+        "model",
+        "prompt_tokens",
+        "cache_read_input_tokens",
+        "cache_creation_input_tokens",
+        "completion_tokens",
+        "total_tokens",
+    ]
+
+    # compute column widths from headers and data
+    widths = [len(h) for h in _HEADERS]
+    for row in rows:
+        for i, key in enumerate(col_keys):
+            widths[i] = max(widths[i], len(str(row[key])))
+
+    sep = "+-" + "-+-".join("-" * w for w in widths) + "-+"
+    fmt = "| " + " | ".join("{{:<{}}}".format(w) for w in widths) + " |"
+
+    lines = [sep, fmt.format(*_HEADERS), sep]
+    for row in rows:
+        lines.append(fmt.format(*[str(row[k]) for k in col_keys]))
+    lines.append(sep)
+    return "\n".join(lines)

--- a/apptrace/tests/unit/test_token_summary.py
+++ b/apptrace/tests/unit/test_token_summary.py
@@ -1,0 +1,236 @@
+"""Unit tests for monocle_apptrace.token_summary"""
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from monocle_apptrace.token_summary import format_table, summarize
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _span(model, prompt, completion, total, cache_read=0, cache_create=0):
+    """Build a minimal span dict with a metadata event."""
+    return {
+        "attributes": {"entity.2.name": model},
+        "events": [
+            {"name": "data.input", "attributes": {}},
+            {"name": "data.output", "attributes": {}},
+            {
+                "name": "metadata",
+                "attributes": {
+                    "prompt_tokens": prompt,
+                    "completion_tokens": completion,
+                    "total_tokens": total,
+                    "cache_read_input_tokens": cache_read,
+                    "cache_creation_input_tokens": cache_create,
+                },
+            },
+        ],
+    }
+
+
+def _write_trace(directory, timestamp, spans):
+    """Write a trace JSON file. timestamp e.g. '2025-11-30_19.47.49'"""
+    fname = "monocle_trace_test_workflow_{}.json".format(timestamp)
+    (Path(directory) / fname).write_text(json.dumps(spans), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Tests: summarize()
+# ---------------------------------------------------------------------------
+
+class TestSummarize(unittest.TestCase):
+
+    def test_missing_directory_returns_empty(self):
+        rows = summarize("all", monocle_dir=Path("/tmp/nonexistent_monocle_xyz"))
+        self.assertEqual(rows, [])
+
+    def test_empty_directory_returns_empty(self):
+        with TemporaryDirectory() as tmp:
+            rows = summarize("all", monocle_dir=Path(tmp))
+            self.assertEqual(rows, [])
+
+    def test_single_span_single_model(self):
+        with TemporaryDirectory() as tmp:
+            _write_trace(tmp, "2025-11-30_10.00.00", [_span("gpt-4o", 100, 50, 150)])
+            rows = summarize("all", monocle_dir=Path(tmp))
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["model"], "gpt-4o")
+            self.assertEqual(rows[0]["prompt_tokens"], 100)
+            self.assertEqual(rows[0]["completion_tokens"], 50)
+            self.assertEqual(rows[0]["total_tokens"], 150)
+
+    def test_multiple_spans_same_model_aggregated(self):
+        with TemporaryDirectory() as tmp:
+            _write_trace(tmp, "2025-11-30_10.00.00", [
+                _span("gpt-4o", 100, 50, 150),
+                _span("gpt-4o", 200, 80, 280),
+            ])
+            rows = summarize("all", monocle_dir=Path(tmp))
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["prompt_tokens"], 300)
+            self.assertEqual(rows[0]["completion_tokens"], 130)
+            self.assertEqual(rows[0]["total_tokens"], 430)
+
+    def test_multiple_models_same_day(self):
+        with TemporaryDirectory() as tmp:
+            _write_trace(tmp, "2025-11-30_10.00.00", [
+                _span("gpt-4o", 100, 50, 150),
+                _span("claude-3-5-sonnet", 200, 80, 280),
+            ])
+            rows = summarize("all", monocle_dir=Path(tmp))
+            self.assertEqual(len(rows), 2)
+            models = {r["model"] for r in rows}
+            self.assertIn("gpt-4o", models)
+            self.assertIn("claude-3-5-sonnet", models)
+
+    def test_multiple_files_different_days(self):
+        with TemporaryDirectory() as tmp:
+            _write_trace(tmp, "2025-11-29_10.00.00", [_span("gpt-4o", 100, 50, 150)])
+            _write_trace(tmp, "2025-11-30_10.00.00", [_span("gpt-4o", 200, 80, 280)])
+            rows = summarize("all", monocle_dir=Path(tmp))
+            self.assertEqual(len(rows), 2)
+            dates = [r["date"] for r in rows]
+            self.assertIn("2025-11-29", dates)
+            self.assertIn("2025-11-30", dates)
+
+    def test_cache_tokens_extracted(self):
+        with TemporaryDirectory() as tmp:
+            _write_trace(tmp, "2025-11-30_10.00.00", [
+                _span("claude-3-5-sonnet", 100, 50, 150, cache_read=40, cache_create=10)
+            ])
+            rows = summarize("all", monocle_dir=Path(tmp))
+            self.assertEqual(rows[0]["cache_read_input_tokens"], 40)
+            self.assertEqual(rows[0]["cache_creation_input_tokens"], 10)
+
+    def test_span_without_model_skipped(self):
+        with TemporaryDirectory() as tmp:
+            span_no_model = {"attributes": {}, "events": [
+                {"name": "metadata", "attributes": {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150}}
+            ]}
+            _write_trace(tmp, "2025-11-30_10.00.00", [span_no_model])
+            rows = summarize("all", monocle_dir=Path(tmp))
+            self.assertEqual(rows, [])
+
+    def test_span_without_metadata_event_skipped(self):
+        with TemporaryDirectory() as tmp:
+            span_no_meta = {
+                "attributes": {"entity.2.name": "gpt-4o"},
+                "events": [
+                    {"name": "data.input", "attributes": {"input": "hello"}},
+                ],
+            }
+            _write_trace(tmp, "2025-11-30_10.00.00", [span_no_meta])
+            rows = summarize("all", monocle_dir=Path(tmp))
+            self.assertEqual(rows, [])
+
+    def test_malformed_json_file_skipped(self):
+        with TemporaryDirectory() as tmp:
+            bad = Path(tmp) / "monocle_trace_bad_2025-11-30_10.00.00.json"
+            bad.write_text("NOT JSON", encoding="utf-8")
+            rows = summarize("all", monocle_dir=Path(tmp))
+            self.assertEqual(rows, [])
+
+    def test_file_with_unparseable_timestamp_skipped(self):
+        with TemporaryDirectory() as tmp:
+            # name doesn't match expected timestamp pattern
+            (Path(tmp) / "monocle_trace_nodate.json").write_text(
+                json.dumps([_span("gpt-4o", 10, 5, 15)]), encoding="utf-8"
+            )
+            rows = summarize("all", monocle_dir=Path(tmp))
+            self.assertEqual(rows, [])
+
+
+# ---------------------------------------------------------------------------
+# Tests: time window filtering
+# ---------------------------------------------------------------------------
+
+class TestTimeWindowFiltering(unittest.TestCase):
+
+    def test_today_excludes_old_files(self):
+        with TemporaryDirectory() as tmp:
+            _write_trace(tmp, "2020-01-01_10.00.00", [_span("gpt-4o", 100, 50, 150)])
+            rows = summarize("today", monocle_dir=Path(tmp))
+            self.assertEqual(rows, [])
+
+    def test_7_days_excludes_old_files(self):
+        with TemporaryDirectory() as tmp:
+            _write_trace(tmp, "2020-01-01_10.00.00", [_span("gpt-4o", 100, 50, 150)])
+            rows = summarize("7 days", monocle_dir=Path(tmp))
+            self.assertEqual(rows, [])
+
+    def test_15_days_excludes_old_files(self):
+        with TemporaryDirectory() as tmp:
+            _write_trace(tmp, "2020-01-01_10.00.00", [_span("gpt-4o", 100, 50, 150)])
+            rows = summarize("15 days", monocle_dir=Path(tmp))
+            self.assertEqual(rows, [])
+
+    def test_all_includes_old_files(self):
+        with TemporaryDirectory() as tmp:
+            _write_trace(tmp, "2020-01-01_10.00.00", [_span("gpt-4o", 100, 50, 150)])
+            rows = summarize("all", monocle_dir=Path(tmp))
+            self.assertEqual(len(rows), 1)
+
+    def test_unknown_window_treated_as_all(self):
+        with TemporaryDirectory() as tmp:
+            _write_trace(tmp, "2020-01-01_10.00.00", [_span("gpt-4o", 100, 50, 150)])
+            rows = summarize("last quarter", monocle_dir=Path(tmp))
+            self.assertEqual(len(rows), 1)
+
+
+# ---------------------------------------------------------------------------
+# Tests: format_table()
+# ---------------------------------------------------------------------------
+
+class TestFormatTable(unittest.TestCase):
+
+    def test_empty_rows_message(self):
+        out = format_table([])
+        self.assertIn("No trace files found", out)
+
+    def test_headers_present(self):
+        rows = [_row()]
+        out = format_table(rows)
+        for header in ["Date", "Model", "Input", "Cache Read", "Cache Create", "Output", "Total"]:
+            self.assertIn(header, out)
+
+    def test_data_present(self):
+        rows = [_row()]
+        out = format_table(rows)
+        self.assertIn("2025-11-30", out)
+        self.assertIn("gpt-4o", out)
+        self.assertIn("100", out)
+
+    def test_multiple_rows(self):
+        rows = [_row("2025-11-29", "gpt-4o"), _row("2025-11-30", "claude-3-5-sonnet")]
+        out = format_table(rows)
+        self.assertIn("gpt-4o", out)
+        self.assertIn("claude-3-5-sonnet", out)
+        self.assertIn("2025-11-29", out)
+        self.assertIn("2025-11-30", out)
+
+    def test_table_borders_present(self):
+        out = format_table([_row()])
+        self.assertIn("+", out)
+        self.assertIn("|", out)
+        self.assertIn("-", out)
+
+
+def _row(date="2025-11-30", model="gpt-4o"):
+    return {
+        "date": date,
+        "model": model,
+        "prompt_tokens": 100,
+        "cache_read_input_tokens": 0,
+        "cache_creation_input_tokens": 0,
+        "completion_tokens": 50,
+        "total_tokens": 150,
+    }
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Proposed changes

Adds a new `token-summary` CLI command that reads local Monocle trace files and aggregates token usage by date and model.

The implementation introduces a new `token_summary.py` module for parsing trace files, extracting token metrics from metadata events, filtering results by time window, and formatting output as a terminal table. The command is wired into the existing CLI and includes comprehensive unit tests covering aggregation, filtering, malformed inputs, and output formatting.

Closes #616.

## Types of changes

* [ ] Bugfix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation Update (if none of the other choices apply)

## Checklist

* [x] I have read the CONTRIBUTING doc
* [x] I have signed the CLA
* [x] Lint and unit tests pass locally with my changes
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added the necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The feature aggregates token metrics from `.monocle/monocle_trace_*.json` files and supports multiple time windows (`today`, `this week`, `N days`, and `all`). Results are grouped by date and model and displayed in a simple ASCII table for terminal use.

Testing was added for aggregation behavior, time-window filtering, malformed trace files, cache token handling, and table formatting. All tests pass locally (21/21 passing).
