### PR TITLE
Add astream/astream_events streaming support and fix span data for LangGraph

### DIFF
--- a/apptrace/src/monocle_apptrace/instrumentation/common/utils.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/common/utils.py
@@ -455,6 +455,16 @@ def get_json_dumps(obj) -> str:
     except TypeError as e:
         return str(obj)
 
+def extract_content_text(content) -> str:
+    """Extract plain text from a message content field.
+    Handles both plain strings and OpenAI-style content block lists
+    ([{'type': 'text', 'text': '...'}]).
+    """
+    if isinstance(content, list):
+        texts = [b.get('text', '') for b in content if isinstance(b, dict) and b.get('type') == 'text']
+        return ' '.join(texts)
+    return str(content)
+
 class Option(Generic[T]):
     def __init__(self, value: Optional[T]):
         self.value = value

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/_helper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/_helper.py
@@ -174,7 +174,9 @@ def get_tool_description(instance) -> str:
     """Get the description of the tool."""
     return get_description(instance)
 
-def extract_thread_id(kwargs) -> str:
+def extract_thread_id(args, kwargs) -> str:
+    if 'config' not in kwargs and len(args) > 1:
+        kwargs = {**kwargs, 'config': args[1]}
     thread_id = None
     if 'config' in kwargs and 'configurable' in kwargs['config']:
         thread_id = kwargs['config']['configurable'].get('thread_id')

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/_helper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/_helper.py
@@ -1,5 +1,5 @@
 from opentelemetry.context import get_value
-from monocle_apptrace.instrumentation.common.utils import resolve_from_alias, get_json_dumps
+from monocle_apptrace.instrumentation.common.utils import resolve_from_alias, get_json_dumps, extract_content_text
 from monocle_apptrace.instrumentation.common.constants import AGENT_NAME_KEY, LAST_AGENT_INVOCATION_ID, LAST_AGENT_NAME
 import logging
 logger = logging.getLogger(__name__)
@@ -10,9 +10,20 @@ LANGGRAPTH_AGENT_NAME_KEY = "agent.langgraph"
 
 def extract_agent_response(response):
     try:
-        if response is not None and 'messages' in response:
-            output = response["messages"][-1]
-            return str(output.content)
+        if response is None:
+            return ""
+        # astream emits a checkpoint tuple ((), 'debug', {payload}) as its final item
+        if isinstance(response, tuple) and len(response) >= 3 and isinstance(response[2], dict):
+            values = response[2].get('payload', {}).get('values', {})
+            if 'messages' in values and values['messages']:
+                return extract_content_text(values['messages'][-1].content)
+            return ""
+        if isinstance(response, dict) and 'messages' in response:
+            return extract_content_text(response['messages'][-1].content)
+        if isinstance(response, dict):
+            for value in response.values():
+                if isinstance(value, dict) and 'messages' in value and value['messages']:
+                    return extract_content_text(value['messages'][-1].content)
     except Exception as e:
         logger.warning("Warning: Error occurred in handle_response: %s", str(e))
     return ""
@@ -39,12 +50,16 @@ def extract_agent_input(arguments):
                     messages.append(message.content)
                 elif isinstance(message, dict) and message.get('role') == "user" and 'content' in message:  # Check if it's a dict with role and content
                     messages.append(message['content'])
-        elif arguments['args'] is not None and len(arguments['args']) > 0 and 'messages' in arguments['args'][0]:
+                elif isinstance(message, dict) and message.get('type') == "human" and 'content' in message:
+                    messages.append(message['content'])
+        elif arguments['args'] is not None and len(arguments['args']) > 0 and isinstance(arguments['args'][0], dict) and 'messages' in arguments['args'][0]:
             history = arguments['args'][0]['messages']
             for message in history:
                 if hasattr(message, 'type') and message.type == "human":
                     messages.append(message.content)
                 elif isinstance(message, dict) and message.get('role') == "user" and 'content' in message:  # Check if it's a dict with role and content
+                    messages.append(message['content'])
+                elif isinstance(message, dict) and message.get('type') == "human" and 'content' in message:
                     messages.append(message['content'])
         return get_json_dumps(messages) if messages else ""
     except Exception as e:

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/langgraph_processor.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/langgraph_processor.py
@@ -119,4 +119,7 @@ class LanggraphToolHandler(SpanHandler):
         # Filter out ParentCommand exceptions as they are LangGraph control flow mechanisms, not actual errors
         if ParentCommand is not None and isinstance(ex, ParentCommand):
             ex = None  # Suppress the ParentCommand exception from being recorded
+        # Use the tool's registered name as the span name rather than the wrapper class path
+        if hasattr(instance, "name") and instance.name:
+            span.update_name(instance.name)
         return super().hydrate_span(to_wrap, wrapped, instance, args, kwargs, result, span, parent_span, ex, is_post_exec)

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/langgraph_processor.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/langgraph_processor.py
@@ -53,7 +53,7 @@ class LanggraphAgentHandler(SpanHandler):
                 agent_request_wrapper["output_processor_list"] = [AGENT_REQUEST, AGENT]
             else:
                 agent_request_wrapper["output_processor"] = AGENT_REQUEST
