### PR TITLE
[claude-skill] langgraph custom-StateGraph I/O + non-primitive scope coercion + idle-based trace files + langchain string/dict data.input + sync CompiledStateGraph.stream

### DIFF
--- a/apptrace/src/monocle_apptrace/exporters/file_exporter.py
+++ b/apptrace/src/monocle_apptrace/exporters/file_exporter.py
@@ -33,7 +33,7 @@ class FileSpanExporter(SpanExporterBase):
         task_processor: Optional[ExportTaskProcessor] = None
     ):
         super().__init__()
-        # Dictionary to store file handles: {trace_id: (file_handle, file_path, creation_time, first_span)}
+        # Dictionary to store file handles: {trace_id: (file_handle, file_path, last_activity, first_span)}
         self.file_handles: Dict[int, Tuple[TextIOWrapper, str, datetime, bool]] = {}
         self.formatter = formatter
         self.service_name = service_name
@@ -76,12 +76,17 @@ class FileSpanExporter(SpanExporterBase):
         self.service_name = service_name
 
     def _cleanup_expired_handles(self) -> None:
-        """Close and remove file handles that have exceeded the timeout."""
+        """Close handles for traces that have been idle past the timeout.
+
+        Idle (time since the last span was written), not age since creation, so a
+        long-running trace that keeps producing spans stays in one file while a
+        genuinely stalled trace is still cleaned up.
+        """
         current_time = datetime.now()
         expired_trace_ids = []
-        
-        for trace_id, (handle, file_path, creation_time, _) in self.file_handles.items():
-            if (current_time - creation_time).total_seconds() > HANDLE_TIMEOUT_SECONDS:
+
+        for trace_id, (handle, file_path, last_activity, _) in self.file_handles.items():
+            if (current_time - last_activity).total_seconds() > HANDLE_TIMEOUT_SECONDS:
                 expired_trace_ids.append(trace_id)
         
         for trace_id in expired_trace_ids:
@@ -133,8 +138,14 @@ class FileSpanExporter(SpanExporterBase):
     def _mark_span_written(self, trace_id: int) -> None:
         """Mark that a span has been written for this trace (no longer first span)."""
         if trace_id in self.file_handles:
-            handle, file_path, creation_time, _ = self.file_handles[trace_id]
-            self.file_handles[trace_id] = (handle, file_path, creation_time, False)
+            handle, file_path, last_activity, _ = self.file_handles[trace_id]
+            self.file_handles[trace_id] = (handle, file_path, last_activity, False)
+
+    def _touch_handle(self, trace_id: int) -> None:
+        """Refresh the idle timer after writing spans, so an active trace isn't expired mid-run."""
+        if trace_id in self.file_handles:
+            handle, file_path, _, first_span = self.file_handles[trace_id]
+            self.file_handles[trace_id] = (handle, file_path, datetime.now(), first_span)
 
     def _process_spans(self, spans: Sequence[ReadableSpan], is_root_span: bool = False) -> SpanExportResult:
         # Group spans by trace_id for efficient processing
@@ -181,6 +192,8 @@ class FileSpanExporter(SpanExporterBase):
                 except Exception as e:
                     print(f"Error formatting span {span.context.span_id}: {e}")
                     continue
+
+            self._touch_handle(trace_id)
         
         # Close handles for traces that are complete (have both root and child spans)
         traces_to_close = set()

--- a/apptrace/src/monocle_apptrace/instrumentation/common/span_handler.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/common/span_handler.py
@@ -86,13 +86,25 @@ class SpanHandler:
             logger.warning("Warning: Error occurred in pre_task_processing: %s", str(e))
 
     @staticmethod
+    def _coerce_scope_value(value):
+        # OTEL only accepts primitives (or sequences of them) as attribute values;
+        # scope ids derived from app objects (e.g. a UUID thread_id) get dropped otherwise.
+        if isinstance(value, (bool, str, bytes, int, float)):
+            return value
+        if isinstance(value, (list, tuple)) and all(
+            isinstance(item, (bool, str, bytes, int, float)) for item in value
+        ):
+            return value
+        return str(value)
+
+    @staticmethod
     def set_default_monocle_attributes(span: Span, source_path = "" ):
         """ Set default monocle attributes for all spans """
         span.set_attribute(MONOCLE_SDK_VERSION, get_monocle_version())
         span.set_attribute(MONOCLE_SDK_LANGUAGE, "python")
         span.set_attribute("span_source", source_path)
         for scope_key, scope_value in get_scopes().items():
-            span.set_attribute(f"scope.{scope_key}", scope_value)
+            span.set_attribute(f"scope.{scope_key}", SpanHandler._coerce_scope_value(scope_value))
         workflow_name = SpanHandler.get_workflow_name(span=span)
         if workflow_name:
             span.set_attribute("workflow.name", workflow_name)
@@ -186,7 +198,7 @@ class SpanHandler:
         # set scopes as attributes by calling get_scopes()
         # scopes is a Mapping[str:object], iterate directly with .items()
         for scope_key, scope_value in get_scopes().items():
-            span.set_attribute(f"scope.{scope_key}", scope_value)
+            span.set_attribute(f"scope.{scope_key}", SpanHandler._coerce_scope_value(scope_value))
 
         if span_index > 0:
             span.set_attribute("entity.count", span_index)

--- a/apptrace/src/monocle_apptrace/instrumentation/common/wrapper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/common/wrapper.py
@@ -2,7 +2,7 @@
 import logging
 import os
 from contextlib import contextmanager
-from typing import AsyncGenerator, Iterator, Optional
+from typing import AsyncGenerator, Generator, Iterator, Optional
 from opentelemetry.trace import NonRecordingSpan, Tracer
 from opentelemetry.trace.propagation import set_span_in_context, get_current_span
 from opentelemetry.context import set_value, attach, detach, get_value
