### PR TITLE
test-tools: surface eval total_tokens + opt-in eval-matrix recorder plugin

### DIFF
--- a/test_tools/src/monocle_test_tools/eval_matrix.py
+++ b/test_tools/src/monocle_test_tools/eval_matrix.py
@@ -1,0 +1,170 @@
+"""Opt-in eval-result-matrix recorder for pytest.
+
+This module provides:
+  - `build_eval_matrix_row`: a pure function that turns the per-test
+    `_last_eval` stash (see `TraceAssertion.check_eval`) into a single
+    matrix row with a fixed schema.
+  - pytest plugin hooks (`pytest_addoption`, `pytest_sessionfinish`) and a
+    `maybe_record_eval_row` helper that `pytest_plugin.py` wires into the
+    `monocle_trace_asserter` fixture teardown.
+
+The feature is OFF by default: unless `--monocle-eval-matrix` is passed or
+`MONOCLE_EVAL_MATRIX` is set, no rows are recorded and no file is written.
+"""
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+# Module-level accumulator for recorded rows. Only ever appended to when the
+# feature is enabled (see `is_enabled` / `maybe_record_eval_row`).
+_records: list[dict[str, Any]] = []
+
+DEFAULT_OUTPUT_PATH = "test-eval-replay-matrix.json"
+
+
+def build_eval_matrix_row(run_id: str, scenario: str, last_eval: dict, passed: bool) -> dict:
+    """Build a single eval-result-matrix row from a `_last_eval` stash.
+
+    `last_eval` is expected to look like the dict stashed by
+    `TraceAssertion.check_eval`:
+        {"trace_id": str, "expected": ..., "fact_name": str, "label": ...,
+         "explanation": ..., "judge_output": dict, "total_tokens": ...}
+
+    Returns a dict with exactly these keys (schema is consumed downstream,
+    do not rename): run_id, scenario, trace_id, expected, actual, status,
+    explanation, total_tokens, claim_verdicts, hallucination_types,
+    entity_match_check.
+    """
+    last_eval = last_eval or {}
+    judge_output = last_eval.get("judge_output") or {}
+
+    actual = last_eval.get("label") or ""
+    if passed:
+        status = "pass"
+    elif actual:
+        status = "drift"
+    else:
+        status = "error"
+
+    return {
+        "run_id": run_id,
+        "scenario": scenario,
+        "trace_id": last_eval.get("trace_id"),
+        "expected": last_eval.get("expected"),
+        "actual": actual,
+        "status": status,
+        "explanation": last_eval.get("explanation"),
+        "total_tokens": last_eval.get("total_tokens"),
+        "claim_verdicts": judge_output.get("claim_verdicts") or [],
+        "hallucination_types": judge_output.get("hallucination_types") or [],
+        "entity_match_check": judge_output.get("entity_match_check") or "",
+    }
+
+
+_FALSY_ENV_VALUES = ("0", "false", "no", "off", "")
+_BOOLEAN_ENV_VALUES = ("1", "true", "yes", "on")
+
+
+def _is_env_truthy(value: Optional[str]) -> bool:
+    """Whether `MONOCLE_EVAL_MATRIX` should be treated as "set" (enabling the
+    recorder), as opposed to unset or explicitly disabled (e.g. "0"/"false").
+    """
+    if value is None:
+        return False
+    return value.strip().lower() not in _FALSY_ENV_VALUES
+
+
+def resolve_output_path(option_value: Optional[str], env_value: Optional[str]) -> Optional[str]:
+    """Resolve whether the matrix recorder is enabled and, if so, the output path.
+
+    Priority: `--monocle-eval-matrix` option value, else `MONOCLE_EVAL_MATRIX`
+    if it looks like a path (i.e. isn't just a boolean-ish "1"/"true"/...),
+    else the default filename. Returns the output path (str) if enabled,
+    otherwise None.
+    """
+    if option_value:
+        return option_value
+    if _is_env_truthy(env_value):
+        if env_value.strip().lower() in _BOOLEAN_ENV_VALUES:
+            return DEFAULT_OUTPUT_PATH
+        return env_value
+    return None
+
+
+def is_enabled(option_value: Optional[str], env_value: Optional[str]) -> bool:
+    return resolve_output_path(option_value, env_value) is not None
+
+
+def reset_records() -> None:
+    """Clear the module-level accumulator. Exposed for test isolation."""
+    _records.clear()
+
+
+def get_records() -> list[dict[str, Any]]:
+    return _records
+
+
+def record_row(row: dict[str, Any]) -> None:
+    _records.append(row)
+
+
+def record_eval_row_for(config, request, trace_assertion) -> None:
+    """Record a matrix row for `trace_assertion`'s last eval, if enabled.
+
+    Self-skips when the feature is disabled or when the asserter has no
+    `_last_eval` (i.e. the test never called `check_eval`).
+    """
+    option_value = config.getoption("monocle_eval_matrix", default=None)
+    env_value = os.environ.get("MONOCLE_EVAL_MATRIX")
+    if not is_enabled(option_value, env_value):
+        return
+
+    last_eval = getattr(trace_assertion, "_last_eval", None)
+    if last_eval is None:
+        return
+
+    node = request.node
+    callspec = getattr(node, "callspec", None)
+    scenario = callspec.id if callspec is not None else node.name
+
+    rep_call = getattr(node, "rep_call", None)
+    passed = bool(rep_call and rep_call.passed)
+
+    run_id = os.getenv("RUN_ID") or os.getenv("LOCAL_RUN_ID") or "local"
+
+    row = build_eval_matrix_row(run_id=run_id, scenario=scenario, last_eval=last_eval, passed=passed)
+    record_row(row)
+
+
+def pytest_addoption(parser) -> None:
+    parser.addoption(
+        "--monocle-eval-matrix",
+        dest="monocle_eval_matrix",
+        nargs="?",
+        const=DEFAULT_OUTPUT_PATH,
+        default=None,
+        help=(
+            "Opt-in: record an eval-result matrix (trace_id, expected/actual "
+            "label, tokens, judge output) for every test that calls "
+            "check_eval, and write it to the given path (default: "
+            f"{DEFAULT_OUTPUT_PATH}) at session end. Also enabled by setting "
+            "the MONOCLE_EVAL_MATRIX env var. Off by default."
+        ),
+    )
+
+
+def pytest_sessionfinish(session) -> None:
+    config = session.config
+    option_value = config.getoption("monocle_eval_matrix", default=None)
+    env_value = os.environ.get("MONOCLE_EVAL_MATRIX")
+    output_path = resolve_output_path(option_value, env_value)
+    if not output_path:
+        return
+
+    payload = {
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+        "records": get_records(),
+    }
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, default=str)

