### PR TITLE
feat(litellm): capture request temperature on inference span metadata

### DIFF
--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/_helper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/_helper.py
@@ -111,6 +111,35 @@ def extract_response_format(kwargs):
         return None
 
 
+def extract_temperature(kwargs):
+    """Extract the request `temperature` from LiteLLM kwargs.
+
+    Like `response_format`, generation params are not a top-level kwarg by the
+    time the instrumented provider backend is called: LiteLLM moves them into
+    `optional_params` (see `transform_request`, which spreads `**optional_params`
+    into the request body). Checks, in order:
+    1. optional_params["temperature"] — OpenAI/Azure sync and most providers.
+    2. data["temperature"] — Azure async, which passes an already-built request.
+    3. top-level kwargs["temperature"] — defensive fallback.
+
+    Returns None when no temperature was supplied (matching the convention of
+    the langchain/llamaindex/botocore/haystack metamodels).
+    """
+    try:
+        optional_params = kwargs.get("optional_params") or {}
+        if optional_params.get("temperature") is not None:
+            return optional_params["temperature"]
+
+        data = kwargs.get("data") or {}
+        if isinstance(data, dict) and data.get("temperature") is not None:
+            return data["temperature"]
+
+        return kwargs.get("temperature")
+    except Exception as e:
+        logger.warning("Warning: Error occurred in extract_temperature: %s", str(e))
+        return None
+
+
 def extract_assistant_message(arguments):
     try:
         messages = []

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/entities/inference.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/entities/inference.py
@@ -126,6 +126,13 @@ INFERENCE = {
                     ),
                 },
                 {
+                    "_comment": "requested generation temperature (parity with langchain/llamaindex/botocore/haystack)",
+                    "attribute": "temperature",
+                    "accessor": lambda arguments: _helper.extract_temperature(
+                        arguments["kwargs"]
+                    ),
+                },
+                {
                     "_comment": "finish reason from LiteLLM response",
                     "attribute": "finish_reason",
                     "accessor": lambda arguments: _helper.extract_finish_reason(arguments)

--- a/apptrace/tests/unit/test_litellm_helper.py
+++ b/apptrace/tests/unit/test_litellm_helper.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 from monocle_apptrace.instrumentation.metamodel.litellm._helper import (
     extract_messages,
     extract_response_format,
+    extract_temperature,
 )
 from monocle_apptrace.instrumentation.metamodel.litellm.entities.inference import (
     INFERENCE,
@@ -43,6 +44,18 @@ def _run_data_input(arguments):
         if event["name"] == "data.input":
             for attr in event["attributes"]:
                 out[attr["attribute"]] = attr["accessor"](arguments)
+    return out
+
+
+def _run_metadata(arguments):
+    """Run the named metadata accessors from the live INFERENCE metamodel."""
+    out = {}
+    for event in INFERENCE["events"]:
+        if event["name"] == "metadata":
+            for attr in event["attributes"]:
+                # The usage accessor has no "attribute" key; skip it here.
+                if "attribute" in attr:
+                    out[attr["attribute"]] = attr["accessor"](arguments)
     return out
 
 
@@ -168,6 +181,62 @@ class TestLiteLLMExtractMessages(unittest.TestCase):
     def test_extract_messages_empty_when_no_messages(self):
         self.assertEqual(extract_messages({"data": {}}), [])
         self.assertEqual(extract_messages({}), [])
+
+
+class TestLiteLLMExtractTemperature(unittest.TestCase):
+    """temperature is moved into optional_params by the time the backend is called."""
+
+    def test_temperature_from_optional_params(self):
+        kwargs = {"optional_params": {"temperature": 0.7, "extra_body": {}}}
+        self.assertEqual(extract_temperature(kwargs), 0.7)
+
+    def test_temperature_zero_is_captured(self):
+        # temperature=0 (deterministic judge) is falsy but must NOT be treated as absent.
+        kwargs = {"optional_params": {"temperature": 0}}
+        self.assertEqual(extract_temperature(kwargs), 0)
+
+    def test_temperature_from_azure_data_dict(self):
+        # Azure async passes an already-built request under data.
+        kwargs = {"data": {"temperature": 0.2}}
+        self.assertEqual(extract_temperature(kwargs), 0.2)
+
+    def test_optional_params_takes_precedence_over_data(self):
+        kwargs = {"optional_params": {"temperature": 0}, "data": {"temperature": 0.9}}
+        self.assertEqual(extract_temperature(kwargs), 0)
+
+    def test_top_level_kwarg_fallback(self):
+        self.assertEqual(extract_temperature({"temperature": 0.5}), 0.5)
+
+    def test_absent_temperature_returns_none(self):
+        self.assertIsNone(extract_temperature({"optional_params": {"extra_body": {}}}))
+        self.assertIsNone(extract_temperature({}))
+
+    def test_none_optional_params_returns_none(self):
+        self.assertIsNone(extract_temperature({"optional_params": None}))
+
+
+class TestLiteLLMInferenceMetadata(unittest.TestCase):
+    """Coverage through the live INFERENCE metadata processor."""
+
+    def test_temperature_attribute_present(self):
+        arguments = {
+            "kwargs": {"optional_params": {"temperature": 0}},
+            "result": None,
+            "exception": None,
+        }
+        result = _run_metadata(arguments)
+        self.assertIn("temperature", result)
+        self.assertEqual(result["temperature"], 0)
+
+    def test_temperature_attribute_none_when_absent(self):
+        arguments = {
+            "kwargs": {"optional_params": {"extra_body": {}}},
+            "result": None,
+            "exception": None,
+        }
+        result = _run_metadata(arguments)
+        self.assertIn("temperature", result)
+        self.assertIsNone(result["temperature"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Proposed changes

Capture the requested LLM **`temperature`** on LiteLLM **inference** spans (in the `metadata` event). Today LiteLLM inference spans record only token usage in `metadata`; the request-side generation params are dropped, so there is no way to confirm from a trace what `temperature` was actually applied — for example that an LLM-as-judge ran at `temperature=0` for deterministic scoring.

Tracking issue: okahu/monocle_backlog_tracking#210

### Why `temperature` (and only `temperature`)

I audited every framework metamodel's inference `metadata` event. `temperature` is the **only** request/generation param any framework captures today:

| Framework | Request params captured in `metadata` |
|---|---|
| langchain, llamaindex, botocore, haystack | **`temperature`** |
| litellm, openai, anthropic, mistral, gemini, adk, agents, crew_ai, langgraph, msagent | none (token usage only) |

So this brings LiteLLM to **parity** with the existing convention. `top_p`, `max_tokens`, `seed`, and penalties are captured by no framework and are intentionally out of scope.

### What changed

`apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/`:

1. **`_helper.py`** — new `extract_temperature(kwargs)`. By the time the instrumented provider backend runs, LiteLLM has moved generation params into `kwargs["optional_params"]` — the same mechanism already handled for `response_format` (confirmed via LiteLLM `transform_request`, which spreads `**optional_params` into the request body). The reader is defensive across provider shapes: `optional_params` → `data` (Azure async) → top-level kwarg, and returns `None` when unset (matching the langchain/llamaindex/botocore/haystack convention).
2. **`entities/inference.py`** — adds a `temperature` attribute to the existing `metadata` event, sourced from `extract_temperature(arguments["kwargs"])`.

Net effect: LiteLLM inference spans now carry `metadata.temperature` alongside the token counts.

### Note on `temperature=0`

`extract_temperature` uses `is not None` checks (not truthiness), so `temperature=0` is captured correctly rather than being treated as absent.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

Tests added in `apptrace/tests/unit/test_litellm_helper.py`: `extract_temperature` reading from `optional_params` (including `temperature=0`), the `data`/top-level fallbacks and precedence, `None` when absent, and the value flowing through the live `INFERENCE` `metadata` accessors. Full file passes locally (24 passed).

**Alternatives considered:** capturing the full generation-param set (`top_p`, `max_tokens`, `seed`, …). Rejected for this PR to stay at parity with the existing convention — none of the other framework metamodels capture those today, so it would be a broader, separate change.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