@@ -169,6 +169,98 @@ def monocle_wrapper_span_processor(tracer: Tracer, handler: SpanHandler, to_wrap
             span_status = span.status
     return return_value, span_status
 
+def monocle_iter_wrapper_span_processor(tracer: Tracer, handler: SpanHandler, to_wrap, wrapped, instance, source_path, add_workflow_span,
+                                        args, kwargs) -> Generator[any, None, None]:
+    # Sync counterpart of amonocle_iter_wrapper_span_processor, for generator-returning methods
+    # (e.g. CompiledStateGraph.stream) that have no async equivalent in the call path.
+    name = get_span_name(to_wrap, instance)
+    auto_close_span = get_auto_close_span(to_wrap, kwargs)
+    parent_span = get_current_monocle_span()
+    last_item = None
+
+    with start_as_monocle_span(tracer, name, auto_close_span) as span:
+        pre_process_span(name, tracer, handler, add_workflow_span, to_wrap, wrapped, instance, args, kwargs, span, source_path)
+
+        if SpanHandler.is_root_span(span) or add_workflow_span or SpanHandler.is_remote_parent_span(span):
+            # Recursive call for the actual span
+            try:
+                for item in monocle_iter_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, False, args, kwargs):
+                    yield item
+                    # Repair monocle context if inner generators leaked theirs.
+                    if get_current_monocle_span() is not span:
+                        attach(set_monocle_span_in_context(span))
+                span.set_status(StatusCode.OK)
+            except Exception as e:
+                # Record the failure on the workflow span and re-raise. Without this the
+                # workflow span is never ended/exported when the stream raises and
+                # auto_close_span is False (the common case for streaming inference).
+                span.set_status(StatusCode.ERROR, str(e))
+                raise
+            finally:
+                if not auto_close_span:
+                    span.end()
+        else:
+            ex:Exception = None
+            to_wrap = get_wrapper_with_next_processor(to_wrap, handler, instance, span, parent_span, args, kwargs)
+            if has_more_processors(to_wrap):
+                try:
+                    handler.hydrate_span(to_wrap, wrapped, instance, args, kwargs, None, span, parent_span, ex,
+                                is_post_exec=False)
+                except Exception as e:
+                    logger.info(f"Warning: Error occurred in hydrate_span pre_process_span: {e}")
+                try:
+                    with monocle_trace_scope(get_builtin_scope_names(to_wrap)):
+                        for item in monocle_iter_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, False, args, kwargs):
+                            last_item = item
+                            yield item
+                            if get_current_monocle_span() is not span:
+                                attach(set_monocle_span_in_context(span))
+                except Exception as e:
+                    ex = e
+                    raise
+                finally:
+                    last_item = post_process_span(handler, to_wrap, wrapped, instance, args, kwargs, last_item, span, parent_span, ex)
+                    # Close non-auto-close intermediate spans (leaf/root branches already do).
+                    if not auto_close_span:
+                        span.end()
+            else:
+                try:
+                    handler.hydrate_span(to_wrap, wrapped, instance, args, kwargs, None, span, parent_span, ex,
+                                is_post_exec=False)
+                except Exception as e:
+                    logger.info(f"Warning: Error occurred in hydrate_span pre_process_span: {e}")
+                try:
+                    skip_execution, last_item = SpanHandler.skip_execution(span)
+                    _has_response_processor = (not auto_close_span
+                        and to_wrap.get("output_processor")
+                        and to_wrap.get("output_processor").get("response_processor"))
+                    _raw_items = [] if _has_response_processor else None
+                    if not skip_execution:
+                        with SpanHandler.workflow_type(to_wrap, span):
+                            for item in wrapped(*args, **kwargs):
+                                last_item = item
+                                if _raw_items is not None:
+                                    _raw_items.append(item)
+                                yield item
+                                # Repair monocle context after resume from yield.
+                                if get_current_monocle_span() is not span:
+                                    attach(set_monocle_span_in_context(span))
+                    else:
+                        yield last_item
+                except Exception as e:
+                    ex = e
+                    raise
+                finally:
+                    def post_process_span_internal(ret_val):
+                        ret_val = post_process_span(handler, to_wrap, wrapped, instance, args, kwargs, ret_val, span, parent_span, ex)
+                        if not auto_close_span:
+                            span.end()
+                    if ex is None and _has_response_processor:
+                        to_wrap.get("output_processor").get("response_processor")(to_wrap, _raw_items or None, post_process_span_internal)
+                    else:
+                        last_item = post_process_span_internal(last_item)
+    return
+
 def monocle_wrapper(tracer: Tracer, handler: SpanHandler, to_wrap, wrapped, instance, source_path, args, kwargs):
     return_value = None
     pre_trace_token = None
@@ -194,6 +286,53 @@ def monocle_wrapper(tracer: Tracer, handler: SpanHandler, to_wrap, wrapped, inst
     finally:
         try:
             handler.post_tracing(to_wrap, wrapped, instance, args, kwargs, return_value, token=pre_trace_token)
+        except Exception as e:
+            logger.info(f"Warning: Error occurred in post_tracing: {e}")
+
+def monocle_iter_wrapper(tracer: Tracer, handler: SpanHandler, to_wrap, wrapped, instance, source_path, args, kwargs) -> Generator[any, None, None]:
+    # Sync counterpart of amonocle_iter_wrapper.
+    token = None
+    pre_trace_token = None
+    # Outer sentinel: guards post_tracing() detach calls in the outer finally.
+    # Set before the first yield so finalization in a different Context is detected.
+    _pre_trace_marker = object()
+    _pre_trace_marker_token = MONOCLE_CONTEXT_MARKER.set(_pre_trace_marker)
+    try:
+        try:
+            pre_trace_token, alternate_to_wrapp = handler.pre_tracing(to_wrap, wrapped, instance, args, kwargs)
+            if alternate_to_wrapp is not None:
+                to_wrap = alternate_to_wrapp
+        except Exception as e:
+            logger.info(f"Warning: Error occurred in pre_tracing: {e}")
+        if to_wrap.get('skip_span', False) or handler.skip_span(to_wrap, wrapped, instance, args, kwargs):
+            for item in wrapped(*args, **kwargs):
+                yield item
+        else:
+            add_workflow_span = get_value(ADD_NEW_WORKFLOW) == True
+            _marker = object()
+            _marker_token = MONOCLE_CONTEXT_MARKER.set(_marker)
+            token = attach(set_value(ADD_NEW_WORKFLOW, False))
+            try:
+                with monocle_trace_scope(get_builtin_scope_names(to_wrap)):
+                    for item in monocle_iter_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, add_workflow_span, args, kwargs):
+                        yield item
+            finally:
+                if MONOCLE_CONTEXT_MARKER.get() is _marker:
+                    detach(token)
+                    try:
+                        MONOCLE_CONTEXT_MARKER.reset(_marker_token)
+                    except ValueError:
+                        pass
+                    # After reset, MONOCLE_CONTEXT_MARKER.get() == _pre_trace_marker again
+        return
+    finally:
+        try:
+            if MONOCLE_CONTEXT_MARKER.get() is _pre_trace_marker:
+                handler.post_tracing(to_wrap, wrapped, instance, args, kwargs, None, pre_trace_token)
+                try:
+                    MONOCLE_CONTEXT_MARKER.reset(_pre_trace_marker_token)
+                except ValueError:
+                    pass
         except Exception as e:
             logger.info(f"Warning: Error occurred in post_tracing: {e}")
 
@@ -453,6 +592,12 @@ async def atask_wrapper(tracer: Tracer, handler: SpanHandler, to_wrap, wrapped, 
 @with_tracer_wrapper
 async def atask_iter_wrapper(tracer: Tracer, handler: SpanHandler, to_wrap, wrapped, instance, source_path, args, kwargs) -> AsyncGenerator[any, None]:
     async for item in amonocle_iter_wrapper(tracer, handler, to_wrap, wrapped, instance, source_path, args, kwargs):
+        yield item
+    return
+
+@with_tracer_wrapper
+def task_iter_wrapper(tracer: Tracer, handler: SpanHandler, to_wrap, wrapped, instance, source_path, args, kwargs) -> Generator[any, None, None]:
+    for item in monocle_iter_wrapper(tracer, handler, to_wrap, wrapped, instance, source_path, args, kwargs):
         yield item
     return
 

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/langchain/_helper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/langchain/_helper.py
@@ -40,6 +40,10 @@ def extract_messages(args, instance=None):
         if args and isinstance(args, (list, tuple)) and hasattr(args[0], 'text'):
             return [args[0].text]
         if args and isinstance(args, (list, tuple)) and len(args) > 0:
+            if isinstance(args[0], str):
+                # A model invoked with a raw string prompt (e.g. llm.invoke("...")
+                # or with_structured_output(...).ainvoke("..."))
+                return [args[0]]
             if isinstance(args[0], list) and len(args[0]) > 0:
                 first_msg = args[0][0]
                 if hasattr(first_msg, 'content') and hasattr(first_msg, 'type') and first_msg.type == "human":
@@ -50,7 +54,10 @@ def extract_messages(args, instance=None):
                         messages.append({msg.type: msg.content})
             else:
                 for msg in args[0]:
-                    if hasattr(msg, 'content') and hasattr(msg, 'type') and msg.content:
+                    if isinstance(msg, dict) and msg.get('content'):
+                        # OpenAI-style dict message: {"role": ..., "content": ...}
+                        messages.append({msg.get('role') or msg.get('type') or 'user': msg['content']})
+                    elif hasattr(msg, 'content') and hasattr(msg, 'type') and msg.content:
                         messages.append({msg.type: msg.content})
                     elif hasattr(msg, 'tool_calls') and msg.tool_calls:
                         messages.append({msg.type: get_json_dumps(msg.tool_calls)})

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/langchain/_helper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/langchain/_helper.py
@@ -22,9 +22,20 @@ from contextlib import suppress
 logger = logging.getLogger(__name__)
 
 
-def extract_messages(args):
+def extract_messages(args, instance=None):
     """Extract system and user messages"""
     try:
+        # Some callers invoke the class method unbound, leaking the model itself into args[0].
+        if args and isinstance(args, (list, tuple)) and len(args) > 1:
+            leading = args[0]
+            is_self_like = leading is instance or (
+                not isinstance(leading, (list, tuple))
+                and not hasattr(leading, 'text')
+                and not hasattr(leading, 'messages')
+                and hasattr(leading, 'ainvoke') and hasattr(leading, 'invoke')
+            )
+            if is_self_like:
+                args = args[1:]
         messages = []
         if args and isinstance(args, (list, tuple)) and hasattr(args[0], 'text'):
             return [args[0].text]

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/langchain/entities/inference.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/langchain/entities/inference.py
@@ -61,7 +61,7 @@ INFERENCE = {
              {
                  "_comment": "this is instruction and user query to LLM",
                  "attribute": "input",
-                 "accessor": lambda arguments: _helper.extract_messages(arguments['args'])
+                 "accessor": lambda arguments: _helper.extract_messages(arguments['args'], arguments.get('instance'))
              }
          ]
          },

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/_helper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/_helper.py
@@ -27,6 +27,14 @@ def _last_message_content_from_state(state) -> str:
                     return extract_content_text(content)
     return ""
 