--- a/test_tools/src/monocle_test_tools/evals/base_eval.py
+++ b/test_tools/src/monocle_test_tools/evals/base_eval.py
@@ -1,9 +1,8 @@
 from typing import Optional, Union
 from opentelemetry.sdk.trace import Span
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel
 
 class BaseEval(BaseModel):
-    model_config = ConfigDict(extra='allow')
     eval_options: Optional[dict] = {}
     def __init__(self, **data):       
         super().__init__(**data)

--- a/test_tools/src/monocle_test_tools/evals/base_eval.py
+++ b/test_tools/src/monocle_test_tools/evals/base_eval.py
@@ -1,8 +1,9 @@
 from typing import Optional, Union
 from opentelemetry.sdk.trace import Span
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 class BaseEval(BaseModel):
+    model_config = ConfigDict(extra='allow')
     eval_options: Optional[dict] = {}
     def __init__(self, **data):       
         super().__init__(**data)

--- a/test_tools/src/monocle_test_tools/evals/okahu_eval.py
+++ b/test_tools/src/monocle_test_tools/evals/okahu_eval.py
@@ -14,6 +14,9 @@ logger = logging.getLogger(__name__)
 OKAHU_PROD_EVALUATION_ENDPOINT = "https://eval.okahu.co/api"
 
 class OkahuEval(BaseEval):
