### PR TITLE
Okahu Span Loader Enhancement

### DIFF
--- a/test_tools/src/monocle_test_tools/okahu_span_loader.py
+++ b/test_tools/src/monocle_test_tools/okahu_span_loader.py
@@ -170,22 +170,36 @@ class OkahuSpanLoader:
             ValueError: If OKAHU_API_KEY is not configured.
             ConnectionError: If the request to Okahu fails.
         """
-        # Strip 0x prefix if present
-        trace_id = trace_id.replace("0x", "")
+        bare_id = trace_id.replace("0x", "")
 
         base = OkahuSpanLoader._get_api_base(endpoint)
         headers = OkahuSpanLoader._get_headers(api_key)
-        url = f"{base}/api/v1/workflows/{workflow_name}/traces/{trace_id}/spans"
 
         params = {}
         if filter_fact and filter_fact_id:
             params["filter_fact"] = filter_fact
             params["filter_fact_id"] = filter_fact_id
 
-        span_data_list = OkahuSpanLoader._do_get(
-            url, headers, params=params or None, timeout=timeout,
-            context_msg=f"spans for trace_id '{trace_id}' in workflow '{workflow_name}'"
-        )
+        # Try bare hex first (OTLP ingest path), then 0x-prefixed
+        # (OTel SDK ingest path) to handle both storage formats.
+        for candidate_id in [bare_id, f"0x{bare_id}"]:
+            url = f"{base}/api/v1/workflows/{workflow_name}/traces/{candidate_id}/spans"
+            try:
+                span_data_list = OkahuSpanLoader._do_get(
+                    url, headers, params=params or None, timeout=timeout,
+                    context_msg=f"spans for trace_id '{candidate_id}' in workflow '{workflow_name}'"
+                )
+                trace_id = candidate_id
+                break
+            except requests.HTTPError as exc:
+                if exc.response is not None and exc.response.status_code == 404 and candidate_id == bare_id:
+                    continue
+                raise
+        else:
+            raise requests.HTTPError(
+                f"Trace '{bare_id}' not found in workflow '{workflow_name}' "
+                f"(tried both bare hex and 0x-prefixed)."
+            )
 
         span_data_list = OkahuSpanLoader._unwrap_list(
             span_data_list, ("spans", "batch", "data", "results", "trace_spans"),


### PR DESCRIPTION
## Proposed changes

providing ability for okahu span loader to read both test traces and live agent traces. Allows for retesting on the same json trace data. Completely backwards compatible.
Previously only accepted traces without the 0x prefix. However load from json or exporting traces via pytest would end up exporting with the 0x prefix to okahu. This change allows both trace and span ids with and without the 0x prefix to be read. 

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...