### PR TITLE
litellm: Responses API coverage + non-streaming tool-call output

### DIFF
--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/_helper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/_helper.py
@@ -148,12 +148,22 @@ def extract_assistant_message(arguments):
             response = arguments["result"]
             if (response is not None and hasattr(response, "choices") and len(response.choices) > 0):
                 if hasattr(response.choices[0], "message"):
-                    role = (
-                        response.choices[0].message.role
-                        if hasattr(response.choices[0].message, "role")
-                        else "assistant"
-                    )
-                    messages.append({role: response.choices[0].message.content})
+                    message = response.choices[0].message
+                    role = getattr(message, "role", None) or "assistant"
+                    # Tool-call responses carry null content; surface the tool
+                    # calls instead (mirrors the openai metamodel helper).
+                    if getattr(message, "tool_calls", None):
+                        tools = []
+                        for tool in message.tool_calls:
+                            function = getattr(tool, "function", None)
+                            tools.append({
+                                "tool_id": getattr(tool, "id", "") or "",
+                                "tool_name": getattr(function, "name", "") or "",
+                                "tool_arguments": getattr(function, "arguments", "") or "",
+                            })
+                        messages.append({role: tools})
+                    else:
+                        messages.append({role: message.content})
             return get_json_dumps(messages[0]) if messages else ""
         else:
             if arguments["exception"] is not None:
@@ -299,5 +309,97 @@ def extract_tool_type(arguments):
 
     except Exception as e:
         logger.warning("Warning: Error occurred in extract_tool_type: %s", str(e))
-    
+
     return None