+    last_judge_output: dict = {}
+    last_total_tokens: Optional[int] = None
+
     def __init__(self, **data):
         eval_options = data.get("eval_options")
         super().__init__(eval_options=eval_options)

--- a/test_tools/src/monocle_test_tools/evals/okahu_eval.py
+++ b/test_tools/src/monocle_test_tools/evals/okahu_eval.py
@@ -21,6 +21,8 @@ class OkahuEval(BaseEval):
         self._trace_exported = self._trace_source == "okahu"  # Only export if using okahu trace source, otherwise assume already exported
         self._current_trace_id = None
         self._fact_map_cache = None
+        self.last_judge_output: dict = {}
+        self.last_total_tokens = None
     
     @staticmethod
     def _map_fact_name(fact_name: str) -> str:
@@ -404,6 +406,8 @@ class OkahuEval(BaseEval):
                 parsed = json.loads(eval_result[0].get("result"))
                 label = parsed.get("label")
                 explanation = parsed.get("explanation")
+                self.last_judge_output = parsed
+                self.last_total_tokens = parsed.get("total_tokens")
             except AssertionError:
                 raise
             except Exception as exc:

--- a/test_tools/src/monocle_test_tools/fluent_api.py
+++ b/test_tools/src/monocle_test_tools/fluent_api.py
@@ -51,6 +51,14 @@ class TraceAssertion():
     _eval:Optional[Union[str, BaseEval]]  = None
     _comparer: Union[str, BaseComparer] = DefaultComparer()
     _assertion_errors: list[dict[str, any]] = []
+    # Per-test eval-result-matrix stash (see check_eval). Class-level like
+    # _assertion_errors above: @collect_assertions returns a *new*
+    # TraceAssertion for every fluent call, so instance attributes set
+    # inside a chained method are invisible to the fixture's original
+    # asserter. Reassign only via `TraceAssertion._last_eval = ...`
+    # (class-qualified) and otherwise mutate in place (`.update(...)`) so
+    # the fixture's `traceAssertion.__last_eval` sees the same object.
+    _last_eval: Optional[dict[str, Any]] = None
 
     @staticmethod
     def get_trace_asserter():
@@ -107,6 +115,7 @@ class TraceAssertion():
         self.validator.cleanup()
         self._filtered_spans = None
         TraceAssertion._assertion_errors = []
+        TraceAssertion._last_eval = None
 
     @staticmethod
     def _validate_count_params(count: Optional[int], min_count: Optional[int], max_count: Optional[int]) -> None:
@@ -718,7 +727,38 @@ class TraceAssertion():
             raise AssertionError(message if message else "No evaluator configured. Call with_evaluation before check_eval.")
         if not self._filtered_spans:
             raise AssertionError(message if message else "No spans available for evaluation. Chain a span selector before check_eval.")
+
+        # Stash a per-call eval-result-matrix record on the asserter (additive,
+        # opt-in recorder in pytest_plugin.py reads this via `_last_eval`).
+        # Populated up-front so trace_id/expected survive even if evaluate()
+        # raises; updated below once a label/explanation are obtained.
+        try:
+            trace_id = format(self._filtered_spans[0].get_span_context().trace_id, "032x")
+        except Exception:
+            trace_id = ""
+        # Class-qualified (not `self._last_eval = ...`): @collect_assertions
+        # hands check_eval a fresh TraceAssertion instance per call, so a
+        # plain `self._last_eval = ...` would only shadow this one
+        # throwaway instance and never reach the fixture's original
+        # asserter. See the class-attribute comment above.
+        TraceAssertion._last_eval = {
+            "trace_id": trace_id,
+            "expected": expected,
+            "fact_name": fact_name,
+            "label": None,
+            "explanation": "",
+            "judge_output": {},
+            "total_tokens": None,
+        }
+
         eval_result, explanation = self._eval.evaluate(filtered_spans=self._filtered_spans, eval_name=eval_name, fact_name=fact_name, template=template)