+def _serialize_state(state) -> str:
+    """Faithful fallback for custom (non message-based) StateGraph I/O: serialize the state itself."""
+    if state is None or state == {}:
+        return ""
+    if isinstance(state, str):
+        return state
+    return get_json_dumps(state)
+
 def extract_agent_response(response):
     try:
         if response is None:
@@ -38,10 +46,10 @@ def extract_agent_response(response):
         # astream emits a checkpoint tuple ((), 'debug', {payload}) as its final item
         if isinstance(response, tuple) and len(response) >= 3 and isinstance(response[2], dict):
             values = response[2].get('payload', {}).get('values', {})
-            return _last_message_content_from_state(values)
+            return _last_message_content_from_state(values) or _serialize_state(values)
         # 2-tuple stream chunk (mode, data) from a nested subgraph astream
         if isinstance(response, tuple) and len(response) == 2 and isinstance(response[1], dict):
-            return _last_message_content_from_state(response[1])
+            return _last_message_content_from_state(response[1]) or _serialize_state(response[1])
         if isinstance(response, dict):
             text = _last_message_content_from_state(response)
             if text:
@@ -52,6 +60,8 @@ def extract_agent_response(response):
                     text = _last_message_content_from_state(value)
                     if text:
                         return text
+            # custom StateGraph with no message channel: serialize the final state
+            return _serialize_state(response)
     except Exception as e:
         logger.warning("Warning: Error occurred in handle_response: %s", str(e))
     return ""
@@ -102,6 +112,8 @@ def extract_agent_input(arguments):
             text = _last_message_content_from_state(input_obj)
             if text:
                 return get_json_dumps([text])
+            # custom StateGraph with no message channel: serialize the input state
+            return _serialize_state(input_obj)
         return ""
     except Exception as e:
         logger.warning("Warning: Error occurred in extract_agent_input: %s", str(e))

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/_helper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/_helper.py
@@ -1,6 +1,7 @@
 from opentelemetry.context import get_value
 from monocle_apptrace.instrumentation.common.utils import resolve_from_alias, get_json_dumps, extract_content_text
 from monocle_apptrace.instrumentation.common.constants import AGENT_NAME_KEY, LAST_AGENT_INVOCATION_ID, LAST_AGENT_NAME
+import dataclasses
 import logging
 logger = logging.getLogger(__name__)
 
@@ -8,9 +9,21 @@ DELEGATION_NAME_PREFIX = 'transfer_to_'
 ROOT_AGENT_NAME = 'LangGraph'
 LANGGRAPTH_AGENT_NAME_KEY = "agent.langgraph"
 
+def _as_state_dict(state):
+    """Shallowly normalize a dataclass/Pydantic StateGraph state to a dict for channel introspection."""
+    if isinstance(state, dict):
+        return state
+    if dataclasses.is_dataclass(state) and not isinstance(state, type):
+        return {f.name: getattr(state, f.name) for f in dataclasses.fields(state)}
+    model_fields = getattr(type(state), "model_fields", None) or getattr(type(state), "__fields__", None)
+    if model_fields:
+        return {name: getattr(state, name) for name in model_fields}
+    return None
+
 def _last_message_content_from_state(state) -> str:
     """Last non-empty message content from a state dict, allowing custom '*messages' channels."""
-    if not isinstance(state, dict):
+    state = _as_state_dict(state)
+    if state is None:
         return ""
     candidate_keys = []
     if 'messages' in state:
@@ -81,7 +94,8 @@ def is_single_agent_instance(instance) -> bool:
 def _human_messages_from_state(state) -> list:
     """Collect human/user message text across any '*messages' channel of a state dict."""
     out = []
-    if not isinstance(state, dict):
+    state = _as_state_dict(state)
+    if state is None:
         return out
     for k, v in state.items():
         if not (k == 'messages' or (isinstance(k, str) and k.endswith('messages'))):
@@ -101,9 +115,9 @@ def extract_agent_input(arguments):
     try:
         input_obj = None
         if arguments.get('kwargs') and 'input' in arguments['kwargs']:
-            input_obj = arguments['kwargs']['input']
-        elif arguments.get('args') and len(arguments['args']) > 0 and isinstance(arguments['args'][0], dict):
-            input_obj = arguments['args'][0]
+            input_obj = _as_state_dict(arguments['kwargs']['input'])
+        elif arguments.get('args') and len(arguments['args']) > 0:
+            input_obj = _as_state_dict(arguments['args'][0])
         if isinstance(input_obj, dict):
             messages = _human_messages_from_state(input_obj)
             if messages:

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/langgraph_processor.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/langgraph_processor.py
@@ -47,7 +47,7 @@ class LanggraphAgentHandler(SpanHandler):
         context = set_value(AGENT_NAME_KEY, get_name(instance))
         context = set_value(AGENT_PREFIX_KEY, DELEGATION_NAME_PREFIX, context)
         scope_name = AGENT_REQUEST.get("type")
-        is_streaming_call = to_wrap.get("method") in ["astream"]
+        is_streaming_call = to_wrap.get("method") in ["astream", "stream"]
         if not is_scope_set(scope_name):
             agent_request_wrapper = to_wrap.copy()
             if is_single_agent_instance(instance):

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/langgraph_stream_processor.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/langgraph_stream_processor.py
@@ -6,6 +6,7 @@ from monocle_apptrace.instrumentation.common.stream_processor import (
     BaseStreamProcessor,
     StreamState,
 )
+from monocle_apptrace.instrumentation.common.utils import get_json_dumps
 
 
 class LanggraphStreamProcessor(BaseStreamProcessor):
@@ -125,6 +126,22 @@ class LanggraphStreamProcessor(BaseStreamProcessor):
     def handle_completion(self, item: Any, state: StreamState) -> bool:
         """LangGraph does not emit a separate completion chunk; unused."""
         return False
