### PR TITLE
strands: anchor agentic.session from Agent.trace_attributes

### DIFF
--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/strands/_helper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/strands/_helper.py
@@ -27,6 +27,13 @@ def extract_session_id(instance,kwargs):
     if "session_manager" in kwargs and hasattr(kwargs["session_manager"],'session_id'):
         return kwargs["session_manager"].session_id
 
+    # Agents without a session_manager commonly carry a session id in trace_attributes
+    trace_attributes = getattr(instance, "trace_attributes", None)
+    if isinstance(trace_attributes, dict):
+        for key in ("session.id", "session_id"):
+            if trace_attributes.get(key):
+                return trace_attributes[key]
+
     return None
 
 

--- a/apptrace/tests/unit/test_strands_session.py
+++ b/apptrace/tests/unit/test_strands_session.py
@@ -8,8 +8,9 @@ from monocle_apptrace.instrumentation.metamodel.strands.strands_processor import
 class Agent:
     """Minimal stand-in for strands.Agent that exposes a session_manager."""
 
-    def __init__(self, session_manager=None):
+    def __init__(self, session_manager=None, trace_attributes=None):
         self._session_manager = session_manager
+        self.trace_attributes = trace_attributes if trace_attributes is not None else {}
         self.name = "travel_agent"
         self.description = "Travel booking agent"
 
@@ -52,4 +53,22 @@ def test_strands_handler_ignores_missing_session():
     assert (
         get_scopes().get(AGENT_SESSION) == previous_scope
     ), "agentic.session scope should remain unchanged when no session exists"
+
+
+def test_strands_handler_uses_trace_attributes_session():
+    handler = StrandsSpanHandler()
+    # No session_manager; session carried in trace_attributes (the common case)
+    agent = Agent(trace_attributes={"session.id": "trace-session-1"})
+    previous_scope = get_scopes().get(AGENT_SESSION)
+
+    token, _ = handler.pre_tracing({}, None, agent, (), {})
+
+    assert token is not None, "Expected set_scope token from trace_attributes session id"
+    assert get_scopes().get(AGENT_SESSION) == "trace-session-1"
+
+    from monocle_apptrace.instrumentation.common.utils import remove_scope
+    if token:
+        remove_scope(token)
+
+    assert get_scopes().get(AGENT_SESSION) == previous_scope
 


### PR DESCRIPTION
## Problem

Strands `Agent`s commonly carry their session id in `Agent.trace_attributes` (the standard Strands mechanism, e.g. `Agent(trace_attributes={"session.id": ...})`) rather than via a `SessionManager`. Monocle's `extract_session_id` only checked `_session_manager`, so any Strands agent without a session manager emitted **no `scope.agentic.session`** — leaving its traces unanchored.

## Reproduction

Instrumented a real Strands app (DevDuck) running on OpenAI. The trace was structurally correct (`workflow → agentic.turn → agentic.invocation → {inference, agentic.tool.invocation}`, all I/O populated, tokens + model present), but every span had an empty `scope.agentic.session` because DevDuck attaches its session via `trace_attributes={"session.id": ...}` and uses no `SessionManager`.

## Fix

`extract_session_id` falls back to `instance.trace_attributes` (`session.id`, then `session_id`) when no `session_manager` is present. After the fix, all spans in the trace share the same `scope.agentic.session`.

## Test

Adds `test_strands_handler_uses_trace_attributes_session` covering the fallback. Existing session tests unchanged and still pass (the no-session case still yields no scope).