### PR TITLE
langchain: capture data.input for string and dict-message model inputs

### DIFF
--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/langchain/_helper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/langchain/_helper.py
@@ -29,6 +29,10 @@ def extract_messages(args):
         if args and isinstance(args, (list, tuple)) and hasattr(args[0], 'text'):
             return [args[0].text]
         if args and isinstance(args, (list, tuple)) and len(args) > 0:
+            if isinstance(args[0], str):
+                # A model invoked with a raw string prompt (e.g. llm.invoke("...")
+                # or with_structured_output(...).ainvoke("..."))
+                return [args[0]]
             if isinstance(args[0], list) and len(args[0]) > 0:
                 first_msg = args[0][0]
                 if hasattr(first_msg, 'content') and hasattr(first_msg, 'type') and first_msg.type == "human":
@@ -39,7 +43,10 @@ def extract_messages(args):
                         messages.append({msg.type: msg.content})
             else:
                 for msg in args[0]:
-                    if hasattr(msg, 'content') and hasattr(msg, 'type') and msg.content:
+                    if isinstance(msg, dict) and msg.get('content'):
+                        # OpenAI-style dict message: {"role": ..., "content": ...}
+                        messages.append({msg.get('role') or msg.get('type') or 'user': msg['content']})
+                    elif hasattr(msg, 'content') and hasattr(msg, 'type') and msg.content:
                         messages.append({msg.type: msg.content})
                     elif hasattr(msg, 'tool_calls') and msg.tool_calls:
                         messages.append({msg.type: get_json_dumps(msg.tool_calls)})

--- a/apptrace/tests/unit/test_langchain_extract_messages.py
+++ b/apptrace/tests/unit/test_langchain_extract_messages.py
@@ -1,0 +1,56 @@
+import unittest
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.prompt_values import ChatPromptValue
+
+from monocle_apptrace.instrumentation.metamodel.langchain._helper import extract_messages
+
+
+class TestExtractMessages(unittest.TestCase):
+    """`extract_messages` receives the positional args of BaseChatModel.invoke/ainvoke,
+    i.e. args[0] is the model input, which LangChain accepts as a str, a PromptValue,
+    or a list of BaseMessage."""
+
+    def test_string_input(self):
+        # llm.invoke("...") / with_structured_output(...).ainvoke("...")
+        self.assertEqual(extract_messages(("say ok in one word",)), ["say ok in one word"])
+
+    def test_string_input_not_iterated_per_character(self):
+        # Regression: a str must not fall through to per-character iteration (which
+        # yielded an empty result and dropped data.input entirely).
+        self.assertNotEqual(extract_messages(("hello",)), [])
+
+    def test_message_list(self):
+        out = extract_messages(([SystemMessage(content="You are terse."),
+                                 HumanMessage(content="Reply blue.")],))
+        self.assertIn('{"system": "You are terse."}', out)
+        self.assertIn('{"human": "Reply blue."}', out)
+
+    def test_prompt_value(self):
+        out = extract_messages((ChatPromptValue(messages=[SystemMessage(content="sys"),
+                                                          HumanMessage(content="hi")]),))
+        self.assertIn('{"system": "sys"}', out)
+        self.assertIn('{"human": "hi"}', out)
+
+    def test_dict_messages(self):
+        # LangChain accepts OpenAI-style dict messages: [{"role", "content"}]
+        out = extract_messages(([{"role": "system", "content": "sys"},
+                                 {"role": "user", "content": "hi"}],))
+        self.assertIn('{"system": "sys"}', out)
+        self.assertIn('{"user": "hi"}', out)
+
+    def test_dict_messages_not_dropped(self):
+        # Regression: dict messages must not be silently dropped (empty result).
+        self.assertNotEqual(extract_messages(([{"role": "user", "content": "hi"}],)), [])
+
+    def test_tool_call_message(self):
+        msg = AIMessage(content="", tool_calls=[{"name": "t", "args": {}, "id": "1"}])
+        out = extract_messages(([msg],))
+        self.assertTrue(out and "tool_call" in out[0])
+
+    def test_empty_args(self):
+        self.assertEqual(extract_messages(()), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Proposed changes

`extract_messages` (LangChain metamodel) builds the `data.input` event for
`inference.framework` spans. It only handled two of LangChain's input shapes:
a `PromptValue` (via `.text`) and a list of `BaseMessage` objects. But
`BaseChatModel.invoke`/`ainvoke` accept `LanguageModelInput`, which also
includes:

- **a raw string** — `llm.invoke("some prompt")`, or
  `llm.with_structured_output(...).ainvoke("some prompt")`; and
- **OpenAI-style dict messages** — `[{"role": "user", "content": "..."}]`.

For a string, the code fell through to `for msg in args[0]`, iterating the
string **character by character** (no char has `.content`/`.type`), so nothing
was collected. For dict messages, the `hasattr(msg, 'content')` /
`hasattr(msg, 'type')` checks fail (those are dict keys, not attributes). In
both cases `data.input` was emitted **empty**, silently dropping the prompt.

This surfaced while instrumenting a real LangChain/LangGraph **1.x** multi-agent
app (an autonomous SRE agent). Its triage, synthesis and NeMo-Guardrails LLM
calls invoke with strings and dict messages, so **~93% of `inference.framework`
spans had no `data.input`**. With this fix, **all 51 `inference.framework`
spans in a multi-agent RCA run carry `data.input`** (and `data.output`/token
metadata were already correct).

The change is additive — two new branches (`str` and `dict` message) ahead of
the existing PromptValue/BaseMessage handling; all previously-handled shapes
behave identically.

## Types of changes

What types of changes does your code introduce to this project?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] I have signed the CLA (commit is DCO `Signed-off-by`)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate) — n/a, no doc surface
- [ ] Any dependent changes have been merged and published in downstream modules — n/a, self-contained

## Further comments

New unit test `test_langchain_extract_messages.py` covers string, dict-message,
`BaseMessage` list, `PromptValue`, tool-call and empty-args inputs. Ran the
LangChain / inference-helper unit suites (`test_langchain_extract_messages`,
`test_langchain_bedrock`, `test_langchain_finish_reason_helpers`,
`test_span_filter`, `test_vectorstore_deployment`, gemini/azure finish-reason)
— **99 passed, 95 subtests passed**, no regressions.

Kept the fix minimal (only the two missing input shapes). Considered also
handling tuple messages (`("user", "...")`), but that shape wasn't exercised by
the target app, so it's left out to keep the change scoped.
