### PR TITLE
Capture FastAPI POST bodies in HTTP spans

### DIFF
--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/fastapi/_helper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/fastapi/_helper.py
@@ -68,12 +68,11 @@ def get_method(scope) -> str:
 
 def get_params(args) -> dict:
     try:
-        query_bytes = args.get("query_string", "")
-        query_str = query_bytes.decode('utf-8')
-        params = urllib.parse.parse_qs(query_str)
-        question = params.get('question', [''])[0]
-        if question:
-            return question
+        query_bytes = args.get("query_string", b"")
+        query_str = query_bytes.decode('utf-8') if isinstance(query_bytes, bytes) else str(query_bytes)
+        if query_str:
+            return urllib.parse.unquote(query_str)
+        return ""
 
     except Exception as e:
         logger.warning(f"Error extracting params: {e}")

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/fastapi/_helper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/fastapi/_helper.py
@@ -1,5 +1,7 @@
 import logging
+from collections import deque
 from threading import local
+
 from monocle_apptrace.instrumentation.common.utils import extract_http_headers, clear_http_scopes, get_exception_status_code, with_tracer_wrapper
 from monocle_apptrace.instrumentation.common.wrapper import amonocle_wrapper
 from monocle_apptrace.instrumentation.common.span_handler import SpanHandler, HttpSpanHandler
@@ -12,6 +14,31 @@ import urllib.parse
 logger = logging.getLogger(__name__)
 MAX_DATA_LENGTH = 1000
 
+
+async def _buffer_request_body(scope, receive):
+    messages = []
+    body_chunks = []
+
+    while True:
+        message = await receive()
+        messages.append(message)
+        if message.get("type") != "http.request":
+            break
+
+        body_chunks.append(message.get("body", b""))
+        if not message.get("more_body", False):
+            break
+
+    scope["_request_body"] = b"".join(body_chunks)
+    replay_messages = deque(messages)
+
+    async def _receive():
+        if replay_messages:
+            return replay_messages.popleft()
+        return await receive()
+
+    return _receive
+
 @with_tracer_wrapper
 async def fastapi_atask_wrapper(tracer, handler, to_wrap, wrapped, instance,
                                source_path, args, kwargs):
