### PR TITLE
Reset span mutation attribute before setting test status properties at the end of test execution

### DIFF
--- a/test_tools/src/monocle_test_tools/validator.py
+++ b/test_tools/src/monocle_test_tools/validator.py
@@ -123,14 +123,27 @@ class MonocleValidator:
         # This is critical for failed tests where spans property may not have been accessed
         _ = self.spans
         span:Span = None
+        _span_immutable:bool = None
         for exporter in self.exporters:
             for span in self._test_all_up_spans:
+                _span_immutable = None
+                # If the span's attributes are made immutable, temporarily make them mutable to add test status attributes
+                try:
+                    _span_immutable = span._attributes._immutable
+                    span._attributes._immutable = False
+                except AttributeError:
+                    pass
                 if test_failed:
                     span._attributes[TEST_STATUS_ATTRIBUTE] = "failed"
                     if test_assertion_message is not None:
                         span._attributes[TEST_ASSERTION_ATTRIBUTE] = test_assertion_message
                 else:
                     span._attributes[TEST_STATUS_ATTRIBUTE] = "passed"
+                if _span_immutable is not None:
+                    try:
+                        span._attributes._immutable = _span_immutable
+                    except AttributeError:
+                        pass
                 exporter.export([span])
             if hasattr(exporter, "force_flush"):
                 exporter.force_flush()


### PR DESCRIPTION
The newer version of Otel SDK sets the span attributes immutable when the span closes. The Monocle test framework sets the test status in the span at the end of test run which is after the span has ended. Hence with latest Otel SDK, the test execution fail.
To fix is to unset and then reset the span immutable property during test status recording.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...