### PR TITLE
Monocle2AI project governance proposal

### DIFF
--- a/CODEOWNERS.md
+++ b/CODEOWNERS.md
@@ -1,10 +1,25 @@
-#MAINTAINERS
-Following is the current list of maintainers on this project
 
-The maintainers are listed in alphabetical order.
+## TSC
+Following is the current list of TSC members on this project.
 
-- [@prasad-okahu] (https://github.com/prasad-okahu) (Prasad Mujumdar)
-- [@oi-raanne] (https://github.com/oi-raanne) (Ravi Anne)
-- [@akshay-okahu](https://github.com/akshay-okahu) (Akshay Yadav)
-- [@anshul7665] (https://github.com/anshul7665) (Anshul Sharma)
-- [@kshitiz-okahu] (https://github.com/kshitiz-okahu) (Kshitiz Vijayvargiya)
+| ID | Name | Affiliation
+|---|---|---|
+| [@prasad-okahu](https://github.com/prasad-okahu) | Prasad Mujumdar | Okahu |
+| [@oi-raanne](https://github.com/oi-raanne) | Ravi Anne | no affiliation |
+| [@akshay-okahu](https://github.com/akshay-okahu) | Akshay Yadav | Okahu |
+| [@anshul7665](https://github.com/anshul7665) | Anshul Sharma | Okahu |
+| [@kshitiz-okahu](https://github.com/kshitiz-okahu) | Kshitiz Vijayvargiya | Further AI |
+
+### TSC Chair
+TBD
+
+## MAINTAINERS
+Following is the current list of maintainers on this project.
+| ID | Name |
+|---|---|
+| [@prasad-okahu](https://github.com/prasad-okahu) | Prasad Mujumdar | Okahu |
+| [@oi-raanne](https://github.com/oi-raanne) | Ravi Anne | no affiliation |
+| [@akshay-okahu](https://github.com/akshay-okahu) | Akshay Yadav | Okahu |
+| [@anshul7665](https://github.com/anshul7665) | Anshul Sharma | Okahu |
+| [@kshitiz-okahu](https://github.com/kshitiz-okahu) | Kshitiz Vijayvargiya | Further AI |
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,5 +39,6 @@ Contributions to Monocle are welcome from everyone. The following are a set of g
 - Instruct newcomers in the community to complete the PR process.
 
 If you want to become a contributor of Monocle, submit your pull requests. All contributions to this project must be accompanied by acknowledgment of, and agreement to, the [Developer Certificate of Origin](https://github.com/apps/dco). All submissions will be reviewed as quickly as possible.
+Please refer to [Monocle Contributor Guide](Monocle_contributor_guide.md) for more details.
 
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,6 +1,6 @@
 
 # Project Monocle  Governance
-This document defines the governance structure and technical decision-making processes for the [Project Name] project.The project operates transparently, openly, and collaboratively, governed by the community. Participation is open to all individuals and organizations, provided they agree to abide by the guidelines in this document.
+This document defines the governance structure and technical decision-making processes for the Monocle project.The project operates transparently, openly, and collaboratively, governed by the community. Participation is open to all individuals and organizations, provided they agree to abide by the guidelines in this document.
 
 ## Code of Conduct 
 Monocle project adheres to [Code of conduct](CODE_OF_CONDUCT.md)

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,63 @@
+
+# Project Monocle  Governance
+This document defines the governance structure and technical decision-making processes for the [Project Name] project.The project operates transparently, openly, and collaboratively, governed by the community. Participation is open to all individuals and organizations, provided they agree to abide by the guidelines in this document.
+
+## Code of Conduct 
+Monocle project adheres to [Code of conduct](CODE_OF_CONDUCT.md)
+
+## Project roles
+
+### Contributor
+A contributor is anyone participating in the project who submits code, documentation, or other valuable assistance including feedback on PRs from other contributors and [committers](#committers-maintainer). 
+
+### Committers (Maintainer)
+A commiter has write access to the Monocle code base, also permissions to approve and merge pull requests.
+#### Responsibilities
+- Contribute code and process improvements to the project
+- Review and merge PRs from contributors and other committers
+- Promote the project on social media, meetups, conferences etc
+
+### Technical Steering Committee (TSC)
+The TSC is the governing body responsible for the technical direction, architecture, releases, and community policies of Monocle.
+#### Composition
+- The TSC consists of elected or appointed active committers of the community
+
+#### Responsibilities
+- Approving overall project architecture and design.
+- Artifact [release process](./RELEASE.md) (eg Python library release on Pypi.org)
+- Resolving technical disputes among contributors.
+- Ensuring alignment with Foundation (e.g., LF Energy, LF AI & Data) mandates.
+- Promote the project on social media, meetups, conferences etc
+
+## Decision-Making Process
+The project relies heavily on consensus-based decision-making for its day-to-day operations.
+
+### Pull Requests
+Require at least one approving review from an active Committer before merging.
+
+### Releases
+- Require at least one committer or TSC memeber to initiate the release by creating a ticket
+- Require at least one approval from an active TSC memeber
+
+### Architectural/Policy Decisions
+If a significant technical dispute or policy change occurs, it is elevated to the TSC.
+
+### Onboarding new committers/maintainer
+- At least one active TSC member to propose onboarding new committer/maintainer
+- An ideal candidate is someone who has made meaningful contributions to the project (patches, features, documentation)
+- A majority vote from active TSC members to approve the new committers/maintainer
+
+### Onboarding new TSC member
+- At least one active TSC member to propose onboarding new TSC member
+- The candidate should be an active maintainer
+- An ideal candidate is someone who has helped project to grow beyond just code contributions, eg reviews, promoting project via social media, conferences, meetup etc.
+- A majority vote from active TSC members to approve the new TSC member
+
+### Voting
+When consensus cannot be reached, the TSC will vote on the matter. TSC decisions require a majority vote of all TSC members
+
+### Amendments
+This governance document may be amended by a two-thirds (2/3) majority vote of the TSC
+
+## Current commetters/maintainers and TSC members
+Please refer to [CODEOWNERS](CODEOWNERS.md) for list of active commetters/maintainers and TSC members

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -1,10 +1,2 @@
 #MAINTAINERS
-Following is the current list of maintainers on this project
-
-The maintainers are listed in alphabetical order.
-
-- [@prasad-okahu] (https://github.com/prasad-okahu) (Prasad Mujumdar)
-- [@oi-raanne] (https://github.com/oi-raanne) (Ravi Anne)
-- [@akshay-okahu](https://github.com/akshay-okahu) (Akshay Yadav)
-- [@anshul7665] (https://github.com/anshul7665) (Anshul Sharma)
-- [@kshitiz-okahu] (https://github.com/kshitiz-okahu) (Kshitiz Vijayvargiya)
+Refer to [CODEOWNERS](./CODEOWNERS.md) for the list of maintainers.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,13 @@
+# Monocle release process
+## Propose a release
+- Any contributor or commiter can propose a release by creating a ticket/issue
+- Any TSC member can approve and initiate the release process
+
+## Release steps
+- Create a release branch off main
+  - Branch name should be release/<version-number>
+- Update the project.toml files to update the new artifact versions
+- Update CHANGELOG.md to list out the changes/RPs included in the release
+- Commit the changes to release branch and create PR
+- Request other TSC members to approve the PR
+- Execute the github release action to publish the release


### PR DESCRIPTION
## Proposed changes
We are moving towards graduating Monocle project level from Sandbox to Incubation under LF AI&Data. This PR addresses following -
- A project governance proposal that defines roles and responsibilities of project community members
- Release process
- Defining Technical Steering Committee (TSC)
  - The proposal is to include all the current maintainers as TSC members 
We are required to identify a chairperson for TSC. I'll start a separate PR for that process after the governance process is accepted.