+
+    def assemble_data(self, state: StreamState) -> None:
+        """Custom (non message-based) StateGraph: fall back to the last streamed state snapshot."""
+        if state.accumulated_response:
+            return
+        for item in reversed(state.raw_items):
+            snapshot = self._chunk_state(item)
+            if snapshot:
+                state.accumulated_response = get_json_dumps(snapshot)
+                return
+
+    def _chunk_state(self, item: Any) -> Any:
+        """Return the state dict carried by a values/updates stream chunk, if any."""
+        if isinstance(item, tuple) and len(item) in (2, 3) and isinstance(item[-1], dict):
+            item = item[-1]
+        return item if isinstance(item, dict) and item else None
 
     def _extract_message_content(self, message: Any) -> str:
         """Extract text from a LangChain message, handling str and list content."""

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/methods.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/methods.py
@@ -1,4 +1,4 @@
-from monocle_apptrace.instrumentation.common.wrapper import task_wrapper, atask_wrapper, atask_iter_wrapper
+from monocle_apptrace.instrumentation.common.wrapper import task_wrapper, atask_wrapper, atask_iter_wrapper, task_iter_wrapper
 from monocle_apptrace.instrumentation.metamodel.langgraph.entities.inference import (
     AGENT,
     AGENT_STREAM,
@@ -29,6 +29,15 @@ LANGGRAPH_METHODS = [
         "object": "CompiledStateGraph",
         "method": "astream",
         "wrapper_method": atask_iter_wrapper,
+        "span_handler": "langgraph_agent_handler",
+        "scope_name": "agent.invocation",
+        "output_processor": AGENT_STREAM,
+    },
+    {
+        "package": "langgraph.graph.state",
+        "object": "CompiledStateGraph",
+        "method": "stream",
+        "wrapper_method": task_iter_wrapper,
         "span_handler": "langgraph_agent_handler",
         "scope_name": "agent.invocation",
         "output_processor": AGENT_STREAM,

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/methods.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/methods.py
@@ -2,7 +2,6 @@ from monocle_apptrace.instrumentation.common.wrapper import task_wrapper, atask_
 from monocle_apptrace.instrumentation.metamodel.langgraph.entities.inference import (
     AGENT,
     AGENT_STREAM,
-    AGENT_REQUEST_STREAM,
     TOOLS,
 )
 
@@ -32,7 +31,7 @@ LANGGRAPH_METHODS = [
         "wrapper_method": atask_iter_wrapper,
         "span_handler": "langgraph_agent_handler",
         "scope_name": "agent.invocation",
-        "output_processor_list": [AGENT_REQUEST_STREAM, AGENT_STREAM],
+        "output_processor": AGENT_STREAM,
     },
     {
         "package": "langgraph.graph.state",

--- a/apptrace/tests/unit/test_file_exporter_idle_timeout.py
+++ b/apptrace/tests/unit/test_file_exporter_idle_timeout.py
@@ -1,0 +1,92 @@
+import datetime as _dt
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from opentelemetry.sdk.resources import SERVICE_NAME
+
+from monocle_apptrace.exporters import file_exporter
+from monocle_apptrace.exporters.file_exporter import FileSpanExporter
+
+
+class _Clock:
+    """Controllable stand-in for `datetime`, returning real datetimes so subtraction/strftime work."""
+    def __init__(self):
+        self.t = _dt.datetime(2026, 1, 1, 0, 0, 0)
+
+    def now(self):
+        return self.t
+
+    def advance(self, seconds):
+        self.t += _dt.timedelta(seconds=seconds)
+
+
+def _span(trace_id, span_id, has_parent=True, span_type=None):
+    attrs = {"monocle_apptrace.version": "test"}
+    if span_type:
+        attrs["span.type"] = span_type
+    return SimpleNamespace(
+        context=SimpleNamespace(trace_id=trace_id, span_id=span_id),
+        parent=SimpleNamespace() if has_parent else None,
+        attributes=attrs,
+        resource=SimpleNamespace(attributes={SERVICE_NAME: "idle_test"}),
+    )
+
+
+class TestFileExporterIdleTimeout(unittest.TestCase):
+    """A trace handle should expire on idle time, not age since creation, so a long-running
+    trace that keeps emitting spans stays in a single file."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.clock = _Clock()
+        self.p = patch.object(file_exporter, "datetime", self.clock)
+        self.p.start()
+        self.exp = FileSpanExporter(
+            service_name="idle_test",
+            out_path=self.tmp,
+            formatter=lambda span: "{}",
+        )
+
+    def tearDown(self):
+        self.exp.shutdown()
+        self.p.stop()
+
+    def _files(self):
+        return sorted(f for f in os.listdir(self.tmp) if f.endswith(".json"))
+
+    def test_active_trace_stays_in_one_file(self):
+        T = 0xABC
+        # Spans keep arriving every 40s for an overall 120s trace (> 60s timeout).
+        self.exp.export([_span(T, 1)])
+        self.clock.advance(40)
+        self.exp.export([_span(T, 2)])
+        self.clock.advance(40)
+        self.exp.export([_span(T, 3)])
+        self.clock.advance(40)
+        # Final batch carries the root: trace completes and the file closes.
+        self.exp.export([_span(T, 4, has_parent=False, span_type="workflow"), _span(T, 5)])
+
+        files = self._files()
+        self.assertEqual(len(files), 1, f"expected one file for an active trace, got {files}")
+        with open(os.path.join(self.tmp, files[0])) as f:
+            self.assertTrue(f.read().rstrip().endswith("]"), "file should be closed")
+
+    def test_idle_trace_is_still_expired(self):
+        T, U = 0xAAA, 0xBBB
+        self.exp.export([_span(T, 1)])
+        self.assertIn(T, self.exp.file_handles)
+        # 70s of silence, then a span for a different trace triggers cleanup.
+        self.clock.advance(70)
+        self.exp.export([_span(U, 9)])
+        self.assertNotIn(T, self.exp.file_handles, "idle trace handle should have been closed")
+        self.assertEqual(self.exp.last_trace_id, T)
+        # T's file is closed (terminated with ']').
+        with open(self.exp.last_file_processed) as f:
+            self.assertTrue(f.read().rstrip().endswith("]"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apptrace/tests/unit/test_langchain_extract_messages.py
+++ b/apptrace/tests/unit/test_langchain_extract_messages.py
@@ -1,0 +1,65 @@
+import json
+import unittest
+from types import SimpleNamespace
+
+from monocle_apptrace.instrumentation.metamodel.langchain._helper import extract_messages
+
+
+class _Msg:
+    def __init__(self, content, type="human"):
+        self.content = content
+        self.type = type
+
+
+class _FakeChatModel:
+    """Stands in for a Runnable chat model (e.g. ChatOpenAI) that ends up as args[0]."""
+
+    def invoke(self, *a, **kw):
+        return None
+
+    async def ainvoke(self, *a, **kw):
+        return None
+
+
+class TestExtractMessagesBoundCall(unittest.TestCase):
+    """Normal bound-method call: args are exactly the call's own positional arguments."""
+
+    def test_messages_list_extracted(self):
+        args = ([_Msg("system prompt", type="system"), _Msg("hi", type="human")],)
+        out = extract_messages(args)
+        self.assertEqual(len(out), 2)
+        self.assertEqual(json.loads(out[1]), {"human": "hi"})
+
+
+class TestExtractMessagesSelfInArgs(unittest.TestCase):
+    """Some callers (e.g. retry decorators that monkeypatch a class attribute and forward the
+    captured call as a plain function invocation) end up passing the model instance itself as
+    the leading positional arg, with no `instance` available via normal descriptor binding.
+    """
+
+    def test_skips_leading_model_instance_by_identity(self):
+        model = _FakeChatModel()
+        messages = [_Msg("system prompt", type="system"), _Msg("hi", type="human")]
+        args = (model, messages)
+        out = extract_messages(args, instance=model)
+        self.assertEqual(len(out), 2)
+        self.assertEqual(json.loads(out[1]), {"human": "hi"})
+
+    def test_skips_leading_model_instance_by_duck_typing(self):
+        # instance=None mirrors what actually happens: Monocle's own instance detection
+        # also comes back empty for this call shape, so identity comparison alone can't help.
+        model = _FakeChatModel()
+        messages = [_Msg("system prompt", type="system"), _Msg("hi", type="human")]
+        args = (model, messages, {"configurable": {"thread_id": "t1"}})
+        out = extract_messages(args, instance=None)
+        self.assertEqual(len(out), 2)
+        self.assertEqual(json.loads(out[1]), {"human": "hi"})
+
+    def test_single_arg_model_only_returns_empty_not_crash(self):
+        model = _FakeChatModel()
+        out = extract_messages((model,), instance=None)
+        self.assertEqual(out, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apptrace/tests/unit/test_langchain_extract_messages.py
+++ b/apptrace/tests/unit/test_langchain_extract_messages.py
@@ -61,5 +61,33 @@ class TestExtractMessagesSelfInArgs(unittest.TestCase):
         self.assertEqual(out, [])
 
 
+class TestExtractMessagesInputShapes(unittest.TestCase):
+    """LanguageModelInput also arrives as a raw string or OpenAI-style dict messages
+    ([{"role", "content"}]); both must populate data.input, not be dropped."""
+
+    def test_string_input(self):
+        # llm.invoke("...") / with_structured_output(...).ainvoke("...")
+        self.assertEqual(extract_messages(("say ok in one word",)), ["say ok in one word"])
+
+    def test_string_input_not_iterated_per_character(self):
+        # Regression: a str must not fall through to per-character iteration (empty result).
+        self.assertNotEqual(extract_messages(("hello",)), [])
+
+    def test_dict_messages(self):
+        out = extract_messages(([{"role": "system", "content": "sys"},
+                                 {"role": "user", "content": "hi"}],))
+        self.assertIn('{"system": "sys"}', out)
+        self.assertIn('{"user": "hi"}', out)
+
+    def test_dict_messages_not_dropped(self):
+        self.assertNotEqual(extract_messages(([{"role": "user", "content": "hi"}],)), [])
+
+    def test_prompt_value_text(self):
+        self.assertEqual(extract_messages((SimpleNamespace(text="hello prompt"),)), ["hello prompt"])
+
+    def test_empty_args(self):
+        self.assertEqual(extract_messages(()), [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/apptrace/tests/unit/test_langgraph_astream_nesting.py
+++ b/apptrace/tests/unit/test_langgraph_astream_nesting.py
@@ -1,0 +1,80 @@
+import types
+import unittest
+
+from monocle_apptrace.instrumentation.common.scope_wrapper import start_scope, stop_scope
+from monocle_apptrace.instrumentation.metamodel.langgraph.entities.inference import (
+    AGENT,
+    AGENT_REQUEST,
+    AGENT_REQUEST_STREAM,
+    AGENT_STREAM,
+)
+from monocle_apptrace.instrumentation.metamodel.langgraph.langgraph_processor import (
+    LanggraphAgentHandler,
+)
+from monocle_apptrace.instrumentation.metamodel.langgraph.methods import LANGGRAPH_METHODS
+
+
+def _fake_graph():
+    """A CompiledStateGraph-shaped stand-in that looks like a single-agent instance."""
+    graph = types.SimpleNamespace()
+    graph.builder = types.SimpleNamespace(nodes={"agent": None})
+    graph.name = "test_graph"
+    return graph
+
+
+class TestLanggraphAstreamRegistryDefault(unittest.TestCase):
+    """astream's registry default must be invocation-only, matching invoke/ainvoke/astream_events.
+
+    Regression guard: a graph's own ainvoke() commonly delegates internally to astream()
+    (or a genuinely nested sub-agent graph is invoked via astream()). pre_tracing() falls back
+    to this registry default whenever it detects we're already inside an agentic turn/invocation
+    scope (is_scope_set() True). If that default escalates to [turn, invocation] unconditionally
+    (as it used to), every such nested call emits a redundant extra 'agentic.turn' span.
+    """
+
+    def test_astream_default_is_single_invocation_processor(self):
+        entry = next(m for m in LANGGRAPH_METHODS if m["method"] == "astream")
+        self.assertNotIn("output_processor_list", entry)
+        self.assertIs(entry.get("output_processor"), AGENT_STREAM)
+
+    def test_invoke_and_ainvoke_default_is_single_invocation_processor(self):
+        for method in ("invoke", "ainvoke"):
+            entry = next(m for m in LANGGRAPH_METHODS if m["method"] == method)
+            self.assertNotIn("output_processor_list", entry)
+            self.assertIs(entry.get("output_processor"), AGENT)
+
+
+class TestLanggraphPreTracingNesting(unittest.TestCase):
+    """pre_tracing() must only escalate to a [turn, invocation] pair for the outermost call."""
+
+    def setUp(self):
+        self.handler = LanggraphAgentHandler()
+        self.instance = _fake_graph()
+
+    def _to_wrap(self, method):
+        return dict(next(m for m in LANGGRAPH_METHODS if m["method"] == method))
+
+    def test_outermost_astream_escalates_to_turn_and_invocation(self):
+        token, alternate = self.handler.pre_tracing(self._to_wrap("astream"), None, self.instance, (), {})
+        try:
+            self.assertIsNotNone(alternate)
+            self.assertEqual(
+                alternate["output_processor_list"], [AGENT_REQUEST_STREAM, AGENT_STREAM]
+            )
+        finally:
+            stop_scope(token)
+
+    def test_nested_astream_does_not_reescalate(self):
+        scope_name = AGENT_REQUEST.get("type")
+        outer_token = start_scope(scope_name, scope_value="already-in-a-turn")
+        try:
+            _, alternate = self.handler.pre_tracing(self._to_wrap("astream"), None, self.instance, (), {})
+            # Falls back to the registry default (single AGENT_STREAM processor) -> no
+            # redundant 'turn' span for this nested call.
+            self.assertIsNone(alternate)
+        finally:
+            stop_scope(outer_token)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apptrace/tests/unit/test_langgraph_state_io.py
+++ b/apptrace/tests/unit/test_langgraph_state_io.py
@@ -1,3 +1,4 @@
+import dataclasses
 import json
 import unittest
 
@@ -12,6 +13,22 @@ class _Msg:
     def __init__(self, content, type="ai"):
         self.content = content
         self.type = type
+
+
+@dataclasses.dataclass
+class _DataclassState:
+    messages: list
+    tool_iterations: int = 0
+
+
+class _PydanticLikeState:
+    """Stands in for a Pydantic BaseModel-based StateGraph schema (v1 or v2)."""
+
+    model_fields = {"messages", "task"}
+
+    def __init__(self, messages=None, task=None):
+        self.messages = messages or []
+        self.task = task
 
 
 class TestLanggraphMessageStateIO(unittest.TestCase):
@@ -47,6 +64,35 @@ class TestLanggraphCustomStateIO(unittest.TestCase):
     def test_empty_state_returns_empty(self):
         self.assertEqual(_helper.extract_agent_input({"kwargs": {"input": {}}, "args": []}), "")
         self.assertEqual(_helper.extract_agent_response({}), "")
+
+
+class TestLanggraphDataclassAndPydanticStateIO(unittest.TestCase):
+    """Custom StateGraphs commonly use a dataclass or Pydantic BaseModel schema instead of a
+    TypedDict. A nested sub-agent graph called with such a state (e.g. `self._graph.ainvoke(state)`
+    where state is a @dataclass) must still have its human message / state extracted, not silently
+    dropped because extract_agent_input only recognized plain dicts."""
+
+    def test_dataclass_state_message_extracted(self):
+        state = _DataclassState(messages=[_Msg("hello", type="human")])
+        out = _helper.extract_agent_input({"kwargs": {}, "args": [state]})
+        self.assertEqual(json.loads(out), ["hello"])
+
+    def test_pydantic_like_state_message_extracted(self):
+        state = _PydanticLikeState(messages=[_Msg("hello", type="human")])
+        out = _helper.extract_agent_input({"kwargs": {}, "args": [state]})
+        self.assertEqual(json.loads(out), ["hello"])
+
+    def test_dataclass_state_without_human_message_serialized(self):
+        state = _DataclassState(messages=[_Msg("assistant reply", type="ai")], tool_iterations=2)
+        out = _helper.extract_agent_input({"kwargs": {}, "args": [state]})
+        self.assertEqual(json.loads(out), ["assistant reply"])
+
+    def test_plain_object_state_returns_empty_not_crash(self):
+        class _NotAState:
+            pass
+
+        out = _helper.extract_agent_input({"kwargs": {}, "args": [_NotAState()]})
+        self.assertEqual(out, "")
 
 
 class TestLanggraphStreamFallback(unittest.TestCase):

--- a/apptrace/tests/unit/test_langgraph_state_io.py
+++ b/apptrace/tests/unit/test_langgraph_state_io.py
@@ -1,0 +1,84 @@
+import json
+import unittest
+
+from monocle_apptrace.instrumentation.metamodel.langgraph import _helper
+from monocle_apptrace.instrumentation.metamodel.langgraph.langgraph_stream_processor import (
+    LanggraphStreamProcessor,
+)
+from monocle_apptrace.instrumentation.common.stream_processor import StreamState
+
+
+class _Msg:
+    def __init__(self, content, type="ai"):
+        self.content = content
+        self.type = type
+
+
+class TestLanggraphMessageStateIO(unittest.TestCase):
+    """Message-based graphs keep extracting message text (no behavior change)."""
+
+    def test_message_input_preferred(self):
+        state = {"messages": [_Msg("hello", type="human")]}
+        out = _helper.extract_agent_input({"kwargs": {"input": state}, "args": []})
+        self.assertEqual(json.loads(out), ["hello"])
+
+    def test_message_output_preferred(self):
+        state = {"messages": [_Msg("the answer")]}
+        self.assertEqual(_helper.extract_agent_response(state), "the answer")
+
+
+class TestLanggraphCustomStateIO(unittest.TestCase):
+    """Custom (non message-based) StateGraphs must still carry their I/O, serialized."""
+
+    def test_custom_input_serialized(self):
+        state = {"task": {"query": "Is AI in a hype cycle?"}}
+        out = _helper.extract_agent_input({"kwargs": {"input": state}, "args": []})
+        self.assertEqual(json.loads(out), state)
+
+    def test_custom_input_from_positional_args(self):
+        state = {"task": {"query": "q"}}
+        out = _helper.extract_agent_input({"kwargs": {}, "args": [state]})
+        self.assertEqual(json.loads(out), state)
+
+    def test_custom_output_serialized(self):
+        state = {"task": {"query": "q"}, "report": "final report text"}
+        self.assertEqual(json.loads(_helper.extract_agent_response(state)), state)
+
+    def test_empty_state_returns_empty(self):
+        self.assertEqual(_helper.extract_agent_input({"kwargs": {"input": {}}, "args": []}), "")
+        self.assertEqual(_helper.extract_agent_response({}), "")
+
+
+class TestLanggraphStreamFallback(unittest.TestCase):
+    """astream of a custom StateGraph yields plain state dicts (no message channel);
+    the stream processor must fall back to the last state snapshot."""
+
+    def _run(self, items):
+        proc = LanggraphStreamProcessor()
+        state = StreamState()
+        for item in items:
+            proc.process_fragment(item, state)
+        proc.assemble_data(state)
+        return state.accumulated_response
+
+    def test_values_mode_snapshot(self):
+        chunks = [
+            {"task": {"query": "q"}},
+            {"task": {"query": "q"}, "report": "done"},
+        ]
+        out = self._run(chunks)
+        self.assertEqual(json.loads(out), chunks[-1])
+
+    def test_message_chunks_still_win(self):
+        chunks = [{"messages": [_Msg("streamed answer")]}]
+        out = self._run(chunks)
+        self.assertEqual(out, "streamed answer")
+
+    def test_tuple_values_mode_snapshot(self):
+        chunks = [("values", {"task": {"query": "q"}, "report": "final"})]
+        out = self._run(chunks)
+        self.assertEqual(json.loads(out), {"task": {"query": "q"}, "report": "final"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apptrace/tests/unit/test_span_handler_scope_coercion.py
+++ b/apptrace/tests/unit/test_span_handler_scope_coercion.py
@@ -1,0 +1,44 @@
+import unittest
+import uuid
+from unittest.mock import MagicMock, patch
+from opentelemetry.sdk.trace import Span
+
+from monocle_apptrace.instrumentation.common.span_handler import SpanHandler
+
+
+class TestScopeValueCoercion(unittest.TestCase):
+    """Scope values derived from app objects (e.g. a UUID thread_id) must be coerced to
+    OTEL-valid attribute types, otherwise OTEL drops them and the run loses its session anchor."""
+
+    def test_primitives_pass_through(self):
+        for value in ["s", b"b", 1, 1.5, True]:
+            self.assertIs(SpanHandler._coerce_scope_value(value), value)
+
+    def test_primitive_sequences_pass_through(self):
+        value = ["a", "b"]
+        self.assertIs(SpanHandler._coerce_scope_value(value), value)
+
+    def test_uuid_is_stringified(self):
+        u = uuid.uuid4()
+        coerced = SpanHandler._coerce_scope_value(u)
+        self.assertEqual(coerced, str(u))
+        self.assertIsInstance(coerced, str)
+
+    def test_object_is_stringified(self):
+        self.assertEqual(SpanHandler._coerce_scope_value({"a": 1}), str({"a": 1}))
+
+    def test_default_attributes_stringify_uuid_scope(self):
+        attrs = {}
+        span = MagicMock(spec=Span)
+        span.set_attribute = MagicMock(side_effect=lambda k, v: attrs.__setitem__(k, v))
+        u = uuid.uuid4()
+        with patch(
+            "monocle_apptrace.instrumentation.common.span_handler.get_scopes",
+            return_value={"agentic.session": u},
+        ), patch.object(SpanHandler, "get_workflow_name", return_value=None):
+            SpanHandler.set_default_monocle_attributes(span)
+        self.assertEqual(attrs["scope.agentic.session"], str(u))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apptrace/tests/unit/test_wrapper_workflow_span_paths.py
+++ b/apptrace/tests/unit/test_wrapper_workflow_span_paths.py
@@ -150,6 +150,41 @@ class TestWorkflowSpanPaths(unittest.IsolatedAsyncioTestCase):
         workflow_span.set_status.assert_called_once_with(StatusCode.ERROR, "boom-stream")
         workflow_span.end.assert_called_once()
 
+    def test_sync_iter_parent_workflow_span_sets_error_and_ends_on_child_failure(self):
+        workflow_span = MagicMock(name="workflow_span")
+        child_span = MagicMock(name="child_span")
+        spans = iter([workflow_span, child_span])
+        handler = MagicMock()
+
+        def failing_stream(*args, **kwargs):
+            raise RuntimeError("boom-sync-stream")
+            yield  # pragma: no cover
+
+        with (
+            self._common_patches(),
+            self._span_handler_patches(remote_parent_side_effect=[False, False]),
+            patch(
+                "monocle_apptrace.instrumentation.common.wrapper.start_as_monocle_span",
+                side_effect=lambda *args, **kwargs: _span_context_manager(next(spans)),
+            ),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "boom-sync-stream"):
+                for _ in wrapper.monocle_iter_wrapper_span_processor(
+                    tracer=MagicMock(),
+                    handler=handler,
+                    to_wrap=self._base_to_wrap(auto_close=False),
+                    wrapped=failing_stream,
+                    instance=MagicMock(),
+                    source_path="/tmp/source.py",
+                    add_workflow_span=True,
+                    args=(),
+                    kwargs={},
+                ):
+                    pass
+
+        workflow_span.set_status.assert_called_once_with(StatusCode.ERROR, "boom-sync-stream")
+        workflow_span.end.assert_called_once()
+
     def _stacked_to_wrap(self, intermediate_auto_close=False, leaf_auto_close=True):
         """to_wrap with two stacked processors; the intermediate (has_more) span is non-auto-close."""
         proc_a = {"is_auto_close": lambda kwargs: leaf_auto_close}
@@ -262,6 +297,45 @@ class TestWorkflowSpanPaths(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(items, ["chunk-1", "chunk-2"])
         # The exact nested-subgraph-streaming case that was orphaned before the fix.
+        intermediate_span.end.assert_called_once()
+
+    def test_sync_iter_intermediate_nonautoclose_span_is_ended(self):
+        intermediate_span = MagicMock(name="intermediate_span")
+        leaf_span = MagicMock(name="leaf_span")
+        spans = iter([intermediate_span, leaf_span])
+        handler = MagicMock()
+        handler.should_skip.return_value = False
+
+        def streaming_wrapped(*args, **kwargs):
+            yield "chunk-1"
+            yield "chunk-2"
+
+        with (
+            self._common_patches(),
+            self._span_handler_patches(remote_parent_side_effect=[False] * 10),
+            patch(
+                "monocle_apptrace.instrumentation.common.wrapper.start_as_monocle_span",
+                side_effect=lambda *args, **kwargs: _span_context_manager(next(spans)),
+            ),
+        ):
+            items = []
+            for item in wrapper.monocle_iter_wrapper_span_processor(
+                tracer=MagicMock(),
+                handler=handler,
+                to_wrap=self._stacked_to_wrap(intermediate_auto_close=False),
+                wrapped=streaming_wrapped,
+                instance=MagicMock(),
+                source_path="/tmp/source.py",
+                add_workflow_span=False,
+                args=(),
+                kwargs={},
+            ):
+                items.append(item)
+
+        self.assertEqual(items, ["chunk-1", "chunk-2"])
+        # Sync counterpart of the nested-subgraph-streaming orphan case: a sync
+        # generator method (e.g. CompiledStateGraph.stream) must close its
+        # intermediate span too.
         intermediate_span.end.assert_called_once()
 
     def test_remote_parent_span_triggers_workflow_recursion_path(self):


### PR DESCRIPTION
## Summary

Six gaps surfaced while instrumenting real multi-agent LangGraph apps with Monocle and grading the emitted trace against the agentic good-trace recipe: three from gpt-researcher's `multi_agents` editorial pipeline, one from NVIDIA's AI-Q blueprint (`nvidia-aiq`, built on the NeMo Agent Toolkit), one from Arvo's Aurora autonomous-SRE agent (`aurora-sre`, LangChain/LangGraph 1.x), and one from ByteDance DeerFlow (`deer-flow`, a LangGraph deep-research super-agent). All are fixed here with unit coverage; the existing suite stays green (no new failures).

Final result: a single trace file that is **ALL PASS** against the recipe, on all four apps.

## Gap 1 — `scope.agentic.session` dropped (run not anchored)

**Symptom:** repeated `Invalid type UUID for attribute 'scope.agentic.session'` at runtime; no session scope on any span.

**Root cause:** the app passes `config.configurable.thread_id` as a `uuid.UUID`. The LangGraph processor derives the session scope from it and `SpanHandler` set it as an OTEL attribute as-is. OTEL only accepts primitives (or sequences of them), so the value was silently dropped.

**Fix:** `SpanHandler._coerce_scope_value` coerces any scope value that isn't an OTEL primitive (or a sequence of primitives) to `str` before `set_attribute`, at both scope-writing sites. Framework-agnostic.

## Gap 2 — empty agentic I/O for custom (non message-based) StateGraphs

**Symptom:** every `agentic.turn` / `agentic.invocation` span had empty `data.input` and `data.output`.

**Root cause:** `extract_agent_input` / `extract_agent_response` and `LanggraphStreamProcessor` only read `*messages` channels. gpt-researcher uses a custom `StateGraph` keyed by `task`/`sections`/`report` (no message channel), so the data — present on the call — was filtered out to `""`.

**Fix:** when no message content is found, the accessors fall back to serializing the state object, and the stream processor falls back to the last streamed state snapshot. Message-based graphs are unaffected (message extraction still takes precedence).

## Gap 3 — a single long trace split across multiple files

**Symptom:** one multi-minute agentic turn (one trace_id) produced several `.monocle` files, ~60s apart; the root `workflow` span landed only in the last file.

**Root cause:** `FileSpanExporter` force-closed a trace's file handle once it was older than `HANDLE_TIMEOUT_SECONDS` measured from **creation**, so any trace running longer than the timeout got a new file every 60s even while still actively emitting spans.

**Fix:** measure the timeout from the **last span written** (idle time) instead of creation age. An actively streaming trace stays in one file; a genuinely stalled trace is still cleaned up after the idle window.

## Gap 4 — nvidia-aiq: redundant turn nesting, dataclass state I/O, and self-leaked args

**Symptom (a):** one user question produced 3 nested `agentic.turn` spans instead of 1 (turn-under-invocation-under-turn).

**Root cause (a):** `CompiledStateGraph.astream()`'s registry entry unconditionally built a `[AGENT_REQUEST_STREAM, AGENT_STREAM]` (turn + invocation) processor pair. LangGraph's own `ainvoke()` commonly delegates internally to `astream()`, and genuinely nested sub-agent graphs are also invoked via `astream()`. `pre_tracing()` already collapses `invoke`/`ainvoke` to a single invocation-only span for these nested calls (falling back to the registry default once a turn scope is already active), but `astream()`'s registry default never had an invocation-only form to fall back to.

**Fix (a):** default `astream()`'s registry entry to `AGENT_STREAM` alone, matching `invoke`/`ainvoke`/`astream_events`. The outermost call still escalates to the full `[turn, invocation]` pair via the existing `pre_tracing()` logic.

**Symptom (b):** `agentic.invocation` spans for a sub-agent (`shallow_researcher`) had empty `data.input`.

**Root cause (b):** `extract_agent_input` (and its shared helpers `_human_messages_from_state`, `_last_message_content_from_state`) only recognized plain `dict` states. nvidia-aiq's `shallow_researcher` agent uses a `@dataclass` `StateGraph` schema (`ShallowResearchAgentState`), so `args[0]` was never a `dict`.

**Fix (b):** add `_as_state_dict()` to shallowly normalize dataclass/Pydantic states to a dict (no recursive serialization, so nested message objects keep their attributes) before the existing channel-introspection logic runs.

**Symptom (c):** every `inference.framework` span for `BaseChatModel.ainvoke` had empty `data.input` despite `data.output`/`metadata` being captured correctly.

**Root cause (c):** `extract_messages()` assumed `args[0]` is always the messages list. NAT's retry decorator monkeypatches a class attribute and forwards the captured call as a plain function invocation rather than a bound method call, so the `ChatOpenAI` instance itself ends up as the leading positional arg — with Monocle's own `instance` detection also coming back empty for that call shape.

**Fix (c):** skip a leading arg that's either the same object as the detected instance, or duck-types as a Runnable chat model (exposes `invoke`/`ainvoke`, isn't a message).

## Gap 5 — aurora-sre: empty `data.input` for string and dict-message model inputs

**Symptom:** on aurora-sre, ~93% of `inference.framework` spans (`BaseChatModel.invoke`/`ainvoke`) had empty `data.input`, while `data.output` and token metadata were captured correctly.

**Root cause:** `extract_messages()` only recognized a `PromptValue` (via `.text`) and a list of `BaseMessage` objects. LangChain's `LanguageModelInput` also accepts (1) a **raw string** — `llm.invoke("...")` and `with_structured_output(...).ainvoke("...")` (aurora-sre's triage / synthesis / visualization), and (2) **OpenAI-style dict messages** `[{"role": ..., "content": ...}]` (the NeMo-Guardrails safety judge). A string fell through to `for msg in args[0]` and was iterated **character by character**; dict messages failed the `hasattr(msg, 'content')` / `hasattr(msg, 'type')` attribute checks (those are dict keys, not attributes). Both produced an empty result, so `data.input` was dropped.

**Fix:** add a `str` branch (return the prompt as-is) and a dict-message branch (`{role or type: content}`) to `extract_messages`, ahead of the existing `BaseMessage` handling and layered on top of the Gap-4c leaked-instance skip. All previously-handled shapes (PromptValue, BaseMessage list, tool-call messages) are unchanged.

## Gap 6 — `CompiledStateGraph.stream` (sync streaming) not instrumented

**The gap:** Monocle's LangGraph coverage is asymmetric across the sync/async axis. `CompiledStateGraph` exposes four ways to drive a graph, and Monocle wrapped only three of them:

| method | call shape | Monocle wrapper | instrumented? |
|---|---|---|---|
| `invoke` | sync function | `task_wrapper` | ✅ |
| `ainvoke` | coroutine | `atask_wrapper` | ✅ |
| `astream` | async generator | `atask_iter_wrapper` | ✅ |
| **`stream`** | **sync generator** | **— none —** | ❌ |

`stream` is a first-class, public LangGraph API — the sync peer of `astream` (both are `Pregel.stream`/`astream`), and the natural entry point for any synchronous caller. It was simply never registered. More fundamentally, this wasn't a one-line omission: Monocle shipped wrappers for the sync-function, async-function, and async-generator call shapes, but **had no sync-generator wrapper primitive at all** — so `stream` could not be instrumented even by adding a registry entry, because there was nothing correct to point it at.

**Consequence:** any application that drives a graph with `graph.stream(...)` gets **no instrumentation at that entry point** — no root `workflow` / `agentic.turn` / `agentic.invocation` span. Because the top-level run is never captured, the LLM/tool spans it produces are not anchored under a single agent run: they fragment into multiple disconnected traces with no shared `scope.agentic.session`.

**Why the existing sync wrapper can't cover it:** registering `stream` against `task_wrapper` (the sync *function* wrapper) does not work. `task_wrapper` calls `wrapped(*args)`, which for a generator returns the generator object *without running its body*, then closes the span immediately — so the entire streamed execution runs *after* the span has already ended and escapes it. A generator's span must stay open across the whole iteration; that is exactly why `astream` needs the async-generator wrapper (`atask_iter_wrapper`) rather than `atask_wrapper`. The sync side needed the same primitive, which didn't exist.

**Fix:** add the missing quadrant. Introduce `monocle_iter_wrapper_span_processor` / `monocle_iter_wrapper` / `task_iter_wrapper` — a line-for-line sync mirror of the async-generator machinery (`async def`→`def`, `async for`→`for`, drop `await`); no existing code paths change. Register `CompiledStateGraph.stream` against `task_iter_wrapper` with `output_processor=AGENT_STREAM` (invocation-only), identical to `astream`'s post-Gap-4a entry, so `pre_tracing` escalates only the outermost call to a turn and nested sync streams stay invocation-only (no redundant turn nesting). Add `"stream"` to `is_streaming_call` in `pre_tracing` so the outermost sync stream selects the streaming turn+invocation processors, consistent with `astream`.

*Surfaced on* ByteDance DeerFlow, whose embedded in-process client drives the graph with the idiomatic sync `agent.stream(...)` (deliberately sync — it avoids spinning up an event loop for synchronous callers); before the fix, one request fragmented into 3–4 disconnected, session-less traces. The `task_wrapper`-only shortcut was verified insufficient (still 4 fragmented traces) before writing the wrapper.

## Before / after (gpt-researcher, query "Is AI in a hype cycle?")

| | before | after |
|---|---|---|
| `scope.agentic.session` | dropped (UUID rejected) | present + shared across the run |
| `agentic.turn` / `agentic.invocation` I/O | `{}` / `{}` | populated (task input → final state with `research_data`/`report`) |
| `inference.framework` token metadata | n/a | non-zero on every inference span |
| files per turn | 3 (same trace_id, split) | 1 |
| recipe grade | FAIL | ALL PASS |

Trace shape: `workflow → agentic.turn → agentic.invocation → inference.framework → inference.modelapi`. (0 `agentic.tool.invocation` is faithful — the app drives search via retrievers, captured as `retrieval` spans, not LangChain `Tool` objects.)

## Before / after (nvidia-aiq, query "Give a concise 3-bullet overview of what retrieval-augmented generation (RAG) is.")

| | before | after |
|---|---|---|
| `agentic.turn` spans for 1 question | 3 (nested turn-under-invocation-under-turn) | 1 |
| `agentic.invocation` `data.input` (shallow_researcher) | `{}` | populated (dataclass state, serialized) |
| `inference.framework` `data.input` (`BaseChatModel.ainvoke`) | `{}` on every call | populated on every call |
| recipe grade | FAIL | ALL PASS |

Trace shape: `workflow → agentic.turn → agentic.invocation (intent classifier) → {inference.framework → inference.modelapi, agentic.invocation (shallow_researcher) → {inference.framework → inference.modelapi, agentic.tool.invocation}}`.

## Before / after (aurora-sre, incident "search-service 500s + heap growth after the 09:45 index-rebuild")

| | before | after |
|---|---|---|
| `inference.framework` `data.input` | `{}` on ~93% of calls | populated on 41/41 |
| `agentic.turn` / `agentic.invocation` / `agentic.tool.invocation` I/O | — | populated (1/1, 3/3, 3/3) |
| `agentic.turn` count for 1 RCA | (redundant) | 1 |
| recipe grade (I/O) | FAIL | ALL PASS |

Note: aurora-sre also runs many LLM calls in separate execution contexts (per-sub-agent `asyncio` loops inside a Celery task, NeMo-Guardrails, summarization), which each emit their own session-less trace — a session-anchoring / fragmentation concern that sits at the app-architecture boundary and is **not** addressed here.

## Before / after (deer-flow, query delegating MCP research to a general-purpose subagent)

| | before | after |
|---|---|---|
| root `workflow` span (sync `stream` entry) | absent | present |
| trace files per request | 3–4 (disconnected, no shared session) | 1 (connected) |
| `scope.agentic.session` | none / not anchored | present + shared across the run |
| `agentic.turn` count for 1 request | (none captured) | 1 |
| nested subagent (`astream`) typing | — | `agentic.invocation` under the `task` tool (no redundant turn, inherits Gap 4a) |
| I/O on inference/tool/invocation spans | — | populated on every span |
| recipe grade | FAIL | ALL PASS |

Trace shape: `workflow → agentic.turn → agentic.invocation → {inference.framework → inference.modelapi, agentic.tool.invocation (task) → agentic.invocation (subagent astream) → {inference.framework → inference.modelapi, agentic.tool.invocation (web_search)}}`.

## Tests

- `tests/unit/test_span_handler_scope_coercion.py` — primitives pass through, UUID/objects stringified, end-to-end `set_default_monocle_attributes`.
- `tests/unit/test_langgraph_state_io.py` — message graphs unchanged; custom-state input/output serialized; streaming fallback; new `TestLanggraphDataclassAndPydanticStateIO` class for Gap 4b.
- `tests/unit/test_file_exporter_idle_timeout.py` — active trace stays in one file across a >60s span; idle trace still expired.
- `tests/unit/test_langgraph_astream_nesting.py` (Gap 4a) — `astream` registry default is invocation-only; `pre_tracing()` escalates only the outermost call, never re-escalates a nested one.
- `tests/unit/test_langchain_extract_messages.py` (Gaps 4c + 5) — Gap 4c: a leaked leading model instance is skipped by identity and duck-typing. Gap 5: raw-string and OpenAI-style dict-message inputs populate `data.input`; PromptValue `.text`, BaseMessage list and empty-args covered.
- `tests/unit/test_wrapper_workflow_span_paths.py` (Gap 6) — sync-generator wrapper paths: the parent workflow span sets error status and ends on child failure, and a non-auto-close intermediate span is ended (mirrors the async-iter cases; fail without the sync-generator wrapper, pass with it).

Unit suite: 391 passed on `main` for Gaps 1-3 (pre-existing failures/errors unrelated, missing optional deps / order-dependent). For Gaps 4-5, all reachable langgraph/langchain unit tests pass (88 in the instrumented run env). For Gap 6, a clean full unit run (deer-flow env): **494 passed, 6 pre-existing unrelated failures, zero new** (`test_cli_validate_command` ×3, `test_exporter_config`, `test_linter_validator`, `test_reset_span_processor` — all fail identically on the base without this change); LangGraph stream integration suite green, including the previously-failing `test_sync_stream_chat_sample`.

Note (deer-flow, out of scope): the delegated subagent runs `astream` inside an isolated event loop on a separate daemon thread; OTel scope lives in `contextvars`, which don't cross a thread boundary — a session-anchoring concern at the app-architecture boundary, not addressed here. With Gap 4a's invocation-only `astream` default, the subagent nonetheless types cleanly as an `agentic.invocation` under the `task` tool.

🤖 Generated with the ok:instrument-monocle skill