@@ -19,15 +46,7 @@ async def fastapi_atask_wrapper(tracer, handler, to_wrap, wrapped, instance,
     similar to how Werkzeug stores request data in environ['werkzeug.request']."""
     scope, receive = args[0], args[1]
     if scope.get('method', 'GET') in ('POST', 'PUT', 'PATCH'):
-        chunks, orig = [], receive
-        async def _receive():
-            msg = await orig()
-            if msg.get('type') == 'http.request':
-                chunks.append(msg.get('body', b''))
-                if not msg.get('more_body', False):
-                    scope['_request_body'] = b''.join(chunks)
-            return msg
-        args = (scope, _receive) + args[2:]
+        args = (scope, await _buffer_request_body(scope, receive)) + args[2:]
     return await amonocle_wrapper(
         tracer, handler, to_wrap, wrapped, instance, source_path, args, kwargs
     )
@@ -40,6 +59,9 @@ def get_url(args) -> str:
     return f"{scheme}://{host}:{port}{path}"
 
 def get_route(scope) -> str:
+    route = scope.get('route')
+    if route is not None and getattr(route, 'path', None):
+        return route.path
     return scope.get('path', '')
 
 def get_method(scope) -> str:

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/fastapi/_helper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/fastapi/_helper.py
@@ -1,6 +1,5 @@
 import logging
 from collections import deque
-from threading import local
 
 from monocle_apptrace.instrumentation.common.utils import extract_http_headers, clear_http_scopes, get_exception_status_code, with_tracer_wrapper
 from monocle_apptrace.instrumentation.common.wrapper import amonocle_wrapper

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/fastapi/_helper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/fastapi/_helper.py
@@ -74,13 +74,20 @@ def get_params(args) -> dict:
         question = params.get('question', [''])[0]
         if question:
             return question
-        body = args.get('_request_body', b'')
-        if body:
-            return (body.decode('utf-8') if isinstance(body, bytes) else str(body))[:MAX_DATA_LENGTH]
 
     except Exception as e:
         logger.warning(f"Error extracting params: {e}")
         return {}
+
+def get_body(args) -> str:
+    try:
+        body = args.get('_request_body', b'')
+        if body:
+            return (body.decode('utf-8') if isinstance(body, bytes) else str(body))[:MAX_DATA_LENGTH]
+        return ""
+    except Exception as e:
+        logger.warning(f"Error extracting body: {e}")
+        return ""
 
 def extract_response(response) -> str:
     try:

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/fastapi/entities/http.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/fastapi/entities/http.py
@@ -30,6 +30,10 @@ FASTAPI_RESPONSE_PROCESSOR = {
                 {
                     "attribute": "params",
                     "accessor": lambda arguments: _helper.get_params(arguments['args'][0])
+                },
+                {
+                    "attribute": "request_body",
+                    "accessor": lambda arguments: _helper.get_body(arguments['args'][0])
                 }
             ]
         },

--- a/apptrace/tests/unit/test_fastapi_helper.py
+++ b/apptrace/tests/unit/test_fastapi_helper.py
@@ -1,6 +1,7 @@
 import pytest
 
 from monocle_apptrace.instrumentation.metamodel.fastapi import _helper
+from monocle_apptrace.instrumentation.metamodel.fastapi.entities.http import FASTAPI_HTTP_PROCESSOR, FASTAPI_RESPONSE_PROCESSOR
 
 
 @pytest.mark.asyncio
@@ -42,13 +43,48 @@ def test_get_body_reads_buffered_request_body():
     assert _helper.get_body(scope) == '{"question":"hello"}'
 
 
-def test_get_params_reads_question_query_param():
+def test_get_params_reads_query_string():
     scope = {"query_string": b"question=hello", "_request_body": b'{"question":"body"}'}
 
-    assert _helper.get_params(scope) == "hello"
+    assert _helper.get_params(scope) == "question=hello"
 
 
 def test_get_params_does_not_read_buffered_request_body():
     scope = {"query_string": b"", "_request_body": b'{"question":"hello"}'}
 
-    assert _helper.get_params(scope) is None
+    assert _helper.get_params(scope) == ""
+
+
+def test_post_processors_capture_http_attributes_params_and_body():
+    route = type("Route", (), {"path": "/api/v1/test"})()
+    scope = {
+        "method": "POST",
+        "route": route,
+        "path": "/api/v1/test",
+        "scheme": "http",
+        "server": ("0.0.0.0", 8000),
+        "query_string": b"param1=value1",
+        "_request_body": b'{"hello": "123"}',
+    }
+    arguments = {"args": (scope,)}
+
+    http_attributes = {
+        attribute["attribute"]: attribute["accessor"](arguments)
+        for attribute in FASTAPI_HTTP_PROCESSOR["attributes"][0]
+    }
+    input_attributes = {
+        attribute["attribute"]: attribute["accessor"](arguments)
+        for event in FASTAPI_RESPONSE_PROCESSOR["events"]
+        if event["name"] == "data.input"
+        for attribute in event["attributes"]
+    }
+
+    assert http_attributes == {
+        "method": "POST",
+        "route": "/api/v1/test",
+        "url": "http://0.0.0.0:8000/api/v1/test",
+    }
+    assert input_attributes == {
+        "params": "param1=value1",
+        "request_body": '{"hello": "123"}',
+    }

--- a/apptrace/tests/unit/test_fastapi_helper.py
+++ b/apptrace/tests/unit/test_fastapi_helper.py
@@ -36,7 +36,19 @@ def test_get_route_prefers_fastapi_route_template():
     assert _helper.get_route(scope) == "/api/v1/items/{item_id}"
 
 
-def test_get_params_reads_buffered_request_body():
+def test_get_body_reads_buffered_request_body():
     scope = {"query_string": b"", "_request_body": b'{"question":"hello"}'}
 
-    assert _helper.get_params(scope) == '{"question":"hello"}'
+    assert _helper.get_body(scope) == '{"question":"hello"}'
+
+
+def test_get_params_reads_question_query_param():
+    scope = {"query_string": b"question=hello", "_request_body": b'{"question":"body"}'}
+
+    assert _helper.get_params(scope) == "hello"
+
+
+def test_get_params_does_not_read_buffered_request_body():
+    scope = {"query_string": b"", "_request_body": b'{"question":"hello"}'}
+
+    assert _helper.get_params(scope) is None

--- a/apptrace/tests/unit/test_fastapi_helper.py
+++ b/apptrace/tests/unit/test_fastapi_helper.py
@@ -30,10 +30,10 @@ async def test_buffer_request_body_replays_messages_and_stores_body():
 
 
 def test_get_route_prefers_fastapi_route_template():
-    route = type("Route", (), {"path": "/api/v1/ask_agent"})()
-    scope = {"route": route, "path": "/api/v1/ask_agent"}
+    route = type("Route", (), {"path": "/api/v1/items/{item_id}"})()
+    scope = {"route": route, "path": "/api/v1/items/123"}
 
-    assert _helper.get_route(scope) == "/api/v1/ask_agent"
+    assert _helper.get_route(scope) == "/api/v1/items/{item_id}"
 
 
 def test_get_params_reads_buffered_request_body():

--- a/apptrace/tests/unit/test_fastapi_helper.py
+++ b/apptrace/tests/unit/test_fastapi_helper.py
@@ -1,0 +1,42 @@
+import pytest
+
+from monocle_apptrace.instrumentation.metamodel.fastapi import _helper
+
+
+@pytest.mark.asyncio
+async def test_buffer_request_body_replays_messages_and_stores_body():
+    messages = [
+        {"type": "http.request", "body": b'{"question":', "more_body": True},
+        {"type": "http.request", "body": b'"hello"}', "more_body": False},
+    ]
+
+    async def receive():
+        return messages.pop(0)
+
+    scope = {}
+    replay_receive = await _helper._buffer_request_body(scope, receive)
+
+    assert scope["_request_body"] == b'{"question":"hello"}'
+    assert await replay_receive() == {
+        "type": "http.request",
+        "body": b'{"question":',
+        "more_body": True,
+    }
+    assert await replay_receive() == {
+        "type": "http.request",
+        "body": b'"hello"}',
+        "more_body": False,
+    }
+
+
+def test_get_route_prefers_fastapi_route_template():
+    route = type("Route", (), {"path": "/api/v1/ask_agent"})()
+    scope = {"route": route, "path": "/api/v1/ask_agent"}
+
+    assert _helper.get_route(scope) == "/api/v1/ask_agent"
+
+
+def test_get_params_reads_buffered_request_body():
+    scope = {"query_string": b"", "_request_body": b'{"question":"hello"}'}
+
+    assert _helper.get_params(scope) == '{"question":"hello"}'


### PR DESCRIPTION
## Summary

- Capture FastAPI POST/PUT/PATCH request bodies before route handling and replay the ASGI request messages unchanged.
- Prefer FastAPI route templates when available for HTTP process span route attributes.
- Add focused unit coverage for request-body buffering, replay, route capture, and buffered body extraction.

Fixes #631.

## Validation

- `python -m pytest tests/unit/test_fastapi_helper.py -q`