-            session_id = extract_thread_id(kwargs)
+            session_id = extract_thread_id(args, kwargs)
             if session_id is not None:
                 return start_scope(AGENT_SESSION, scope_value=session_id, context=context), agent_request_wrapper
             return attach(context), agent_request_wrapper

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/methods.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/methods.py
@@ -1,4 +1,4 @@
-from monocle_apptrace.instrumentation.common.wrapper import task_wrapper, atask_wrapper
+from monocle_apptrace.instrumentation.common.wrapper import task_wrapper, atask_wrapper, atask_iter_wrapper
 from monocle_apptrace.instrumentation.metamodel.langgraph.entities.inference import (
     AGENT,
     TOOLS,
@@ -19,6 +19,24 @@ LANGGRAPH_METHODS = [
         "object": "CompiledStateGraph",
         "method": "ainvoke",
         "wrapper_method": atask_wrapper,
+        "span_handler": "langgraph_agent_handler",
+        "scope_name": "agent.invocation",
+        "output_processor": AGENT,
+    },
+    {
+        "package": "langgraph.graph.state",
+        "object": "CompiledStateGraph",
+        "method": "astream",
+        "wrapper_method": atask_iter_wrapper,
+        "span_handler": "langgraph_agent_handler",
+        "scope_name": "agent.invocation",
+        "output_processor": AGENT,
+    },
+    {
+        "package": "langgraph.graph.state",
+        "object": "CompiledStateGraph",
+        "method": "astream_events",
+        "wrapper_method": atask_iter_wrapper,
         "span_handler": "langgraph_agent_handler",
         "scope_name": "agent.invocation",
         "output_processor": AGENT,

--- a/apptrace/tests/unit/test_langchain.py
+++ b/apptrace/tests/unit/test_langchain.py
@@ -212,6 +212,73 @@ class TestHandler(MonocleTestBase):
             os.environ.pop(test_input_infra)
             os.environ.pop(test_input_infra_identifier, None)
 
+class TestLangGraphHelpers(unittest.TestCase):
+    """Unit tests for LangGraph streaming helper functions."""
+
+    # ------------------------------------------------------------------ #
+    # extract_content_text                                                 #
+    # ------------------------------------------------------------------ #
+
+    def test_extract_content_text_plain_string(self):
+        from monocle_apptrace.instrumentation.common.utils import extract_content_text
+        self.assertEqual(extract_content_text("hello"), "hello")
+
+    def test_extract_content_text_openai_content_blocks(self):
+        from monocle_apptrace.instrumentation.common.utils import extract_content_text
+        blocks = [{"type": "text", "text": "hello world"}]
+        self.assertEqual(extract_content_text(blocks), "hello world")
+
+    def test_extract_content_text_ignores_non_text_blocks(self):
+        from monocle_apptrace.instrumentation.common.utils import extract_content_text
+        blocks = [{"type": "thinking", "text": "reasoning"}, {"type": "text", "text": "answer"}]
+        self.assertEqual(extract_content_text(blocks), "answer")
+
+    # ------------------------------------------------------------------ #
+    # extract_agent_response                                               #
+    # ------------------------------------------------------------------ #
+
+    def test_extract_agent_response_none(self):
+        from monocle_apptrace.instrumentation.metamodel.langgraph._helper import extract_agent_response
+        self.assertEqual(extract_agent_response(None), "")
+
+    def test_extract_agent_response_astream_checkpoint_tuple(self):
+        from unittest.mock import MagicMock
+        from monocle_apptrace.instrumentation.metamodel.langgraph._helper import extract_agent_response
+        msg = MagicMock()
+        msg.content = "final answer"
+        payload = {"type": "checkpoint", "values": {"messages": [msg]}}
+        self.assertEqual(extract_agent_response(((), "debug", {"payload": payload})), "final answer")
+
+    def test_extract_agent_response_ainvoke_flat_dict(self):
+        from unittest.mock import MagicMock
+        from monocle_apptrace.instrumentation.metamodel.langgraph._helper import extract_agent_response
+        msg = MagicMock()
+        msg.content = "hello"
+        self.assertEqual(extract_agent_response({"messages": [msg]}), "hello")
+
+    # ------------------------------------------------------------------ #
+    # extract_agent_input                                                  #
+    # ------------------------------------------------------------------ #
+
+    def test_extract_agent_input_type_human_dict(self):
+        """LangGraph Studio sends {'type': 'human'} dicts — must be detected."""
+        from monocle_apptrace.instrumentation.metamodel.langgraph._helper import extract_agent_input
+        args = {"args": [], "kwargs": {"input": {"messages": [{"type": "human", "content": "hi"}]}}}
+        self.assertEqual(json.loads(extract_agent_input(args)), ["hi"])
+
+    def test_extract_agent_input_role_user_dict(self):
+        from monocle_apptrace.instrumentation.metamodel.langgraph._helper import extract_agent_input
+        args = {"args": [], "kwargs": {"input": {"messages": [{"role": "user", "content": "hi"}]}}}
+        self.assertEqual(json.loads(extract_agent_input(args)), ["hi"])
+
+    def test_extract_agent_input_non_dict_args_is_safe(self):
+        """isinstance guard: args[0] is a graph object, not an input dict."""
+        from unittest.mock import MagicMock
+        from monocle_apptrace.instrumentation.metamodel.langgraph._helper import extract_agent_input
+        args = {"args": [MagicMock()], "kwargs": {}}
+        self.assertEqual(extract_agent_input(args), "")
+
+
 if __name__ == '__main__':
     unittest.main()
     


### PR DESCRIPTION
## Changes 

- Register astream and astream_events on CompiledStateGraph so LangGraph server deployments produce traces
- Fix data.input to correctly extract user messages sent as dicts from the LangGraph Studio UI and SDK
- Fix data.output to handle the checkpoint tuple that astream yields as its last item, and unwrap OpenAI content blocks into readable text
- Rename tool spans from the generic class path to the tool's actual registered name


## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