+
+        self._last_eval.update(
+            label=eval_result,
+            explanation=explanation,
+            judge_output=getattr(self._eval, "last_judge_output", {}) or {},
+            total_tokens=getattr(self._eval, "last_total_tokens", None),
+        )
 
         if (positive and eval_result not in positive) or (negative and eval_result in negative):
             if message:

--- a/test_tools/src/monocle_test_tools/pytest_plugin.py
+++ b/test_tools/src/monocle_test_tools/pytest_plugin.py
@@ -2,6 +2,23 @@ import os
 from datetime import datetime
 import pytest
 from .fluent_api import TraceAssertion
+from . import eval_matrix
+
+
+def pytest_addoption(parser) -> None:
+    """Register the opt-in --monocle-eval-matrix option.
+
+    See `eval_matrix.py` for the recorder implementation. Off by default:
+    a plain `pytest` invocation with neither this flag nor the
+    MONOCLE_EVAL_MATRIX env var set records nothing and writes no file.
+    """
+    eval_matrix.pytest_addoption(parser)
+
+
+def pytest_sessionfinish(session) -> None:
+    """If the eval-result-matrix recorder is enabled, write the collected
+    records to the resolved output path."""
+    eval_matrix.pytest_sessionfinish(session)
 
 @pytest.fixture(scope="session", autouse=True)
 def run_once_at_start_of_session():
@@ -78,7 +95,11 @@ def monocle_trace_asserter(request:pytest.FixtureRequest):
             assertion_messages = None
         traceAssertion.validator.post_test_cleanup(token, request.node.name, is_test_failed,
                                     assertion_messages, skip_export=traceAssertion._skip_export)
-        
+
+        # Opt-in eval-result-matrix recorder: self-skips when disabled, or
+        # when this test never called check_eval (no `_last_eval` stash).
+        eval_matrix.record_eval_row_for(request.config, request, traceAssertion)
+
         # Cleanup trace asserter (triggers eval cleanup including trace deletion)
         traceAssertion.cleanup()
 

--- a/test_tools/tests/unit/test_eval_matrix.py
+++ b/test_tools/tests/unit/test_eval_matrix.py
@@ -1,0 +1,93 @@
+from monocle_test_tools.eval_matrix import build_eval_matrix_row
+
+
+def test_build_eval_matrix_row_pass_includes_tokens():
+    last_eval = {
+        "trace_id": "abc123",
+        "expected": ["no_hallucination"],
+        "fact_name": "traces",
+        "label": "no_hallucination",
+        "explanation": "matches expectations",
+        "judge_output": {
+            "claim_verdicts": [{"claim": "x", "verdict": "supported"}],
+            "hallucination_types": [],
+            "entity_match_check": "ok",
+        },
+        "total_tokens": 123,
+    }
+
+    row = build_eval_matrix_row(run_id="run-1", scenario="test_x", last_eval=last_eval, passed=True)
+
+    assert row == {
+        "run_id": "run-1",
+        "scenario": "test_x",
+        "trace_id": "abc123",
+        "expected": ["no_hallucination"],
+        "actual": "no_hallucination",
+        "status": "pass",
+        "explanation": "matches expectations",
+        "total_tokens": 123,
+        "claim_verdicts": [{"claim": "x", "verdict": "supported"}],
+        "hallucination_types": [],
+        "entity_match_check": "ok",
+    }
+
+
+def test_build_eval_matrix_row_not_passed_with_label_is_drift():
+    last_eval = {
+        "trace_id": "def456",
+        "expected": ["no_hallucination"],
+        "fact_name": "traces",
+        "label": "major_hallucination",
+        "explanation": "diverged",
+        "judge_output": {},
+        "total_tokens": 42,
+    }
+
+    row = build_eval_matrix_row(run_id="run-2", scenario="test_y", last_eval=last_eval, passed=False)
+
+    assert row["status"] == "drift"
+    assert row["actual"] == "major_hallucination"
+    assert row["claim_verdicts"] == []
+    assert row["hallucination_types"] == []
+    assert row["entity_match_check"] == ""
+
+
+def test_build_eval_matrix_row_not_passed_without_label_is_error():
+    last_eval = {
+        "trace_id": "",
+        "expected": None,
+        "fact_name": "traces",
+        "label": None,
+        "explanation": "",
+        "judge_output": {},
+        "total_tokens": None,
+    }
+
+    row = build_eval_matrix_row(run_id="run-3", scenario="test_z", last_eval=last_eval, passed=False)
+
+    assert row["status"] == "error"
+    assert row["actual"] == ""
+    assert row["total_tokens"] is None
+    assert row["trace_id"] == ""
+
+
+def test_build_eval_matrix_row_is_none_safe_for_missing_judge_output_keys():
+    last_eval = {
+        "trace_id": "abc",
+        "expected": "no_hallucination",
+        "fact_name": "traces",
+        "label": "no_hallucination",
+        "explanation": None,
+        "judge_output": None,
+        "total_tokens": None,
+    }
+
+    row = build_eval_matrix_row(run_id="run-4", scenario="test_w", last_eval=last_eval, passed=True)
+
+    assert row["status"] == "pass"
+    assert row["claim_verdicts"] == []
+    assert row["hallucination_types"] == []
+    assert row["entity_match_check"] == ""
+    # explanation is passed through as-is from last_eval (no forced fallback)
+    assert row["explanation"] is None