+
+
+# --- OpenAI Responses API (litellm.responses / aresponses) --------------------
+# gpt-5 / o-series models route through litellm's raw-httpx response handler,
+# which the chat-completion accessors above do not cover. These read a
+# ResponsesAPIResponse (non-streaming).
+
+def _item_attr(item, key):
+    if isinstance(item, dict):
+        return item.get(key)
+    return getattr(item, key, None)
+
+
+def extract_responses_input(kwargs):
+    """Extract input messages for the Responses API path (kwargs['input'])."""
+    try:
+        raw_input = kwargs.get("input")
+        if raw_input is None:
+            return []
+        if isinstance(raw_input, str):
+            return [get_json_dumps({"user": raw_input})]
+        messages = []
+        for item in raw_input:
+            role = _item_attr(item, "role")
+            content = _item_attr(item, "content")
+            if role and content is not None:
+                messages.append({role: content})
+            elif isinstance(item, dict):
+                messages.append(item)
+            else:
+                messages.append(str(item))
+        return [get_json_dumps(message) for message in messages]
+    except Exception as e:
+        logger.warning("Warning: Error occurred in extract_responses_input: %s", str(e))
+        return []
+
+
+def extract_responses_output(arguments):
+    """Extract assistant message/tool calls from a ResponsesAPIResponse."""
+    try:
+        if arguments.get("exception") is not None:
+            return get_exception_message(arguments)
+        response = arguments["result"]
+        if response is None:
+            return ""
+        messages = []
+        tools = []
+        texts = []
+        for item in getattr(response, "output", None) or []:
+            item_type = _item_attr(item, "type")
+            if item_type == "function_call":
+                tools.append({
+                    "tool_id": _item_attr(item, "call_id") or "",
+                    "tool_name": _item_attr(item, "name") or "",
+                    "tool_arguments": _item_attr(item, "arguments") or "",
+                })
+            elif item_type == "message":
+                for part in _item_attr(item, "content") or []:
+                    text = _item_attr(part, "text")
+                    if text:
+                        texts.append(text)
+        if tools:
+            messages.append({"tools": tools})
+        if texts:
+            messages.append({"assistant": "\n".join(texts)})
+        return get_json_dumps(messages[0]) if messages else ""
+    except Exception as e:
+        logger.warning("Warning: Error occurred in extract_responses_output: %s", str(e))
+        return None
+
+
+def extract_responses_finish_reason(arguments):
+    """Finish reason for the Responses API: tool_calls beat plain completion status."""
+    try:
+        if arguments.get("exception") is not None:
+            return "error"
+        response = arguments.get("result")
+        if response is None:
+            return None
+        for item in getattr(response, "output", None) or []:
+            if _item_attr(item, "type") == "function_call":
+                return "tool_calls"
+        return getattr(response, "status", None)
+    except Exception as e:
+        logger.warning("Warning: Error occurred in extract_responses_finish_reason: %s", str(e))
+        return None
+
+
+def responses_inference_type(arguments):
+    if extract_responses_finish_reason(arguments) == "tool_calls":
+        return INFERENCE_TOOL_CALL
+    return INFERENCE_TURN_END

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/entities/responses.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/entities/responses.py
@@ -1,0 +1,102 @@
+from monocle_apptrace.instrumentation.common.constants import SPAN_TYPES
+from monocle_apptrace.instrumentation.metamodel.litellm import (
+    _helper,
+)
+from monocle_apptrace.instrumentation.common.utils import (
+    get_error_message,
+    resolve_from_alias,
+)
+
+# OpenAI Responses API (litellm.responses / aresponses). gpt-5 / o-series
+# models route through litellm's raw-httpx response handler, which the
+# chat-completion INFERENCE entity does not wrap. Non-streaming only.
+RESPONSES = {
+    "type": SPAN_TYPES.INFERENCE,
+    "subtype": lambda arguments: _helper.responses_inference_type(arguments),
+    "attributes": [
+        [
+            {
+                "_comment": "provider type, name, inference_endpoint",
+                "attribute": "type",
+                "accessor": lambda arguments: "inference."
+                + (arguments["kwargs"].get("custom_llm_provider") or "generic"),
+            },
+            {
+                "attribute": "provider_name",
+                "accessor": lambda arguments: _helper.extract_provider_name(
+                    (arguments["kwargs"].get("litellm_params") or {}).get("api_base")
+                ),
+            },
+            {
+                "attribute": "inference_endpoint",
+                "accessor": lambda arguments: (
+                    arguments["kwargs"].get("litellm_params") or {}
+                ).get("api_base"),
+            },
+        ],
+        [
+            {
+                "_comment": "LLM Model",
+                "attribute": "name",
+                "accessor": lambda arguments: resolve_from_alias(
+                    arguments["kwargs"], ["model"]
+                ),
+            },
+            {
+                "attribute": "type",
+                "accessor": lambda arguments: "model.llm."
+                + resolve_from_alias(arguments["kwargs"], ["model"]),
+            },
+        ],
+    ],
+    "events": [
+        {
+            "name": "data.input",
+            "attributes": [
+                {
+                    "_comment": "this is instruction and user query to LLM",
+                    "attribute": "input",
+                    "accessor": lambda arguments: _helper.extract_responses_input(
+                        arguments["kwargs"]
+                    ),
+                }
+            ],
+        },
+        {
+            "name": "data.output",
+            "attributes": [
+                {
+                    "attribute": "error_code",
+                    "accessor": lambda arguments: get_error_message(arguments)
+                },
+                {
+                    "_comment": "this is result from LLM",
+                    "attribute": "response",
+                    "accessor": lambda arguments: _helper.extract_responses_output(arguments),
+                }
+            ],
+        },
+        {
+            "name": "metadata",
+            "attributes": [
+                {
+                    "_comment": "this is metadata usage from LLM",
+                    "accessor": lambda arguments: _helper.update_span_from_llm_response(
+                        arguments["result"]
+                    ),
+                },
+                {
+                    "_comment": "finish reason from the Responses API result",
+                    "attribute": "finish_reason",
+                    "accessor": lambda arguments: _helper.extract_responses_finish_reason(arguments)
+                },
+                {
+                    "_comment": "finish type mapped from finish reason",
+                    "attribute": "finish_type",
+                    "accessor": lambda arguments: _helper.map_finish_reason_to_finish_type(
+                        _helper.extract_responses_finish_reason(arguments))
+                }
+            ],
+        },
+    ],
+}

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/litellm_span_handler.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/litellm_span_handler.py
@@ -25,5 +25,8 @@ class LiteLLMSyncSpanHandler(SpanHandler):
         Returns:
             bool: True if the argument acompletion is true, False otherwise
         """
-        return kwargs.get('acompletion') is True
+        # response_api_handler signals its async variant via _is_async: the
+        # sync call then returns an unawaited coroutine, so a span here would
+        # never see the real result (the async wrap owns the span).
+        return kwargs.get('acompletion') is True or kwargs.get('_is_async') is True
 

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/methods.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/litellm/methods.py
@@ -1,7 +1,25 @@
 from monocle_apptrace.instrumentation.common.wrapper import atask_wrapper, task_wrapper
 from monocle_apptrace.instrumentation.metamodel.litellm.entities.inference import INFERENCE
+from monocle_apptrace.instrumentation.metamodel.litellm.entities.responses import RESPONSES
 
 LITELLM_METHODS = [
+    {
+        # OpenAI Responses API (and compatible providers) via litellm's HTTP handler.
+        # gpt-5 / o-series models route here instead of chat completions.
+        "package": "litellm.llms.custom_httpx.llm_http_handler",
+        "object": "BaseLLMHTTPHandler",
+        "method": "response_api_handler",
+        "wrapper_method": task_wrapper,
+        "output_processor": RESPONSES,
+        "span_handler": "litellm_sync_handler"
+    },
+    {
+        "package": "litellm.llms.custom_httpx.llm_http_handler",
+        "object": "BaseLLMHTTPHandler",
+        "method": "async_response_api_handler",
+        "wrapper_method": atask_wrapper,
+        "output_processor": RESPONSES
+    },
     {
         "package": "litellm.llms.openai.openai",
         "object": "OpenAIChatCompletion",

--- a/apptrace/tests/unit/test_litellm_responses_toolcall.py
+++ b/apptrace/tests/unit/test_litellm_responses_toolcall.py
@@ -1,0 +1,102 @@
+"""Unit tests for the non-streaming litellm additions in this PR:
+
+- ``extract_assistant_message`` surfaces tool calls (was ``{"assistant": null}``)
+- Responses API accessors (input / output / finish_reason / inference type)
+- ``litellm_sync_handler`` skips the async Responses shim (``_is_async``)
+
+All stand-ins — no network, no litellm/openhands install required.
+"""
+from types import SimpleNamespace
+
+from monocle_apptrace.instrumentation.metamodel.litellm import _helper
+from monocle_apptrace.instrumentation.metamodel.litellm.litellm_span_handler import (
+    LiteLLMSyncSpanHandler,
+)
+from monocle_apptrace.instrumentation.metamodel.litellm.entities.responses import RESPONSES
+
+
+# --- non-streaming tool-call output fix -------------------------------------
+
+def test_extract_assistant_message_non_streaming_tool_calls():
+    # tool-call responses carry content=None; the output must surface the tool
+    # calls instead of {"assistant": null}
+    function = SimpleNamespace(name="terminal", arguments='{"command":"ls"}')
+    tool_call = SimpleNamespace(id="call_7", function=function)
+    message = SimpleNamespace(role="assistant", content=None, tool_calls=[tool_call])
+    response = SimpleNamespace(choices=[SimpleNamespace(message=message)])
+    out = _helper.extract_assistant_message({"result": response, "exception": None})
+    assert '"tool_name": "terminal"' in out
+    assert "null" not in out
+
+
+def test_extract_assistant_message_plain_content_unchanged():
+    message = SimpleNamespace(role="assistant", content="hello", tool_calls=None)
+    response = SimpleNamespace(choices=[SimpleNamespace(message=message)])
+    out = _helper.extract_assistant_message({"result": response, "exception": None})
+    assert out == '{"assistant": "hello"}'
+
+
+# --- Responses API accessors ------------------------------------------------
+
+def _responses_result():
+    function_call = SimpleNamespace(
+        type="function_call", call_id="call_9", name="terminal", arguments='{"command":"ls"}'
+    )
+    message = SimpleNamespace(type="message", content=[SimpleNamespace(text="listing files")])
+    return SimpleNamespace(
+        output=[function_call, message],
+        status="completed",
+        usage=SimpleNamespace(completion_tokens=None, output_tokens=5, prompt_tokens=None,
+                              input_tokens=7, total_tokens=12),
+    )
+
+
+def test_extract_responses_input_string_and_messages():
+    assert _helper.extract_responses_input({"input": "hi there"}) == ['{"user": "hi there"}']
+    assert _helper.extract_responses_input(
+        {"input": [{"role": "user", "content": "list the files"}]}
+    ) == ['{"user": "list the files"}']
+
+
+def test_extract_responses_output_and_finish_reason_tool_calls():
+    arguments = {"result": _responses_result(), "exception": None}
+    out = _helper.extract_responses_output(arguments)
+    assert '"tool_name": "terminal"' in out
+    assert _helper.extract_responses_finish_reason(arguments) == "tool_calls"
+    assert _helper.responses_inference_type(arguments) == _helper.INFERENCE_TOOL_CALL
+
+
+def test_extract_responses_finish_reason_message_only():
+    message_only = SimpleNamespace(
+        output=[SimpleNamespace(type="message", content=[SimpleNamespace(text="hi")])],
+        status="completed",
+    )
+    arguments = {"result": message_only, "exception": None}
+    assert _helper.extract_responses_finish_reason(arguments) == "completed"
+    assert _helper.responses_inference_type(arguments) == _helper.INFERENCE_TURN_END
+
+
+def test_responses_usage_metadata():
+    meta = _helper.update_span_from_llm_response(_responses_result())
+    assert meta["completion_tokens"] == 5
+    assert meta["prompt_tokens"] == 7
+    assert meta["total_tokens"] == 12
+
+
+# --- async Responses shim skip ----------------------------------------------
+
+def test_responses_sync_handler_skips_async_shim():
+    # response_api_handler with _is_async=True returns an unawaited coroutine;
+    # the sync span must be skipped (the async wrap owns the real span)
+    handler = LiteLLMSyncSpanHandler()
+    assert handler.skip_span({}, None, None, (), {"_is_async": True}) is True
+    assert handler.skip_span({}, None, None, (), {"_is_async": False}) is False
+    assert handler.skip_span({}, None, None, (), {"acompletion": True}) is True
+
+
+# --- the Responses entity is non-streaming ----------------------------------
+
+def test_responses_entity_is_non_streaming():
+    # no deferred-close / stream-processor wiring on this entity
+    assert "response_processor" not in RESPONSES
+    assert "is_auto_close" not in RESPONSES


### PR DESCRIPTION
## What

Two additive, non-streaming litellm gaps — touches only `metamodel/litellm/` (no shared-code, no streaming):

1. **Responses API.** `litellm.responses()` / `aresponses()` route through `BaseLLMHTTPHandler.response_api_handler` / `async_response_api_handler` (raw httpx; the path gpt-5 / o-series take), which nothing wrapped → **zero inference spans**. New `RESPONSES` entity with input/output/usage/finish-reason accessors over `ResponsesAPIResponse`. The sync shim is skipped when `_is_async=True` (the sync call returns an unawaited coroutine; the async wrap owns the span).

2. **Non-streaming tool-call output.** Tool-call responses carry `content=None`, so `data.output` read `{"assistant": null}`; now surfaces the tool calls. Provider-agnostic — applies to any litellm provider whose tool calls arrive in chat-completion shape (OpenAI, Anthropic, Bedrock, Gemini, …).


## Validation (`main` → this PR, real runs)

- chat + tool (gpt-4o-mini), sync & async: `{"assistant": null}` → tool calls surfaced, with token usage.
- Responses (gpt-5-nano), sync & async: no inference span → span with output + usage (async: exactly one, no leaked twin).
- End-to-end via OpenHands (with #708): 4 tool-using runs, each a single connected `workflow → agentic.turn → agentic.invocation → agentic.tool.invocation → inference` trace.

`tests/unit/test_litellm_responses_toolcall.py` adds 8 stand-in unit tests (no network) covering the tool-call output fix, the Responses accessors (input/output/finish_reason/inference type/usage), and the async-shim skip. (The litellm *streaming* unit tests remain in #641.)

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
