### PR TITLE
litellm: streaming span support and OpenAI Responses API coverage

### DIFF
--- a/apptrace/src/monocle_apptrace/instrumentation/common/stream_processor.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/common/stream_processor.py
@@ -71,6 +71,15 @@ class StreamState:
         """Mark stream as closed with current timestamp."""
         self.stream_closed_time = time.time_ns()
 
+    def fire_close_once(self) -> bool:
+        """Return True exactly once; guards span_processor against re-firing
+        when an exhausted stream is iterated again (span.end()/hydrate on an
+        already-ended span, duplicated assemble_data)."""
+        if getattr(self, "_close_fired", False):
+            return False
+        self._close_fired = True
+        return True
+
 
 class BaseStreamProcessor(ABC):
     """Base class for streaming processors using Template Method pattern.
@@ -289,21 +298,47 @@ class BaseStreamProcessor(ABC):
         original_iter = response.__iter__
 
         def new_iter(self_iter):
+            # Claim ownership so a simultaneously patched __next__ (below)
+            # doesn't double-process items pulled through this generator.
+            state.iter_owner = "iter"
             iterator = original_iter()
-            while True:
-                try:
-                    item = next(iterator)
-                    self.process_fragment(item, state)
-                    yield item
-                except StopIteration:
-                    if span_processor:
-                        ret_val = self.create_span_result(state, stream_start_time)
-                        span_processor(ret_val)
-                    break
+            try:
+                while True:
+                    try:
+                        item = next(iterator)
+                        self.process_fragment(item, state)
+                        yield item
+                    except StopIteration:
+                        if span_processor and state.fire_close_once():
+                            ret_val = self.create_span_result(state, stream_start_time)
+                            span_processor(ret_val)
+                        break
+            finally:
+                # Consumer abandoned the loop early: release ownership so a
+                # direct __next__ drain can resume processing and close.
+                state.iter_owner = None
 
         if not patch_instance_method(response, "__iter__", new_iter):
             # Native C-level generator — return a wrapper object instead
             return self._create_sync_generator_wrapper(response, state, stream_start_time, span_processor)
+        # Some consumers (e.g. litellm's CustomStreamWrapper) pull items via a
+        # direct __next__/next() call and never go through __iter__ — cover
+        # that entry point too, gated on the ownership flag.
+        if hasattr(response, "__next__"):
+            original_next = response.__next__
+
+            def new_next(self_iter):
+                try:
+                    item = original_next()
+                    if getattr(state, "iter_owner", None) != "iter":
+                        self.process_fragment(item, state)
+                    return item
+                except StopIteration:
+                    if getattr(state, "iter_owner", None) != "iter" and span_processor and state.fire_close_once():
+                        span_processor(self.create_span_result(state, stream_start_time))
+                    raise
+
+            patch_instance_method(response, "__next__", new_next)
         return None
     
     def _wrap_async_iterator(self, response: Any, state: StreamState,
@@ -316,21 +351,47 @@ class BaseStreamProcessor(ABC):
         original_iter = response.__aiter__
 
         async def new_aiter(self_iter):
+            # Claim ownership so a simultaneously patched __anext__ (below)
+            # doesn't double-process items pulled through this generator.
+            state.iter_owner = "aiter"
             iterator = original_iter()
-            while True:
-                try:
-                    item = await anext(iterator)
-                    self.process_fragment(item, state)
-                    yield item
-                except StopAsyncIteration:
-                    if span_processor:
-                        ret_val = self.create_span_result(state, stream_start_time)
-                        span_processor(ret_val)
-                    break
+            try:
+                while True:
+                    try:
+                        item = await anext(iterator)
+                        self.process_fragment(item, state)
+                        yield item
+                    except StopAsyncIteration:
+                        if span_processor and state.fire_close_once():
+                            ret_val = self.create_span_result(state, stream_start_time)
+                            span_processor(ret_val)
+                        break
+            finally:
+                # Consumer abandoned the loop early: release ownership so a
+                # direct __anext__ drain can resume processing and close.
+                state.iter_owner = None
 
         if not patch_instance_method(response, "__aiter__", new_aiter):
             # Native C-level async_generator — return a wrapper object instead
             return self._create_async_generator_wrapper(response, state, stream_start_time, span_processor)
+        # Some consumers (e.g. litellm's CustomStreamWrapper) pull items via a
+        # direct __anext__ attribute call and never go through __aiter__ —
+        # cover that entry point too, gated on the ownership flag.
+        if hasattr(response, "__anext__"):
+            original_anext = response.__anext__
+
+            async def new_anext(self_iter):
+                try:
+                    item = await original_anext()
+                    if getattr(state, "iter_owner", None) != "aiter":
+                        self.process_fragment(item, state)
+                    return item
+                except StopAsyncIteration:
+                    if getattr(state, "iter_owner", None) != "aiter" and span_processor and state.fire_close_once():
+                        span_processor(self.create_span_result(state, stream_start_time))
+                    raise
+
+            patch_instance_method(response, "__anext__", new_anext)
         return None
 
     def _wrap_sync_next(self, response: Any, state: StreamState,
@@ -344,7 +405,7 @@ class BaseStreamProcessor(ABC):
                 self.process_fragment(item, state)
                 return item
             except StopIteration:
-                if span_processor:
+                if span_processor and state.fire_close_once():
                     ret_val = self.create_span_result(state, stream_start_time)
                     span_processor(ret_val)
                 raise
@@ -362,7 +423,7 @@ class BaseStreamProcessor(ABC):
                 self.process_fragment(item, state)
                 return item
             except StopAsyncIteration:
-                if span_processor:
+                if span_processor and state.fire_close_once():
                     ret_val = self.create_span_result(state, stream_start_time)
                     span_processor(ret_val)
                 raise

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/_helper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/_helper.py
@@ -146,14 +146,37 @@ def extract_assistant_message(arguments):
         status = get_status_code(arguments)
         if status == 'success' or status == 'completed':
             response = arguments["result"]
+            # Assembled streaming result (SimpleNamespace from the stream processor)
+            if getattr(response, "type", None) == "stream":
+                if isinstance(getattr(response, "tools", None), list) and len(response.tools) > 0 and isinstance(response.tools[0], dict):
+                    tools = []
+                    for tool in response.tools:
+                        tools.append({
+                            "tool_id": tool.get("id", ""),
+                            "tool_name": tool.get("name", ""),
+                            "tool_arguments": tool.get("arguments", ""),
+                        })
+                    messages.append({"tools": tools})
+                if getattr(response, "output_text", None):
+                    messages.append({"assistant": response.output_text})
+                return get_json_dumps(messages[0]) if messages else ""
             if (response is not None and hasattr(response, "choices") and len(response.choices) > 0):
                 if hasattr(response.choices[0], "message"):
-                    role = (
-                        response.choices[0].message.role
-                        if hasattr(response.choices[0].message, "role")
-                        else "assistant"
-                    )
-                    messages.append({role: response.choices[0].message.content})
+                    message = response.choices[0].message
+                    role = getattr(message, "role", None) or "assistant"
+                    # tool-call responses carry null content; surface the tool
+                    # calls instead (mirrors the openai metamodel helper)
+                    if getattr(message, "tool_calls", None):
+                        tools = []
+                        for tool in message.tool_calls:
+                            tools.append({
+                                "tool_id": getattr(tool, "id", ""),
+                                "tool_name": getattr(getattr(tool, "function", None), "name", "") or "",
+                                "tool_arguments": getattr(getattr(tool, "function", None), "arguments", "") or "",
+                            })
+                        messages.append({role: tools})
+                    else:
+                        messages.append({role: message.content})
             return get_json_dumps(messages[0]) if messages else ""
         else:
             if arguments["exception"] is not None:
@@ -214,7 +237,11 @@ def extract_finish_reason(arguments):
             return "error"
             
         response = arguments.get("result")
-        
+
+        # Assembled streaming result carries finish_reason directly
+        if response is not None and getattr(response, "finish_reason", None) and not hasattr(response, "choices"):
+            return response.finish_reason
+
         # Handle LiteLLM response structure (similar to OpenAI)
         if response is not None and hasattr(response, "choices") and len(response.choices) > 0:
             finish_reason = None
@@ -301,3 +328,97 @@ def extract_tool_type(arguments):
         logger.warning("Warning: Error occurred in extract_tool_type: %s", str(e))
     
     return None
+
+def _item_attr(item, key):
+    if isinstance(item, dict):
+        return item.get(key)
+    return getattr(item, key, None)
+
+
+def extract_responses_input(kwargs):
+    """Extract input messages for the Responses API path (kwargs['input'])."""
+    try:
+        raw_input = kwargs.get("input")
+        if raw_input is None:
+            return []
+        if isinstance(raw_input, str):
+            return [get_json_dumps({"user": raw_input})]
+        messages = []
+        for item in raw_input:
+            role = _item_attr(item, "role")
+            content = _item_attr(item, "content")
+            if role and content is not None:
+                messages.append({role: content})
+            elif isinstance(item, dict):
+                messages.append(item)
+            else:
+                messages.append(str(item))
+        return [get_json_dumps(message) for message in messages]
+    except Exception as e:
+        logger.warning("Warning: Error occurred in extract_responses_input: %s", str(e))
+        return []
+
+
+def extract_responses_output(arguments):
+    """Extract assistant message/tool calls from a ResponsesAPIResponse."""
+    try:
+        if arguments.get("exception") is not None:
+            return get_exception_message(arguments)
+        response = arguments["result"]
+        if response is None:
+            return ""
+        if getattr(response, "type", None) == "stream":
+            return extract_assistant_message(arguments)
+        messages = []
+        tools = []
+        texts = []
+        for item in getattr(response, "output", None) or []:
+            item_type = _item_attr(item, "type")
+            if item_type == "function_call":
+                tools.append({
+                    "tool_id": _item_attr(item, "call_id") or "",
+                    "tool_name": _item_attr(item, "name") or "",
+                    "tool_arguments": _item_attr(item, "arguments") or "",
+                })
+            elif item_type == "message":
+                for part in _item_attr(item, "content") or []:
+                    text = _item_attr(part, "text")
+                    if text:
+                        texts.append(text)
+        if tools:
+            messages.append({"tools": tools})
+        if texts:
+            messages.append({"assistant": "\n".join(texts)})
+        return get_json_dumps(messages[0]) if messages else ""
+    except Exception as e:
+        logger.warning("Warning: Error occurred in extract_responses_output: %s", str(e))
+        return None
+
+
+def extract_responses_finish_reason(arguments):
+    """Finish reason for the Responses API: tool_calls beat plain completion status."""
+    try:
+        if arguments.get("exception") is not None:
+            return "error"
+        response = arguments.get("result")
+        if response is None:
+            return None
+        if getattr(response, "type", None) == "stream":
+            if getattr(response, "tools", None):
+                return "tool_calls"
+            return getattr(response, "finish_reason", None) or "completed"
+        if getattr(response, "finish_reason", None) and not hasattr(response, "output"):
+            return response.finish_reason
+        for item in getattr(response, "output", None) or []:
+            if _item_attr(item, "type") == "function_call":
+                return "tool_calls"
+        return getattr(response, "status", None)
+    except Exception as e:
+        logger.warning("Warning: Error occurred in extract_responses_finish_reason: %s", str(e))
+        return None
+
+
+def responses_inference_type(arguments):
+    if extract_responses_finish_reason(arguments) == "tool_calls":
+        return INFERENCE_TOOL_CALL
+    return INFERENCE_TURN_END

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/entities/inference.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/entities/inference.py
@@ -2,14 +2,32 @@ from monocle_apptrace.instrumentation.common.constants import SPAN_TYPES
 from monocle_apptrace.instrumentation.metamodel.litellm import (
     _helper,
 )
+from monocle_apptrace.instrumentation.metamodel.openai.openai_stream_processor import (
+    OpenAIStreamProcessor,
+)
 from monocle_apptrace.instrumentation.common.utils import (
     get_error_message,
     resolve_from_alias,
     get_llm_type,
 )
+
+def _is_streaming(kwargs):
+    # Provider handlers receive stream inside optional_params, not top-level
+    return bool((kwargs.get("optional_params") or {}).get("stream"))
+
+
+def process_stream(to_wrap, response, span_processor):
+    # Provider handlers return the provider SDK's native stream; the
+    # OpenAI-format chunk processor covers the OpenAI/Azure handlers.
+    processor = OpenAIStreamProcessor()
+    return processor.process_stream(to_wrap, response, span_processor)
+
+
 INFERENCE = {
     "type": SPAN_TYPES.INFERENCE,
     "subtype": lambda arguments: _helper.agent_inference_type(arguments),
+    "is_auto_close": lambda kwargs: not _is_streaming(kwargs),
+    "response_processor": process_stream,
     "attributes": [
         [
             {
@@ -146,4 +164,11 @@ INFERENCE = {
             ],
         },
     ],
+}
+
+# streaming/async_streaming are unconditionally streaming; `stream` is not in
+# their optional_params (litellm sets data["stream"] internally).
+INFERENCE_STREAMING = {
+    **INFERENCE,
+    "is_auto_close": lambda kwargs: False,
 }

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/entities/responses.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/entities/responses.py
@@ -1,0 +1,109 @@
+from monocle_apptrace.instrumentation.common.constants import SPAN_TYPES
+from monocle_apptrace.instrumentation.metamodel.litellm import (
+    _helper,
+)
+from monocle_apptrace.instrumentation.metamodel.litellm.entities.inference import (
+    process_stream,
+)
+from monocle_apptrace.instrumentation.common.utils import (
+    get_error_message,
+    resolve_from_alias,
+)
+
+
+def _is_streaming(kwargs):
+    return bool((kwargs.get("response_api_optional_request_params") or {}).get("stream"))
+
+
+RESPONSES = {
+    "type": SPAN_TYPES.INFERENCE,
+    "subtype": lambda arguments: _helper.responses_inference_type(arguments),
+    "is_auto_close": lambda kwargs: not _is_streaming(kwargs),
+    "response_processor": process_stream,
+    "attributes": [
+        [
+            {
+                "_comment": "provider type, name, inference_endpoint",
+                "attribute": "type",
+                "accessor": lambda arguments: "inference."
+                + (arguments["kwargs"].get("custom_llm_provider") or "generic"),
+            },
+            {
+                "attribute": "provider_name",
+                "accessor": lambda arguments: _helper.extract_provider_name(
+                    (arguments["kwargs"].get("litellm_params") or {}).get("api_base")
+                ),
+            },
+            {
+                "attribute": "inference_endpoint",
+                "accessor": lambda arguments: (
+                    arguments["kwargs"].get("litellm_params") or {}
+                ).get("api_base"),
+            },
+        ],
+        [
+            {
+                "_comment": "LLM Model",
+                "attribute": "name",
+                "accessor": lambda arguments: resolve_from_alias(
+                    arguments["kwargs"], ["model"]
+                ),
+            },
+            {
+                "attribute": "type",
+                "accessor": lambda arguments: "model.llm."
+                + resolve_from_alias(arguments["kwargs"], ["model"]),
+            },
+        ],
+    ],
+    "events": [
+        {
+            "name": "data.input",
+            "attributes": [
+                {
+                    "_comment": "this is instruction and user query to LLM",
+                    "attribute": "input",
+                    "accessor": lambda arguments: _helper.extract_responses_input(
+                        arguments["kwargs"]
+                    ),
+                }
+            ],
+        },
+        {
+            "name": "data.output",
+            "attributes": [
+                {
+                    "attribute": "error_code",
+                    "accessor": lambda arguments: get_error_message(arguments)
+                },
+                {
+                    "_comment": "this is result from LLM",
+                    "attribute": "response",
+                    "accessor": lambda arguments: _helper.extract_responses_output(arguments),
+                }
+            ],
+        },
+        {
+            "name": "metadata",
+            "attributes": [
+                {
+                    "_comment": "this is metadata usage from LLM",
+                    "accessor": lambda arguments: _helper.update_span_from_llm_response(
+                        arguments["result"]
+                    ),
+                },
+                {
+                    "_comment": "finish reason from the Responses API result",
+                    "attribute": "finish_reason",
+                    "accessor": lambda arguments: _helper.extract_responses_finish_reason(arguments)
+                },
+                {
+                    "_comment": "finish type mapped from finish reason",
+                    "attribute": "finish_type",
+                    "accessor": lambda arguments: _helper.map_finish_reason_to_finish_type(
+                        _helper.extract_responses_finish_reason(arguments))
+                }
+            ],
+        },
+    ],
+}

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/litellm_span_handler.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/litellm_span_handler.py
@@ -25,5 +25,8 @@ class LiteLLMSyncSpanHandler(SpanHandler):
         Returns:
             bool: True if the argument acompletion is true, False otherwise
         """