--- a/test_tools/tests/unit/test_eval_matrix.py
+++ b/test_tools/tests/unit/test_eval_matrix.py
@@ -1,4 +1,6 @@
-from monocle_test_tools.eval_matrix import build_eval_matrix_row
+from unittest.mock import Mock, patch
+from monocle_test_tools.eval_matrix import build_eval_matrix_row, reset_records, record_eval_row_for, get_records
+from monocle_test_tools.fluent_api import TraceAssertion
 
 
 def test_build_eval_matrix_row_pass_includes_tokens():
@@ -91,3 +93,84 @@ def test_build_eval_matrix_row_is_none_safe_for_missing_judge_output_keys():
     assert row["entity_match_check"] == ""
     # explanation is passed through as-is from last_eval (no forced fallback)
     assert row["explanation"] is None
+
+
+def test_recorder_does_not_bleed_stale_eval_between_tests():
+    """Regression test: verify that _last_eval state doesn't leak from scenario A to scenario B.
+
+    This tests the fragile class-level _last_eval attribute isolation: if a test
+    never populated _last_eval, it should record NO row and NOT inherit a previous
+    scenario's _last_eval.
+    """
+    reset_records()
+
+    # Scenario A: test with _last_eval set
+    asserter_a = TraceAssertion.get_trace_asserter()
+    # At this point, cleanup() has been called, so _last_eval is None
+    assert TraceAssertion._last_eval is None
+
+    # Manually set _last_eval (simulating what check_eval would do)
+    TraceAssertion._last_eval = {
+        "trace_id": "t1",
+        "expected": "major_hallucination",
+        "fact_name": "traces",
+        "label": "major_hallucination",
+        "explanation": "e",
+        "judge_output": {},
+        "total_tokens": 10,
+    }
+
+    # Record scenario A
+    mock_config_a = Mock()
+    mock_config_a.getoption.return_value = "test-matrix.json"
+    mock_node_a = Mock()
+    mock_node_a.name = "test_scenario_a"
+    mock_node_a.callspec = None
+    mock_rep_call_a = Mock()
+    mock_rep_call_a.passed = True
+    mock_node_a.rep_call = mock_rep_call_a
+    mock_request_a = Mock()
+    mock_request_a.config = mock_config_a
+    mock_request_a.node = mock_node_a
+
+    record_eval_row_for(mock_config_a, mock_request_a, asserter_a)
+
+    # Cleanup A (resets _last_eval to None)
+    asserter_a.cleanup()
+    assert TraceAssertion._last_eval is None
+
+    # Scenario B: test without _last_eval set
+    asserter_b = TraceAssertion.get_trace_asserter()
+    # Cleanup has reset _last_eval, so it should be None
+    assert TraceAssertion._last_eval is None
+
+    # Do NOT set _last_eval for scenario B
+
+    # Try to record scenario B
+    mock_config_b = Mock()
+    mock_config_b.getoption.return_value = "test-matrix.json"
+    mock_node_b = Mock()
+    mock_node_b.name = "test_scenario_b"
+    mock_node_b.callspec = None
+    mock_rep_call_b = Mock()
+    mock_rep_call_b.passed = True
+    mock_node_b.rep_call = mock_rep_call_b
+    mock_request_b = Mock()
+    mock_request_b.config = mock_config_b
+    mock_request_b.node = mock_node_b
+
+    record_eval_row_for(mock_config_b, mock_request_b, asserter_b)
+
+    # Cleanup B
+    asserter_b.cleanup()
+
+    # Verify: exactly ONE row recorded (from scenario A only)
+    records = get_records()
+    assert len(records) == 1, f"Expected 1 record, got {len(records)}: {records}"
+
+    # Verify the one row is from scenario A
+    row_a = records[0]
+    assert row_a["scenario"] == "test_scenario_a"
+    assert row_a["trace_id"] == "t1"
+    assert row_a["actual"] == "major_hallucination"
+    assert row_a["total_tokens"] == 10

--- a/test_tools/tests/unit/test_okahu_eval_tokens.py
+++ b/test_tools/tests/unit/test_okahu_eval_tokens.py
@@ -1,0 +1,24 @@
+import json
+from unittest.mock import patch, MagicMock
+from monocle_test_tools.evals.okahu_eval import OkahuEval
+
+def _resp(judge: dict):
+    m = MagicMock()
+    m.headers = {"Content-Type": "application/json"}
+    m.raise_for_status.return_value = None
+    m.json.return_value = {"job_id": "interactive_x_1", "result": [{"result": json.dumps(judge)}]}
+    return m
+
+def test_evaluate_stashes_total_tokens_and_output(monkeypatch):
+    ev = OkahuEval(eval_options={"trace_source": "file"})
+    judge = {"label": "major_hallucination", "explanation": "why", "total_tokens": 512}
+    span = MagicMock()
+    span.attributes = {"workflow.name": "wf"}
+    monkeypatch.setenv("OKAHU_API_KEY", "k")
+    with patch.object(OkahuEval, "export_trace", return_value="traceid"), \
+         patch.object(OkahuEval, "enumerate_fact_ids", return_value=["traceid"]), \
+         patch("monocle_test_tools.evals.okahu_eval.requests.post", return_value=_resp(judge)):
+        label, explanation = ev.evaluate(filtered_spans=[span], template={"name": "t"}, fact_name="traces")
+    assert (label, explanation) == ("major_hallucination", "why")   # arity unchanged
+    assert ev.last_total_tokens == 512
+    assert ev.last_judge_output["label"] == "major_hallucination"


### PR DESCRIPTION
## What
- `OkahuEval.evaluate()` now stashes `last_judge_output` + `last_total_tokens` on the instance (the token count already returned by the eval API); return arity unchanged (2-tuple).
- New **opt-in** pytest plugin option `--monocle-eval-matrix[=PATH]` (env `MONOCLE_EVAL_MATRIX`) that records a per-test eval-result matrix — scenario, label, expected, judge output (claim_verdicts / hallucination_types / entity_match_check), total_tokens, and pass/drift/error — and writes `{generated_at, records:[…]}` at `pytest_sessionfinish`. **Off by default** (no behavior change unless enabled); test-isolated (class-level `_last_eval` reset per test, with a committed regression test).

## Why
Lets eval benchmarks capture stability + token-cost matrices via the harness instead of each project hand-rolling a conftest recorder.

## Tests
New `tests/unit/test_eval_matrix.py` (5); full unit suite green (191 unrelated pre-existing google.adk skip aside). Verified off-by-default + no stale-bleed via live repro in review.

DCO: all commits `Signed-off-by`.
Backlog: https://github.com/okahu/monocle_backlog_tracking/issues/214

🤖 Generated with [Claude Code](https://claude.com/claude-code)