-        return kwargs.get('acompletion') is True
+        # response_api_handler signals its async variant via _is_async: the
+        # sync call then returns an unawaited coroutine, so a span here would
+        # never see the real result (the async wrap owns the span).
+        return kwargs.get('acompletion') is True or kwargs.get('_is_async') is True
 

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/methods.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/methods.py
@@ -1,7 +1,24 @@
 from monocle_apptrace.instrumentation.common.wrapper import atask_wrapper, task_wrapper
-from monocle_apptrace.instrumentation.metamodel.litellm.entities.inference import INFERENCE
+from monocle_apptrace.instrumentation.metamodel.litellm.entities.inference import INFERENCE, INFERENCE_STREAMING
+from monocle_apptrace.instrumentation.metamodel.litellm.entities.responses import RESPONSES
 
 LITELLM_METHODS = [
+    {
+        # OpenAI Responses API (and compatible providers) via litellm's HTTP handler
+        "package": "litellm.llms.custom_httpx.llm_http_handler",
+        "object": "BaseLLMHTTPHandler",
+        "method": "response_api_handler",
+        "wrapper_method": task_wrapper,
+        "output_processor": RESPONSES,
+        "span_handler": "litellm_sync_handler"
+    },
+    {
+        "package": "litellm.llms.custom_httpx.llm_http_handler",
+        "object": "BaseLLMHTTPHandler",
+        "method": "async_response_api_handler",
+        "wrapper_method": atask_wrapper,
+        "output_processor": RESPONSES
+    },
     {
         "package": "litellm.llms.openai.openai",
         "object": "OpenAIChatCompletion",
@@ -24,6 +41,14 @@ LITELLM_METHODS = [
         "method": "acompletion",
         "wrapper_method": atask_wrapper,
         "output_processor": INFERENCE
+    },
+    {
+        # Async streaming bypasses acompletion and routes here
+        "package": "litellm.llms.openai.openai",
+        "object": "OpenAIChatCompletion",
+        "method": "async_streaming",
+        "wrapper_method": atask_wrapper,
+        "output_processor": INFERENCE_STREAMING
     },
     {
         "package": "litellm.llms.azure.azure",

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/openai/openai_stream_processor.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/openai/openai_stream_processor.py
@@ -16,7 +16,18 @@ class OpenAIStreamProcessor(BaseStreamProcessor):
         
         state.update_first_token_time()
         
-        if item.type == StreamEventTypes.RESPONSE_OUTPUT_TEXT_DELTA:
+        if item.type == "response.output_item.added":
+            output_item = getattr(item, "item", None)
+            if getattr(output_item, "type", None) == "function_call":
+                state.tools.append({
+                    "id": getattr(output_item, "call_id", None) or getattr(output_item, "id", "") or "",
+                    "name": getattr(output_item, "name", "") or "",
+                    "arguments": getattr(output_item, "arguments", "") or "",
+                })
+        elif item.type == "response.function_call_arguments.delta":
+            if state.tools and getattr(item, "delta", None):
+                state.tools[-1]["arguments"] += item.delta
+        elif item.type == StreamEventTypes.RESPONSE_OUTPUT_TEXT_DELTA:
             state.accumulated_response += item.delta
         elif item.type == StreamEventTypes.RESPONSE_TEXT_DELTA:
             state.accumulated_response += item.delta
@@ -48,6 +59,13 @@ class OpenAIStreamProcessor(BaseStreamProcessor):
         if hasattr(delta, "refusal") and delta.refusal:
             state.refusal = delta.refusal
 
+        # Some providers (e.g. litellm's CustomStreamWrapper) attach usage to a
+        # chunk that still carries an empty delta, so it never reaches
+        # handle_completion — capture it here too.
+        if hasattr(item, "usage") and item.usage:
+            state.token_usage = item.usage
+            state.close_stream()
+
         return True
 
     def handle_completion(self, item: Any, state: StreamState) -> bool:
@@ -68,6 +86,9 @@ class OpenAIStreamProcessor(BaseStreamProcessor):
 
     def assemble_data(self, state: StreamState) -> None:
         """Assemble tool calls and completion data from fragmented streaming chunks."""
+        # A tool call streams as one id/name-bearing fragment followed by
+        # id-less fragments carrying argument deltas; accumulate by index.
+        tools_by_index = {}
         for item in state.raw_items:
             try:
                 if (hasattr(item, "choices") and item.choices and
@@ -80,14 +101,25 @@ class OpenAIStreamProcessor(BaseStreamProcessor):
                         choice.delta.tool_calls):
 
                         for tool_call in choice.delta.tool_calls:
-                            if (hasattr(tool_call, "id") and tool_call.id and
-                                hasattr(tool_call, "function") and tool_call.function):
-
-                                state.tools.append({
+                            index = getattr(tool_call, "index", None)
+                            if index is None:
+                                # id-less argument fragments without an index
+                                # belong to the most recently started call
+                                index = max(tools_by_index) if tools_by_index and not getattr(tool_call, "id", None) else len(tools_by_index)
+                            if getattr(tool_call, "id", None) and getattr(tool_call, "function", None) is not None:
+                                tools_by_index[index] = {
                                     "id": tool_call.id,
-                                    "name": tool_call.function.name,
-                                    "arguments": getattr(tool_call.function, "arguments", ""),
-                                })
+                                    "name": getattr(tool_call.function, "name", None) or "",
+                                    "arguments": "",
+                                }
+                            entry = tools_by_index.get(index)
+                            function = getattr(tool_call, "function", None)
+                            if entry is not None and function is not None:
+                                if not entry["name"] and getattr(function, "name", None):
+                                    entry["name"] = function.name
+                                arguments_piece = getattr(function, "arguments", None)
+                                if arguments_piece:
+                                    entry["arguments"] += arguments_piece
 
                     # Extract finish_reason
                     if hasattr(choice, "finish_reason") and choice.finish_reason:
@@ -97,3 +129,4 @@ class OpenAIStreamProcessor(BaseStreamProcessor):
                 self.logger.warning(
                     "Warning: Error occurred while processing tool calls: %s", str(e)
                 )
+        state.tools.extend(tools_by_index[index] for index in sorted(tools_by_index))

--- a/apptrace/tests/unit/test_litellm_streaming_responses.py
+++ b/apptrace/tests/unit/test_litellm_streaming_responses.py
@@ -1,0 +1,243 @@
+from types import SimpleNamespace
+
+from monocle_apptrace.instrumentation.common.stream_processor import StreamState
+from monocle_apptrace.instrumentation.metamodel.litellm import _helper
+from monocle_apptrace.instrumentation.metamodel.litellm.entities.inference import _is_streaming
+from monocle_apptrace.instrumentation.metamodel.litellm.entities.responses import (
+    _is_streaming as _responses_is_streaming,
+)
+from monocle_apptrace.instrumentation.metamodel.openai.openai_stream_processor import (
+    OpenAIStreamProcessor,
+)
+
+
+def _chunk(delta=None, usage=None, finish_reason=None):
+    choice = SimpleNamespace(delta=delta, finish_reason=finish_reason)
+    return SimpleNamespace(
+        object="chat.completion.chunk",
+        choices=[choice] if delta is not None or finish_reason else [],
+        usage=usage,
+    )
+
+
+def _tool_delta(index, id=None, name=None, arguments=None):
+    function = SimpleNamespace(name=name, arguments=arguments)
+    tool_call = SimpleNamespace(index=index, id=id, function=function)
+    return SimpleNamespace(content=None, role=None, refusal=None, tool_calls=[tool_call])
+
+
+def test_stream_processor_accumulates_tool_arguments_across_fragments():
+    processor = OpenAIStreamProcessor()
+    state = StreamState()
+    for delta in [
+        _tool_delta(0, id="call_1", name="terminal", arguments=""),
+        _tool_delta(0, arguments='{"command":'),
+        _tool_delta(0, arguments='"date"}'),
+    ]:
+        processor.process_fragment(_chunk(delta=delta), state)
+    processor.assemble_data(state)
+    assert state.tools == [
+        {"id": "call_1", "name": "terminal", "arguments": '{"command":"date"}'}
+    ]
+
+
+def test_stream_processor_captures_usage_on_delta_carrying_chunk():
+    # litellm's CustomStreamWrapper attaches usage to a chunk that still has an
+    # (empty) delta, so handle_completion never fires — handle_chunk must catch it.
+    processor = OpenAIStreamProcessor()
+    state = StreamState()
+    usage = SimpleNamespace(completion_tokens=9, prompt_tokens=9, total_tokens=18)
+    empty_delta = SimpleNamespace(content=None, role=None, refusal=None, tool_calls=None)
+    processor.process_fragment(_chunk(delta=empty_delta, usage=usage), state)
+    assert state.token_usage is usage
+
+
+def test_extract_assistant_message_stream_result():
+    result = SimpleNamespace(
+        type="stream",
+        tools=[{"id": "call_1", "name": "finish", "arguments": '{"message":"done"}'}],
+        output_text="",
+    )
+    arguments = {"result": result, "exception": None}
+    message = _helper.extract_assistant_message(arguments)
+    assert '"tool_name": "finish"' in message
+    assert '"tool_arguments": "{\\"message\\":\\"done\\"}"' in message
+
+
+def test_is_streaming_reads_optional_params():
+    assert _is_streaming({"optional_params": {"stream": True}}) is True
+    assert _is_streaming({"optional_params": {}}) is False
+    assert _is_streaming({}) is False
+
+
+def test_responses_is_streaming_reads_request_params():
+    assert _responses_is_streaming({"response_api_optional_request_params": {"stream": True}}) is True
+    assert _responses_is_streaming({}) is False
+
+
+def _responses_result():
+    function_call = SimpleNamespace(
+        type="function_call", call_id="call_9", name="terminal", arguments='{"command":"ls"}'
+    )
+    message = SimpleNamespace(
+        type="message", content=[SimpleNamespace(text="listing files")]
+    )
+    return SimpleNamespace(
+        output=[function_call, message],
+        status="completed",
+        usage=SimpleNamespace(completion_tokens=None, output_tokens=5, prompt_tokens=None,
+                              input_tokens=7, total_tokens=12),
+    )
+
+
+def test_extract_responses_input_and_output():
+    kwargs = {"input": [{"role": "user", "content": "list the files"}]}
+    assert _helper.extract_responses_input(kwargs) == ['{"user": "list the files"}']
+
+    arguments = {"result": _responses_result(), "exception": None}
+    output = _helper.extract_responses_output(arguments)
+    assert '"tool_name": "terminal"' in output
+
+    assert _helper.extract_responses_finish_reason(arguments) == "tool_calls"
+
+    meta = _helper.update_span_from_llm_response(arguments["result"])
+    assert meta["completion_tokens"] == 5
+    assert meta["prompt_tokens"] == 7
+    assert meta["total_tokens"] == 12
+
+
+def test_extract_responses_finish_reason_without_tools():
+    message_only = SimpleNamespace(
+        output=[SimpleNamespace(type="message", content=[SimpleNamespace(text="hi")])],
+        status="completed",
+    )
+    arguments = {"result": message_only, "exception": None}
+    assert _helper.extract_responses_finish_reason(arguments) == "completed"
+
+
+def test_inference_streaming_variant_never_auto_closes():
+    from monocle_apptrace.instrumentation.metamodel.litellm.entities.inference import (
+        INFERENCE,
+        INFERENCE_STREAMING,
+    )
+    # async_streaming has no stream flag in optional_params; the variant must
+    # defer close unconditionally while sharing the base entity's processors.
+    assert INFERENCE_STREAMING["is_auto_close"]({}) is False
+    assert INFERENCE_STREAMING["attributes"] is INFERENCE["attributes"]
+    assert INFERENCE_STREAMING["events"] is INFERENCE["events"]
+
+
+class _SelfIterStream:
+    """Mimics litellm's CustomStreamWrapper: __iter__ returns self, items via __next__."""
+
+    def __init__(self, items):
+        self._items = iter(items)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self._items)
+
+
+def _text_chunk(text):
+    delta = SimpleNamespace(content=text, role="assistant", refusal=None, tool_calls=None)
+    return _chunk(delta=delta)
+
+
+def test_process_stream_direct_next_consumption_closes_once():
+    # litellm pulls via next(self.completion_stream) without touching __iter__
+    processor = OpenAIStreamProcessor()
+    fired = []
+    stream = _SelfIterStream([_text_chunk("hel"), _text_chunk("lo")])
+    wrapper = processor.process_stream({"x": 1}, stream, fired.append)
+    assert wrapper is None  # patched in place
+    collected = ""
+    try:
+        while True:
+            collected += stream.__next__().choices[0].delta.content
+    except StopIteration:
+        pass
+    # post-exhaustion re-iteration must not re-fire the close
+    for _ in range(3):
+        try:
+            stream.__next__()
+        except StopIteration:
+            pass
+    assert collected == "hello"
+    assert len(fired) == 1
+    assert fired[0].output_text == "hello"
+
+
+def test_process_stream_for_loop_consumption_closes_once():
+    processor = OpenAIStreamProcessor()
+    fired = []
+    stream = _SelfIterStream([_text_chunk("a"), _text_chunk("b")])
+    processor.process_stream({"x": 1}, stream, fired.append)
+    text = "".join(ch.choices[0].delta.content for ch in stream)
+    assert text == "ab"
+    assert len(fired) == 1
+    assert fired[0].output_text == "ab"
+
+
+def test_assemble_data_indexless_argument_fragments():
+    # Some providers emit argument fragments with index=None; they belong to
+    # the most recently started tool call, not a new ghost entry.
+    processor = OpenAIStreamProcessor()
+    state = StreamState()
+    frags = [
+        _tool_delta(0, id="call_1", name="terminal", arguments=""),
+        _tool_delta(None, arguments='{"cmd":'),
+        _tool_delta(None, arguments='"ls"}'),
+    ]
+    for delta in frags:
+        processor.process_fragment(_chunk(delta=delta), state)
+    processor.assemble_data(state)
+    assert state.tools == [{"id": "call_1", "name": "terminal", "arguments": '{"cmd":"ls"}'}]
+
+
+def test_responses_sync_handler_skips_async_shim():
+    from monocle_apptrace.instrumentation.metamodel.litellm.litellm_span_handler import (
+        LiteLLMSyncSpanHandler,
+    )
+    handler = LiteLLMSyncSpanHandler()
+    # response_api_handler with _is_async=True returns an unawaited coroutine;
+    # the sync span must be skipped (the async wrap owns the real span)
+    assert handler.skip_span({}, None, None, (), {"_is_async": True}) is True
+    assert handler.skip_span({}, None, None, (), {"_is_async": False}) is False
+    assert handler.skip_span({}, None, None, (), {"acompletion": True}) is True
+
+
+def test_handle_event_assembles_streamed_responses_tool_calls():
+    processor = OpenAIStreamProcessor()
+    state = StreamState()
+    added = SimpleNamespace(
+        type="response.output_item.added",
+        item=SimpleNamespace(type="function_call", call_id="call_9", name="terminal", arguments=""),
+    )
+    delta1 = SimpleNamespace(type="response.function_call_arguments.delta", delta='{"cmd":')
+    delta2 = SimpleNamespace(type="response.function_call_arguments.delta", delta='"date"}')
+    for ev in (added, delta1, delta2):
+        processor.process_fragment(ev, state)
+    assert state.tools == [{"id": "call_9", "name": "terminal", "arguments": '{"cmd":"date"}'}]
+    # finish reason for a stream namespace with tools
+    ns = SimpleNamespace(type="stream", tools=state.tools)
+    assert _helper.extract_responses_finish_reason({"result": ns, "exception": None}) == "tool_calls"
+
+
+def test_extract_assistant_message_non_streaming_tool_calls():
+    # tool-call responses have content=None; the output must carry the tool
+    # calls instead of {"assistant": null}
+    function = SimpleNamespace(name="terminal", arguments='{"command":"ls"}')
+    tool_call = SimpleNamespace(id="call_7", function=function)
+    message = SimpleNamespace(role="assistant", content=None, tool_calls=[tool_call])
+    response = SimpleNamespace(choices=[SimpleNamespace(message=message)])
+    out = _helper.extract_assistant_message({"result": response, "exception": None})
+    assert '"tool_name": "terminal"' in out
+    assert "null" not in out
+
+    # plain content responses are unchanged
+    message2 = SimpleNamespace(role="assistant", content="hello", tool_calls=None)
+    response2 = SimpleNamespace(choices=[SimpleNamespace(message=message2)])
+    out2 = _helper.extract_assistant_message({"result": response2, "exception": None})
+    assert out2 == '{"assistant": "hello"}'


### PR DESCRIPTION
## Proposed changes

Closes two litellm-layer gaps: **streaming inference spans carry no output/tokens** (the span closes before the stream is consumed), and **`litellm.responses()` produces no inference spans at all** (the Responses API goes through litellm's raw-httpx handler, which nothing wraps — this is the path gpt-5/o-series models take). Both were surfaced while instrumenting OpenHands, whose LLM layer is litellm, but they apply to every litellm application and are therefore a separate PR from the OpenHands metamodel (#708).

## Changes

1. **Streaming support on the litellm inference entity** (`metamodel/litellm/entities/inference.py`)
   - `is_auto_close` defers span close when `optional_params.stream` is set; `response_processor` reuses the existing OpenAI-format stream processor, so the span closes when the stream is exhausted, hydrated with the accumulated output, token usage, and finish_reason.
   - New `INFERENCE_STREAMING` variant (unconditional defer) wired to `OpenAIChatCompletion.async_streaming` — litellm's async streaming bypasses `acompletion` and routes here, and this method receives no `stream` flag in `optional_params` (litellm sets `data["stream"]` internally). Previously async streaming produced **no inference span at all**.

2. **Stream-processor fixes** (`metamodel/openai/openai_stream_processor.py`, `common/stream_processor.py`) — three real data-loss bugs in the shared OpenAI-format engine, each reproduced before fixing:
   - **Usage capture**: litellm's `CustomStreamWrapper` attaches usage to a chunk that still carries an (empty) delta, so `handle_chunk` returned True and `handle_completion` never saw it — tokens were silently lost. `handle_chunk` now also captures usage.
   - **Tool-argument accumulation**: a streamed tool call arrives as one id-bearing fragment followed by id-less argument deltas; `assemble_data` kept only the first fragment, so `tool_arguments` was always empty. Arguments are now accumulated per `tool_call.index`.
   - **Direct `__next__`/`__anext__` consumers**: the patcher only covered `__iter__`/`__aiter__`, but litellm pulls the inner stream via direct `__anext__()` attribute calls — spans never closed and were dropped. Both entry points are now patched, with an ownership flag so `async for` consumers don't double-process.

3. **OpenAI Responses API coverage** (`metamodel/litellm/entities/responses.py`, `_helper.py`, `methods.py`)
   - New `RESPONSES` entity wrapping `BaseLLMHTTPHandler.response_api_handler` / `async_response_api_handler` with input/output/usage/finish-reason accessors over `ResponsesAPIResponse` (function_call and message output items), plus streaming support via the same processor (SSE `response.*` events were already handled).

4. **Non-streaming tool-call output** (`_helper.py`): tool-call responses carry `content=None`, so `data.output` read `{"assistant": null}`; the helper now surfaces the tool calls (`{"assistant": [{tool_id, tool_name, tool_arguments}]}`), mirroring the openai metamodel helper. Applies to every litellm-based agent framework.

5. **Tests**: `tests/unit/test_litellm_streaming_responses.py` — 8 tests: fragment accumulation, delta-chunk usage capture, stream-result message extraction, `optional_params` stream detection, the `INFERENCE_STREAMING` variant, and the Responses accessors (input/output/finish_reason/usage). All stand-ins, no network.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

**Why the shared stream processor had to change:** the litellm entity reuses `OpenAIStreamProcessor` (as hugging_face already does), and the three fixes above are bugs for *any* OpenAI-format stream, not litellm specials — e.g. empty `tool_arguments` affects the openai metamodel's own streaming today. The alternative (a litellm-only subclass duplicating the processor) would fork shared logic to preserve known data loss.

**Behavior change to be aware of:** with streaming, the litellm inference span now closes when the stream is exhausted instead of at method return. A stream that is never consumed will not export its inference span (previously an empty-output span was exported); this matches the openai metamodel's existing streaming semantics.

**Validated with real runs** (`gpt-4o-mini`, `gpt-5-nano`): sync streaming (output + tokens + accumulated tool args), async streaming (previously span-less), and Responses API sync (previously span-less) — plus end-to-end through OpenHands. `tests/unit`: 506 passed; all failures present are byte-identical on clean `main` (pre-existing environment issues, verified by stash/re-run).

**Review round (adversarial review applied):** the async Responses path no longer leaks a never-ended span — `response_api_handler(_is_async=True)` returns an unawaited coroutine, so its sync span is now skipped via the existing `litellm_sync_handler` (extended to recognize `_is_async`), mirroring how chat-completion sync shims are already handled; close is idempotent (`fire_close_once` guards all six close sites — post-exhaustion re-iteration no longer re-fires span end/hydrate); generator early-exit releases stream ownership so a direct `next()` drain still processes and closes; index-less tool-argument fragments attach to the most recent tool call instead of being dropped, and id-only fragments no longer create ghost entries; streamed Responses SSE tool calls are assembled (`response.output_item.added` / `response.function_call_arguments.delta`) with correct `tool_calls` finish reason. 14 unit tests including direct-`next()` consumption, non-streaming tool-call extraction, close-once, and the `_is_async` skip. Live re-validated: async Responses emits exactly one closed span (no leaked twin); sync + async chat streaming carry output and tokens. Known scope limit: async streaming for non-OpenAI providers (Azure/Vertex/Bedrock/Anthropic dedicated `async_streaming` methods) is unchanged from main — wraps for those need provider-native chunk validation and are a follow-up.

🤖 Generated with the monocle-auto-instrument skill
