### PR TITLE
Add CSV → fluent test-case adapter to monocle_test_tools

### DIFF
--- a/test_tools/examples/cases.example.csv
+++ b/test_tools/examples/cases.example.csv
@@ -1,4 +1,4 @@
-case_id,id,workflow_name,fact_name,expected,not_expected,called_tool,called_agent,token_limit,duration_ms,has_input,has_output,extra_json,notes
-cc_t01,642dbd9d0dfcfdbdc8849f67f34c8a19,test_cc_customer_care_agent,traces,major_hallucination,,,,,,,,,eval-replay row (kit parity)
-cc_t02,8f127fc9bad5199ff073acbf1cbdece1,test_cc_customer_care_agent,traces,no_hallucination,,,,,,,,,eval-replay row
-tool_01,642dbd9d0dfcfdbdc8849f67f34c8a19,test_cc_customer_care_agent,,,,search_web,,5000,,,,"[{""method"":""has_attribute"",""kwargs"":{""attribute_name"":""model"",""expected"":""gpt-4o""}}]",non-eval row: tool + token budget + attribute via escape hatch
+case_id,fact_id,workflow_name,fact_name,expected,not_expected,max_tokens,max_duration_ms,notes
+cc_t01,642dbd9d0dfcfdbdc8849f67f34c8a19,test_cc_customer_care_agent,traces,major_hallucination,,,,eval-replay row (kit parity)
+cc_t02,8f127fc9bad5199ff073acbf1cbdece1,test_cc_customer_care_agent,traces,no_hallucination,,,,eval-replay row
+cc_t03,642dbd9d0dfcfdbdc8849f67f34c8a19,test_cc_customer_care_agent,traces,no_hallucination,,5000,4000,eval row with token budget + duration guard rails

--- a/test_tools/examples/cases.example.csv
+++ b/test_tools/examples/cases.example.csv
@@ -1,0 +1,4 @@
+case_id,id,workflow_name,fact_name,expected,not_expected,called_tool,called_agent,token_limit,duration_ms,has_input,has_output,extra_json,notes
+cc_t01,642dbd9d0dfcfdbdc8849f67f34c8a19,test_cc_customer_care_agent,traces,major_hallucination,,,,,,,,,eval-replay row (kit parity)
+cc_t02,8f127fc9bad5199ff073acbf1cbdece1,test_cc_customer_care_agent,traces,no_hallucination,,,,,,,,,eval-replay row
+tool_01,642dbd9d0dfcfdbdc8849f67f34c8a19,test_cc_customer_care_agent,,,,search_web,,5000,,,,"[{""method"":""has_attribute"",""kwargs"":{""attribute_name"":""model"",""expected"":""gpt-4o""}}]",non-eval row: tool + token budget + attribute via escape hatch

--- a/test_tools/examples/csv_cases_example.py
+++ b/test_tools/examples/csv_cases_example.py
@@ -1,0 +1,29 @@
+"""Copy-ready example: drive monocle test cases from a CSV.
+
+Real usage — a teammate writes this stub once; non-engineers edit the CSV:
+
+    import os
+    from monocle_test_tools import monocle_csv_cases
+
+    TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), "hallucination_test.json")
+
+    @monocle_csv_cases("cases.example.csv")
+    def test_cases(monocle_trace_asserter, case):
+        case.run(monocle_trace_asserter.with_evaluation("okahu"),
+                 template_path=TEMPLATE_PATH)
+
+The smoke test below runs offline: it only checks the CSV loads and maps.
+"""
+import os
+
+from monocle_test_tools import load_cases_from_csv
+
+_CSV = os.path.join(os.path.dirname(os.path.abspath(__file__)), "cases.example.csv")
+
+
+def test_example_csv_loads():
+    cases = load_cases_from_csv(_CSV)
+    assert len(cases) >= 2
+    assert cases[0].case_id
+    # every example row has at least one assertion (guaranteed by the loader)
+    assert cases[0].expected is not None or cases[0].called_tool is not None

--- a/test_tools/examples/csv_cases_example.py
+++ b/test_tools/examples/csv_cases_example.py
@@ -1,4 +1,4 @@
-"""Copy-ready example: drive monocle test cases from a CSV.
+"""Copy-ready example: drive monocle eval test cases from a CSV.
 
 Real usage — a teammate writes this stub once; non-engineers edit the CSV:
 
@@ -25,5 +25,5 @@ def test_example_csv_loads():
     cases = load_cases_from_csv(_CSV)
     assert len(cases) >= 2
     assert cases[0].case_id
-    # every example row has at least one assertion (guaranteed by the loader)
-    assert cases[0].expected is not None or cases[0].called_tool is not None
+    # every eval row carries a label (guaranteed by the loader)
+    assert cases[0].expected is not None or cases[0].not_expected is not None

--- a/test_tools/src/monocle_test_tools/__init__.py
+++ b/test_tools/src/monocle_test_tools/__init__.py
@@ -25,6 +25,7 @@ from .comparer import ( BaseComparer, BertScoreComparer, DefaultComparer)
 from . import trace_utils
 from .runner import AgentRunner, get_agent_runner
 from .fluent_api import TraceAssertion
+from .csv_cases import CsvCase, load_cases_from_csv, monocle_csv_cases
 from .test_generator import TestGenerator
 from . import pytest_plugin
 from . import gitutils
@@ -48,6 +49,9 @@ __all__ = [
     "MockTool",
     "ToolType",
     "TraceAssertion",
+    "CsvCase",
+    "load_cases_from_csv",
+    "monocle_csv_cases",
     "TestGenerator",
     "pytest_plugin",
     "gitutils"

--- a/test_tools/src/monocle_test_tools/csv_cases.py
+++ b/test_tools/src/monocle_test_tools/csv_cases.py
@@ -1,15 +1,24 @@
-"""CSV -> fluent test-case adapter for monocle_test_tools.
+"""CSV -> fluent eval test-case adapter for monocle_test_tools.
 
-Loads a flat CSV of okahu-trace test cases and drives each row through the
-existing fluent TraceAssertion API via ``@monocle_csv_cases`` + ``CsvCase.run``,
-so test data can be curated in a spreadsheet.
+Loads a flat CSV of okahu-trace *evaluation* test cases and drives each row
+through the existing fluent TraceAssertion API via ``@monocle_csv_cases`` +
+``CsvCase.run``, so eval test data can be curated in a spreadsheet.
+
+Scope (v0): evaluation tests only. Each row asserts an eval label
+(``expected``/``not_expected`` via ``check_eval``) and, optionally, operational
+guard rails on the run: a token budget (``max_tokens`` -> ``under_token_limit``)
+and an effort ceiling (``max_duration_ms`` -> ``under_duration``). The loader
+bridges exactly these three stable, eval-relevant fluent methods -- not the
+open set of assertions. General non-eval assertions (tool/agent calls,
+input/output, arbitrary fluent methods) and multi-condition rows are
+intentionally out of scope for v0; see the PR for the rationale and future
+considerations.
 
 Config-in-code, data-in-CSV: the test stub owns everything constant across the
 sheet (the evaluator via ``with_evaluation(...)``, the eval ``template_path``,
 and the trace source, fixed to ``okahu`` in this version); the CSV owns only
-what varies per row (trace id, workflow, expected labels, and per-row
-assertions). One row = one test; a row may carry several assertions, each run
-independently against the same loaded trace.
+what varies per row (fact id, workflow, expected labels, guard rails).
+One row = one test.
 
 Example test stub::
 
@@ -22,26 +31,12 @@ import csv
 import inspect
 import json
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Dict, List, Optional, Union
 
 import pytest
 
-from monocle_test_tools.fluent_api import TraceAssertion
-
-REQUIRED_COLUMNS = ("case_id", "id", "workflow_name")
-
-FACT_NAME_VALUES = (
-    "traces", "inferences", "agentic_turns", "agentic_sessions",
-    "agent_invocation", "tool_execution", "commits", "conversations",
-    "test_runs", "tests",
-)
-
-# Columns that constitute an assertion; a valid row has >= 1 populated.
-ASSERTION_COLUMNS = (
-    "expected", "not_expected", "called_tool", "called_agent",
-    "token_limit", "duration_ms", "has_input", "has_output", "extra_json",
-)
+REQUIRED_COLUMNS = ("case_id", "fact_id", "workflow_name")
 
 
 class CsvCaseError(ValueError):
@@ -98,82 +93,46 @@ def parse_float(cell: str, column: str, case_id: str) -> Optional[float]:
         raise CsvCaseError(f"row '{case_id}': column '{column}' must be a number, got '{cell}'")
 
 
-def parse_extra_json(cell: str, case_id: str) -> List[dict]:
-    """Parse the extra_json cell into a list of {"method", "kwargs"?} steps."""
-    if cell == "":
-        return []
-    try:
-        value = json.loads(cell)
-    except json.JSONDecodeError as exc:
-        raise CsvCaseError(f"row '{case_id}': column 'extra_json' is not valid JSON — {exc}")
-    if not isinstance(value, list):
-        raise CsvCaseError(f"row '{case_id}': column 'extra_json' must be a JSON array of steps")
-    for step in value:
-        if not isinstance(step, dict) or "method" not in step or not isinstance(step["method"], str):
-            raise CsvCaseError(
-                f"row '{case_id}': each extra_json step must be an object with a string 'method'"
-            )
-        if "kwargs" in step and not isinstance(step["kwargs"], dict):
-            raise CsvCaseError(f"row '{case_id}': extra_json step 'kwargs' must be an object")
-    return value
-
-
 @dataclass
 class CsvCase:
-    """One CSV row: an okahu-trace test case driven through the fluent API."""
+    """One CSV row: an okahu-trace evaluation test case driven through the fluent API."""
     case_id: str
-    id: str
+    fact_id: str
     workflow_name: str
     fact_name: str = "traces"
     expected: Optional[Union[str, List[str]]] = None
     not_expected: Optional[Union[str, List[str]]] = None
-    called_tool: Optional[str] = None
-    called_agent: Optional[str] = None
-    token_limit: Optional[int] = None
-    duration_ms: Optional[float] = None
-    has_input: Optional[str] = None
-    has_output: Optional[str] = None
-    extra_steps: List[dict] = field(default_factory=list)
+    max_tokens: Optional[int] = None
+    max_duration_ms: Optional[float] = None
     notes: Optional[str] = None
 
     def run(self, asserter, **check_eval_kwargs) -> None:
         """Drive this row through the fluent TraceAssertion `asserter`.
 
-        Independent assertions are each invoked on the base asserter (not
-        threaded): PR #721 collects failures on the asserter and the pytest
-        plugin reports them. Only misconfiguration (eval columns with no
-        evaluator) raises from here.
+        Runs the eval (``check_eval``) plus optional operational guard rails
+        (token budget, duration). Independent assertions are each invoked on
+        the base asserter (not threaded): PR #721 collects failures on the
+        asserter and the pytest plugin reports them. Only misconfiguration
+        (an eval row with no evaluator) raises from here.
         """
-        asserter.with_trace_source("okahu", id=self.id, workflow_name=self.workflow_name)
+        asserter.with_trace_source("okahu", id=self.fact_id, workflow_name=self.workflow_name)
 
-        if self.expected is not None or self.not_expected is not None:
-            if getattr(asserter, "_eval", None) is None:
-                raise CsvCaseError(
-                    f"row '{self.case_id}': has expected/not_expected but no evaluator is "
-                    f"configured. Add .with_evaluation(...) to your test stub."
-                )
-            asserter.check_eval(
-                expected=self.expected,
-                not_expected=self.not_expected,
-                fact_name=self.fact_name,
-                **check_eval_kwargs,
+        if getattr(asserter, "_eval", None) is None:
+            raise CsvCaseError(
+                f"row '{self.case_id}': is an evaluation case but no evaluator is "
+                f"configured. Add .with_evaluation(...) to your test stub."
             )
+        asserter.check_eval(
+            expected=self.expected,
+            not_expected=self.not_expected,
+            fact_name=self.fact_name,
+            **check_eval_kwargs,
+        )
 
-        if self.called_tool is not None:
-            asserter.called_tool(self.called_tool)
-        if self.called_agent is not None:
-            asserter.called_agent(self.called_agent)
-        if self.token_limit is not None:
-            asserter.under_token_limit(self.token_limit)
-        if self.duration_ms is not None:
-            asserter.under_duration(self.duration_ms, units="ms")
-        if self.has_input is not None:
-            asserter.has_input(self.has_input)
-        if self.has_output is not None:
-            asserter.has_output(self.has_output)
-
-        for step in self.extra_steps:
-            getattr(asserter, step["method"])(**step.get("kwargs", {}))
+        if self.max_tokens is not None:
+            asserter.under_token_limit(self.max_tokens)
+        if self.max_duration_ms is not None:
+            asserter.under_duration(self.max_duration_ms, units="ms")
 
 
 def _require(row: dict, column: str, case_id: str, line: int) -> str:
@@ -183,76 +142,37 @@ def _require(row: dict, column: str, case_id: str, line: int) -> str:
     return value
 
 
-def _validate_extra_steps(steps: List[dict], case_id: str) -> None:
-    for step in steps:
-        method_name = step["method"]
-        method = getattr(TraceAssertion, method_name, None)
-        if method is None or not callable(method):
-            raise CsvCaseError(
-                f"row '{case_id}': extra_json method '{method_name}' is not a TraceAssertion method"
-            )
-        kwargs = step.get("kwargs", {})
-        sig = inspect.signature(method)
-        accepts_var_kw = any(p.kind == p.VAR_KEYWORD for p in sig.parameters.values())
-        if not accepts_var_kw:
-            valid = set(sig.parameters) - {"self"}
-            unknown = set(kwargs) - valid
-            if unknown:
-                raise CsvCaseError(
-                    f"row '{case_id}': extra_json '{method_name}' got unknown kwargs {sorted(unknown)}; "
-                    f"valid: {sorted(valid)}"
-                )
-
-
 def _row_to_case(row: dict, line: int) -> CsvCase:
     case_id = row.get("case_id", "").strip()
     _require(row, "case_id", case_id, line)
-    trace_id = _require(row, "id", case_id, line)
+    fact_id = _require(row, "fact_id", case_id, line)
     workflow_name = _require(row, "workflow_name", case_id, line)
 
     fact_name = row.get("fact_name", "").strip() or "traces"
-    if fact_name not in FACT_NAME_VALUES:
+
+    expected = parse_multivalue(row.get("expected", "").strip())
+    not_expected = parse_multivalue(row.get("not_expected", "").strip())
+    if expected is None and not_expected is None:
         raise CsvCaseError(
-            f"row '{case_id}': invalid fact_name '{fact_name}'. Supported: {', '.join(FACT_NAME_VALUES)}"
+            f"row '{case_id}': an evaluation case requires an 'expected' or "
+            f"'not_expected' label (a token/duration guard rail alone is not a test)."
         )
 
-    extra_steps = parse_extra_json(row.get("extra_json", "").strip(), case_id)
-    _validate_extra_steps(extra_steps, case_id)
-
-    case = CsvCase(
+    return CsvCase(
         case_id=case_id,
-        id=trace_id,
+        fact_id=fact_id,
         workflow_name=workflow_name,
         fact_name=fact_name,
-        expected=parse_multivalue(row.get("expected", "").strip()),
-        not_expected=parse_multivalue(row.get("not_expected", "").strip()),
-        called_tool=(row.get("called_tool", "").strip() or None),
-        called_agent=(row.get("called_agent", "").strip() or None),
-        token_limit=parse_int(row.get("token_limit", "").strip(), "token_limit", case_id),
-        duration_ms=parse_float(row.get("duration_ms", "").strip(), "duration_ms", case_id),
-        has_input=(row.get("has_input", "").strip() or None),
-        has_output=(row.get("has_output", "").strip() or None),
-        extra_steps=extra_steps,
+        expected=expected,
+        not_expected=not_expected,
+        max_tokens=parse_int(row.get("max_tokens", "").strip(), "max_tokens", case_id),
+        max_duration_ms=parse_float(row.get("max_duration_ms", "").strip(), "max_duration_ms", case_id),
         notes=(row.get("notes", "").strip() or None),
     )
 
-    has_assertion = (
-        case.expected is not None or case.not_expected is not None
-        or case.called_tool is not None or case.called_agent is not None
-        or case.token_limit is not None or case.duration_ms is not None
-        or case.has_input is not None or case.has_output is not None
-        or len(case.extra_steps) > 0
-    )
-    if not has_assertion:
-        raise CsvCaseError(
-            f"row '{case_id}': declares a trace source but no assertions (vacuous test). "
-            f"Populate at least one of: {', '.join(ASSERTION_COLUMNS)}"
-        )
-    return case
-
 
 def load_cases_from_csv(path: str) -> List[CsvCase]:
-    """Load and validate a CSV of test cases into a list of CsvCase."""
+    """Load and validate a CSV of eval test cases into a list of CsvCase."""
     if not os.path.isfile(path):
         raise CsvCaseError(f"CSV file not found: {path}")
     rows = read_rows(path)
@@ -275,7 +195,7 @@ def load_cases_from_csv(path: str) -> List[CsvCase]:
 
 
 def monocle_csv_cases(path: str):
-    """Parametrize a test over the rows of a CSV of CsvCase.
+    """Parametrize a test over the rows of a CSV of eval CsvCase.
 
     Usage:
         @monocle_csv_cases("cases.csv")

--- a/test_tools/src/monocle_test_tools/csv_cases.py
+++ b/test_tools/src/monocle_test_tools/csv_cases.py
@@ -1,10 +1,22 @@
 """CSV -> fluent test-case adapter for monocle_test_tools.
 
-Loads a flat CSV of okahu-trace test cases and drives them through the
-existing fluent TraceAssertion API via @monocle_csv_cases + CsvCase.run.
-Config (evaluator, template_path, source=okahu) lives in the test stub;
-only per-row data lives in the CSV. See the design doc:
-okahu/monocle_backlog_tracking designs/2026-07-17-monocle-csv-testcase-adapter.md
+Loads a flat CSV of okahu-trace test cases and drives each row through the
+existing fluent TraceAssertion API via ``@monocle_csv_cases`` + ``CsvCase.run``,
+so test data can be curated in a spreadsheet.
+
+Config-in-code, data-in-CSV: the test stub owns everything constant across the
+sheet (the evaluator via ``with_evaluation(...)``, the eval ``template_path``,
+and the trace source, fixed to ``okahu`` in this version); the CSV owns only
+what varies per row (trace id, workflow, expected labels, and per-row
+assertions). One row = one test; a row may carry several assertions, each run
+independently against the same loaded trace.
+
+Example test stub::
+
+    @monocle_csv_cases("cases.csv")
+    def test_cases(monocle_trace_asserter, case):
+        case.run(monocle_trace_asserter.with_evaluation("okahu"),
+                 template_path=TEMPLATE_PATH)
 """
 import csv
 import inspect

--- a/test_tools/src/monocle_test_tools/csv_cases.py
+++ b/test_tools/src/monocle_test_tools/csv_cases.py
@@ -7,7 +7,8 @@ only per-row data lives in the CSV. See the design doc:
 okahu/monocle_backlog_tracking designs/2026-07-17-monocle-csv-testcase-adapter.md
 """
 import csv
-from typing import Dict, List
+import json
+from typing import Dict, List, Optional, Union
 
 REQUIRED_COLUMNS = ("case_id", "id", "workflow_name")
 
@@ -41,3 +42,58 @@ def read_rows(path: str) -> List[Dict[str, str]]:
                 row[key.strip()] = (value or "").strip()
             rows.append(row)
         return rows
+
+
+def parse_multivalue(cell: str) -> Optional[Union[str, List[str]]]:
+    """Parse a cell into None, a string, or a list (JSON array or pipe-delimited)."""
+    if cell == "":
+        return None
+    if cell.startswith("["):
+        try:
+            value = json.loads(cell)
+        except json.JSONDecodeError:
+            return cell  # not JSON; treat as a literal string
+        if isinstance(value, list):
+            return [str(v) for v in value]
+        return cell
+    if "|" in cell:
+        return [part.strip() for part in cell.split("|") if part.strip() != ""]
+    return cell
+
+
+def parse_int(cell: str, column: str, case_id: str) -> Optional[int]:
+    if cell == "":
+        return None
+    try:
+        return int(cell)
+    except ValueError:
+        raise CsvCaseError(f"row '{case_id}': column '{column}' must be an integer, got '{cell}'")
+
+
+def parse_float(cell: str, column: str, case_id: str) -> Optional[float]:
+    if cell == "":
+        return None
+    try:
+        return float(cell)
+    except ValueError:
+        raise CsvCaseError(f"row '{case_id}': column '{column}' must be a number, got '{cell}'")
+
+
+def parse_extra_json(cell: str, case_id: str) -> List[dict]:
+    """Parse the extra_json cell into a list of {"method", "kwargs"?} steps."""
+    if cell == "":
+        return []
+    try:
+        value = json.loads(cell)
+    except json.JSONDecodeError as exc:
+        raise CsvCaseError(f"row '{case_id}': column 'extra_json' is not valid JSON — {exc}")
+    if not isinstance(value, list):
+        raise CsvCaseError(f"row '{case_id}': column 'extra_json' must be a JSON array of steps")
+    for step in value:
+        if not isinstance(step, dict) or "method" not in step or not isinstance(step["method"], str):
+            raise CsvCaseError(
+                f"row '{case_id}': each extra_json step must be an object with a string 'method'"
+            )
+        if "kwargs" in step and not isinstance(step["kwargs"], dict):
+            raise CsvCaseError(f"row '{case_id}': extra_json step 'kwargs' must be an object")
+    return value

--- a/test_tools/src/monocle_test_tools/csv_cases.py
+++ b/test_tools/src/monocle_test_tools/csv_cases.py
@@ -122,6 +122,45 @@ class CsvCase:
     extra_steps: List[dict] = field(default_factory=list)
     notes: Optional[str] = None
 
+    def run(self, asserter, **check_eval_kwargs) -> None:
+        """Drive this row through the fluent TraceAssertion `asserter`.
+
+        Independent assertions are each invoked on the base asserter (not
+        threaded): PR #721 collects failures on the asserter and the pytest
+        plugin reports them. Only misconfiguration (eval columns with no
+        evaluator) raises from here.
+        """
+        asserter.with_trace_source("okahu", id=self.id, workflow_name=self.workflow_name)
+
+        if self.expected is not None or self.not_expected is not None:
+            if getattr(asserter, "_eval", None) is None:
+                raise CsvCaseError(
+                    f"row '{self.case_id}': has expected/not_expected but no evaluator is "
+                    f"configured. Add .with_evaluation(...) to your test stub."
+                )
+            asserter.check_eval(
+                expected=self.expected,
+                not_expected=self.not_expected,
+                fact_name=self.fact_name,
+                **check_eval_kwargs,
+            )
+
+        if self.called_tool is not None:
+            asserter.called_tool(self.called_tool)
+        if self.called_agent is not None:
+            asserter.called_agent(self.called_agent)
+        if self.token_limit is not None:
+            asserter.under_token_limit(self.token_limit)
+        if self.duration_ms is not None:
+            asserter.under_duration(self.duration_ms, units="ms")
+        if self.has_input is not None:
+            asserter.has_input(self.has_input)
+        if self.has_output is not None:
+            asserter.has_output(self.has_output)
+
+        for step in self.extra_steps:
+            getattr(asserter, step["method"])(**step.get("kwargs", {}))
+
 
 def _require(row: dict, column: str, case_id: str, line: int) -> str:
     value = row.get(column, "").strip()

--- a/test_tools/src/monocle_test_tools/csv_cases.py
+++ b/test_tools/src/monocle_test_tools/csv_cases.py
@@ -1,0 +1,43 @@
+"""CSV -> fluent test-case adapter for monocle_test_tools.
+
+Loads a flat CSV of okahu-trace test cases and drives them through the
+existing fluent TraceAssertion API via @monocle_csv_cases + CsvCase.run.
+Config (evaluator, template_path, source=okahu) lives in the test stub;
+only per-row data lives in the CSV. See the design doc:
+okahu/monocle_backlog_tracking designs/2026-07-17-monocle-csv-testcase-adapter.md
+"""
+import csv
+from typing import Dict, List
+
+REQUIRED_COLUMNS = ("case_id", "id", "workflow_name")
+
+FACT_NAME_VALUES = (
+    "traces", "inferences", "agentic_turns", "agentic_sessions",
+    "agent_invocation", "tool_execution", "commits", "conversations",
+    "test_runs", "tests",
+)
+
+# Columns that constitute an assertion; a valid row has >= 1 populated.
+ASSERTION_COLUMNS = (
+    "expected", "not_expected", "called_tool", "called_agent",
+    "token_limit", "duration_ms", "has_input", "has_output", "extra_json",
+)
+
+
+class CsvCaseError(ValueError):
+    """Raised for invalid CSV content; message carries path/line context."""
+
+
+def read_rows(path: str) -> List[Dict[str, str]]:
+    """Read a CSV file into a list of {column: value} dicts (values stripped)."""
+    with open(path, newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh)
+        rows: List[Dict[str, str]] = []
+        for raw in reader:
+            row = {}
+            for key, value in raw.items():
+                if key is None:
+                    continue
+                row[key.strip()] = (value or "").strip()
+            rows.append(row)
+        return rows

--- a/test_tools/src/monocle_test_tools/csv_cases.py
+++ b/test_tools/src/monocle_test_tools/csv_cases.py
@@ -9,6 +9,7 @@ okahu/monocle_backlog_tracking designs/2026-07-17-monocle-csv-testcase-adapter.m
 import csv
 import inspect
 import json
+import os
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Union
 
@@ -195,3 +196,26 @@ def _row_to_case(row: dict, line: int) -> CsvCase:
             f"Populate at least one of: {', '.join(ASSERTION_COLUMNS)}"
         )
     return case
+
+
+def load_cases_from_csv(path: str) -> List[CsvCase]:
+    """Load and validate a CSV of test cases into a list of CsvCase."""
+    if not os.path.isfile(path):
+        raise CsvCaseError(f"CSV file not found: {path}")
+    rows = read_rows(path)
+    if not rows:
+        raise CsvCaseError(f"CSV file has no data rows: {path}")
+    missing = [c for c in REQUIRED_COLUMNS if c not in rows[0]]
+    if missing:
+        raise CsvCaseError(f"{path}: missing required column(s): {', '.join(missing)}")
+
+    cases: List[CsvCase] = []
+    seen = set()
+    for index, row in enumerate(rows):
+        line = index + 2  # +1 for header, +1 for 1-based line numbers
+        case = _row_to_case(row, line)
+        if case.case_id in seen:
+            raise CsvCaseError(f"line {line}: duplicate case_id '{case.case_id}'")
+        seen.add(case.case_id)
+        cases.append(case)
+    return cases

--- a/test_tools/src/monocle_test_tools/csv_cases.py
+++ b/test_tools/src/monocle_test_tools/csv_cases.py
@@ -7,8 +7,12 @@ only per-row data lives in the CSV. See the design doc:
 okahu/monocle_backlog_tracking designs/2026-07-17-monocle-csv-testcase-adapter.md
 """
 import csv
+import inspect
 import json
+from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Union
+
+from monocle_test_tools.fluent_api import TraceAssertion
 
 REQUIRED_COLUMNS = ("case_id", "id", "workflow_name")
 
@@ -97,3 +101,97 @@ def parse_extra_json(cell: str, case_id: str) -> List[dict]:
         if "kwargs" in step and not isinstance(step["kwargs"], dict):
             raise CsvCaseError(f"row '{case_id}': extra_json step 'kwargs' must be an object")
     return value
+
+
+@dataclass
+class CsvCase:
+    """One CSV row: an okahu-trace test case driven through the fluent API."""
+    case_id: str
+    id: str
+    workflow_name: str
+    fact_name: str = "traces"
+    expected: Optional[Union[str, List[str]]] = None
+    not_expected: Optional[Union[str, List[str]]] = None
+    called_tool: Optional[str] = None
+    called_agent: Optional[str] = None
+    token_limit: Optional[int] = None
+    duration_ms: Optional[float] = None
+    has_input: Optional[str] = None
+    has_output: Optional[str] = None
+    extra_steps: List[dict] = field(default_factory=list)
+    notes: Optional[str] = None
+
+
+def _require(row: dict, column: str, case_id: str, line: int) -> str:
+    value = row.get(column, "").strip()
+    if value == "":
+        raise CsvCaseError(f"line {line} (row '{case_id or '?'}'): required column '{column}' is empty")
+    return value
+
+
+def _validate_extra_steps(steps: List[dict], case_id: str) -> None:
+    for step in steps:
+        method_name = step["method"]
+        method = getattr(TraceAssertion, method_name, None)
+        if method is None or not callable(method):
+            raise CsvCaseError(
+                f"row '{case_id}': extra_json method '{method_name}' is not a TraceAssertion method"
+            )
+        kwargs = step.get("kwargs", {})
+        sig = inspect.signature(method)
+        accepts_var_kw = any(p.kind == p.VAR_KEYWORD for p in sig.parameters.values())
+        if not accepts_var_kw:
+            valid = set(sig.parameters) - {"self"}
+            unknown = set(kwargs) - valid
+            if unknown:
+                raise CsvCaseError(
+                    f"row '{case_id}': extra_json '{method_name}' got unknown kwargs {sorted(unknown)}; "
+                    f"valid: {sorted(valid)}"
+                )
+
+
+def _row_to_case(row: dict, line: int) -> CsvCase:
+    case_id = row.get("case_id", "").strip()
+    _require(row, "case_id", case_id, line)
+    trace_id = _require(row, "id", case_id, line)
+    workflow_name = _require(row, "workflow_name", case_id, line)
+
+    fact_name = row.get("fact_name", "").strip() or "traces"
+    if fact_name not in FACT_NAME_VALUES:
+        raise CsvCaseError(
+            f"row '{case_id}': invalid fact_name '{fact_name}'. Supported: {', '.join(FACT_NAME_VALUES)}"
+        )
+
+    extra_steps = parse_extra_json(row.get("extra_json", "").strip(), case_id)
+    _validate_extra_steps(extra_steps, case_id)
+
+    case = CsvCase(
+        case_id=case_id,
+        id=trace_id,
+        workflow_name=workflow_name,
+        fact_name=fact_name,
+        expected=parse_multivalue(row.get("expected", "").strip()),
+        not_expected=parse_multivalue(row.get("not_expected", "").strip()),
+        called_tool=(row.get("called_tool", "").strip() or None),
+        called_agent=(row.get("called_agent", "").strip() or None),
+        token_limit=parse_int(row.get("token_limit", "").strip(), "token_limit", case_id),
+        duration_ms=parse_float(row.get("duration_ms", "").strip(), "duration_ms", case_id),
+        has_input=(row.get("has_input", "").strip() or None),
+        has_output=(row.get("has_output", "").strip() or None),
+        extra_steps=extra_steps,
+        notes=(row.get("notes", "").strip() or None),
+    )
+
+    has_assertion = (
+        case.expected is not None or case.not_expected is not None
+        or case.called_tool is not None or case.called_agent is not None
+        or case.token_limit is not None or case.duration_ms is not None
+        or case.has_input is not None or case.has_output is not None
+        or len(case.extra_steps) > 0
+    )
+    if not has_assertion:
+        raise CsvCaseError(
+            f"row '{case_id}': declares a trace source but no assertions (vacuous test). "
+            f"Populate at least one of: {', '.join(ASSERTION_COLUMNS)}"
+        )
+    return case

--- a/test_tools/src/monocle_test_tools/csv_cases.py
+++ b/test_tools/src/monocle_test_tools/csv_cases.py
@@ -13,6 +13,8 @@ import os
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Union
 
+import pytest
+
 from monocle_test_tools.fluent_api import TraceAssertion
 
 REQUIRED_COLUMNS = ("case_id", "id", "workflow_name")
@@ -258,3 +260,23 @@ def load_cases_from_csv(path: str) -> List[CsvCase]:
         seen.add(case.case_id)
         cases.append(case)
     return cases
+
+
+def monocle_csv_cases(path: str):
+    """Parametrize a test over the rows of a CSV of CsvCase.
+
+    Usage:
+        @monocle_csv_cases("cases.csv")
+        def test_cases(monocle_trace_asserter, case):
+            case.run(monocle_trace_asserter.with_evaluation("okahu"),
+                     template_path=TEMPLATE_PATH)
+
+    Relative paths resolve against the calling test file's directory, so the
+    test works regardless of pytest's invocation directory.
+    """
+    resolved = path
+    if not os.path.isabs(path):
+        caller_file = inspect.stack()[1].filename
+        resolved = os.path.join(os.path.dirname(os.path.abspath(caller_file)), path)
+    cases = load_cases_from_csv(resolved)
+    return pytest.mark.parametrize("case", cases, ids=[c.case_id for c in cases])

--- a/test_tools/tests/integration/test_csv_cases_okahu.py
+++ b/test_tools/tests/integration/test_csv_cases_okahu.py
@@ -28,7 +28,7 @@ def cases_csv(tmp_path):
     path = tmp_path / "cases.csv"
     path.write_text(
         textwrap.dedent(f"""\
-            case_id,id,workflow_name,expected
+            case_id,fact_id,workflow_name,expected
             cc_t01,{PLACEHOLDER_TRACE_ID},{DEMO_WORKFLOW_NAME},{EXPECTED_LABEL}
         """),
         encoding="utf-8",
@@ -40,7 +40,7 @@ def test_csv_case_replays_and_evaluates(monocle_trace_asserter, cases_csv):
     cases = load_cases_from_csv(cases_csv)
     assert len(cases) == 1
 
-    # Stub owns evaluator + template selection; CSV owns id/workflow/expected.
+    # Stub owns evaluator + template selection; CSV owns fact_id/workflow/expected.
     cases[0].run(
         monocle_trace_asserter.with_evaluation("okahu"),
         eval_name="hallucination",

--- a/test_tools/tests/integration/test_csv_cases_okahu.py
+++ b/test_tools/tests/integration/test_csv_cases_okahu.py
@@ -1,0 +1,55 @@
+"""Integration: drive a CSV of test cases through the fluent asserter against okahu.
+
+Requires a real Okahu environment. Update the placeholder constants below with
+real values (same convention as test_okahu_trace_assertions.py) before running:
+
+    pytest tests/integration/test_csv_cases_okahu.py -m integration
+
+The CSV adapter fixes source=okahu and replays by trace id; the evaluator and
+template are supplied by the stub (here the built-in "hallucination" template
+via eval_name), exactly as with the fluent check_eval path.
+"""
+import textwrap
+
+import pytest
+
+from monocle_test_tools import load_cases_from_csv
+
+pytestmark = pytest.mark.integration
+
+# Update these with real values from your Okahu environment to run the test.
+DEMO_WORKFLOW_NAME = "Okahu-Loader-Demo"
+PLACEHOLDER_TRACE_ID = "642dbd9d0dfcfdbdc8849f67f34c8a19"
+EXPECTED_LABEL = "major_hallucination"
+
+
+@pytest.fixture()
+def cases_csv(tmp_path):
+    path = tmp_path / "cases.csv"
+    path.write_text(
+        textwrap.dedent(f"""\
+            case_id,id,workflow_name,expected
+            cc_t01,{PLACEHOLDER_TRACE_ID},{DEMO_WORKFLOW_NAME},{EXPECTED_LABEL}
+        """),
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+def test_csv_case_replays_and_evaluates(monocle_trace_asserter, cases_csv):
+    cases = load_cases_from_csv(cases_csv)
+    assert len(cases) == 1
+
+    # Stub owns evaluator + template selection; CSV owns id/workflow/expected.
+    cases[0].run(
+        monocle_trace_asserter.with_evaluation("okahu"),
+        eval_name="hallucination",
+    )
+
+    # Failures (if any) are collected on the asserter and surfaced by the
+    # pytest plugin's makereport hook; a passing eval leaves no assertions.
+    assert not monocle_trace_asserter.has_assertions()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/test_tools/tests/unit/test_csv_cases.py
+++ b/test_tools/tests/unit/test_csv_cases.py
@@ -13,3 +13,30 @@ def test_read_rows_parses_header_and_strips(tmp_path):
     path = _write(tmp_path, "case_id, id ,workflow_name\n a1 ,tid1, wf1 \n")
     rows = csv_cases.read_rows(path)
     assert rows == [{"case_id": "a1", "id": "tid1", "workflow_name": "wf1"}]
+
+
+def test_parse_multivalue_variants():
+    assert csv_cases.parse_multivalue("") is None
+    assert csv_cases.parse_multivalue("major") == "major"
+    assert csv_cases.parse_multivalue("major|minor") == ["major", "minor"]
+    assert csv_cases.parse_multivalue('["a","b"]') == ["a", "b"]
+
+
+def test_parse_int_and_float():
+    assert csv_cases.parse_int("", "token_limit", "c1") is None
+    assert csv_cases.parse_int("5000", "token_limit", "c1") == 5000
+    assert csv_cases.parse_float("12.5", "duration_ms", "c1") == 12.5
+    with pytest.raises(csv_cases.CsvCaseError):
+        csv_cases.parse_int("five", "token_limit", "c1")
+
+
+def test_parse_extra_json():
+    assert csv_cases.parse_extra_json("", "c1") == []
+    steps = csv_cases.parse_extra_json(
+        '[{"method":"has_attribute","kwargs":{"attribute_name":"model","expected":"gpt-4o"}}]', "c1"
+    )
+    assert steps == [{"method": "has_attribute", "kwargs": {"attribute_name": "model", "expected": "gpt-4o"}}]
+    with pytest.raises(csv_cases.CsvCaseError):
+        csv_cases.parse_extra_json('{"method":"x"}', "c1")   # not an array
+    with pytest.raises(csv_cases.CsvCaseError):
+        csv_cases.parse_extra_json('[{"kwargs":{}}]', "c1")  # missing method

--- a/test_tools/tests/unit/test_csv_cases.py
+++ b/test_tools/tests/unit/test_csv_cases.py
@@ -183,3 +183,10 @@ def test_monocle_csv_cases_parametrizes(tmp_path):
     assert argnames == "case"
     assert [c.case_id for c in argvalues] == ["a", "b"]
     assert params[0].kwargs["ids"] == ["a", "b"]
+
+
+def test_public_exports():
+    import monocle_test_tools as mtt
+    assert hasattr(mtt, "CsvCase")
+    assert hasattr(mtt, "load_cases_from_csv")
+    assert hasattr(mtt, "monocle_csv_cases")

--- a/test_tools/tests/unit/test_csv_cases.py
+++ b/test_tools/tests/unit/test_csv_cases.py
@@ -40,3 +40,41 @@ def test_parse_extra_json():
         csv_cases.parse_extra_json('{"method":"x"}', "c1")   # not an array
     with pytest.raises(csv_cases.CsvCaseError):
         csv_cases.parse_extra_json('[{"kwargs":{}}]', "c1")  # missing method
+
+
+def test_row_to_case_valid_eval_row():
+    row = {"case_id": "cc_t01", "id": "642d", "workflow_name": "wf",
+           "fact_name": "traces", "expected": "major|minor"}
+    case = csv_cases._row_to_case(row, line=2)
+    assert case.case_id == "cc_t01"
+    assert case.id == "642d"
+    assert case.workflow_name == "wf"
+    assert case.expected == ["major", "minor"]
+    assert case.fact_name == "traces"
+
+
+def test_row_to_case_defaults_fact_name():
+    row = {"case_id": "c", "id": "t", "workflow_name": "wf", "expected": "ok"}
+    assert csv_cases._row_to_case(row, 2).fact_name == "traces"
+
+
+@pytest.mark.parametrize("row,needle", [
+    ({"case_id": "", "id": "t", "workflow_name": "wf", "expected": "ok"}, "case_id"),
+    ({"case_id": "c", "id": "", "workflow_name": "wf", "expected": "ok"}, "id"),
+    ({"case_id": "c", "id": "t", "workflow_name": "", "expected": "ok"}, "workflow_name"),
+    ({"case_id": "c", "id": "t", "workflow_name": "wf", "fact_name": "bogus", "expected": "ok"}, "fact_name"),
+    ({"case_id": "c", "id": "t", "workflow_name": "wf"}, "no assertions"),
+    ({"case_id": "c", "id": "t", "workflow_name": "wf",
+      "extra_json": '[{"method":"not_a_method"}]'}, "not_a_method"),
+])
+def test_row_to_case_errors(row, needle):
+    with pytest.raises(csv_cases.CsvCaseError) as exc:
+        csv_cases._row_to_case(row, line=7)
+    assert needle in str(exc.value)
+
+
+def test_row_to_case_non_eval_only_is_valid():
+    row = {"case_id": "tool_01", "id": "t", "workflow_name": "wf", "called_tool": "search_web"}
+    case = csv_cases._row_to_case(row, 2)
+    assert case.called_tool == "search_web"
+    assert case.expected is None

--- a/test_tools/tests/unit/test_csv_cases.py
+++ b/test_tools/tests/unit/test_csv_cases.py
@@ -110,3 +110,57 @@ def test_load_cases_missing_required_column(tmp_path):
 def test_load_cases_missing_file():
     with pytest.raises(csv_cases.CsvCaseError):
         csv_cases.load_cases_from_csv("/nonexistent/cases.csv")
+
+
+class _RecordingAsserter:
+    """Test double: records calls, returns self, mimics _eval presence."""
+    def __init__(self, has_eval=True):
+        self.calls = []
+        self._eval = object() if has_eval else None
+
+    def __getattr__(self, name):
+        def method(*args, **kwargs):
+            self.calls.append((name, args, kwargs))
+            return self
+        return method
+
+
+def test_run_eval_row_issues_trace_source_and_check_eval():
+    case = csv_cases._row_to_case(
+        {"case_id": "c", "id": "t1", "workflow_name": "wf", "expected": "ok"}, 2)
+    a = _RecordingAsserter(has_eval=True)
+    case.run(a, template_path="tpl.json")
+    names = [c[0] for c in a.calls]
+    assert names == ["with_trace_source", "check_eval"]
+    ts = a.calls[0]
+    assert ts[1] == ("okahu",) and ts[2] == {"id": "t1", "workflow_name": "wf"}
+    ce = a.calls[1]
+    assert ce[2] == {"expected": "ok", "not_expected": None,
+                     "fact_name": "traces", "template_path": "tpl.json"}
+
+
+def test_run_eval_row_without_evaluator_raises():
+    case = csv_cases._row_to_case(
+        {"case_id": "needs_eval", "id": "t", "workflow_name": "wf", "expected": "ok"}, 2)
+    a = _RecordingAsserter(has_eval=False)
+    with pytest.raises(csv_cases.CsvCaseError) as exc:
+        case.run(a)
+    assert "needs_eval" in str(exc.value)
+    assert "with_evaluation" in str(exc.value)
+
+
+def test_run_non_eval_row_maps_all_columns():
+    row = {"case_id": "c", "id": "t", "workflow_name": "wf",
+           "called_tool": "search_web", "called_agent": "planner",
+           "token_limit": "5000", "duration_ms": "1200",
+           "has_input": "hello", "has_output": "world",
+           "extra_json": '[{"method":"has_attribute","kwargs":{"attribute_name":"model","expected":"gpt-4o"}}]'}
+    case = csv_cases._row_to_case(row, 2)
+    a = _RecordingAsserter(has_eval=False)
+    case.run(a)
+    names = [c[0] for c in a.calls]
+    assert names == ["with_trace_source", "called_tool", "called_agent",
+                     "under_token_limit", "under_duration", "has_input",
+                     "has_output", "has_attribute"]
+    assert ("under_duration", (1200.0,), {"units": "ms"}) in a.calls
+    assert ("has_attribute", (), {"attribute_name": "model", "expected": "gpt-4o"}) in a.calls

--- a/test_tools/tests/unit/test_csv_cases.py
+++ b/test_tools/tests/unit/test_csv_cases.py
@@ -78,3 +78,35 @@ def test_row_to_case_non_eval_only_is_valid():
     case = csv_cases._row_to_case(row, 2)
     assert case.called_tool == "search_web"
     assert case.expected is None
+
+
+def test_load_cases_from_csv_happy(tmp_path):
+    path = _write(tmp_path,
+        "case_id,id,workflow_name,expected\n"
+        "cc_t01,642d,wf_cc,major_hallucination\n"
+        "cc_t02,8f12,wf_cc,no_hallucination\n")
+    cases = csv_cases.load_cases_from_csv(path)
+    assert [c.case_id for c in cases] == ["cc_t01", "cc_t02"]
+    assert cases[0].expected == "major_hallucination"
+
+
+def test_load_cases_duplicate_case_id(tmp_path):
+    path = _write(tmp_path,
+        "case_id,id,workflow_name,expected\n"
+        "dup,t1,wf,ok\n"
+        "dup,t2,wf,ok\n")
+    with pytest.raises(csv_cases.CsvCaseError) as exc:
+        csv_cases.load_cases_from_csv(path)
+    assert "duplicate" in str(exc.value).lower()
+
+
+def test_load_cases_missing_required_column(tmp_path):
+    path = _write(tmp_path, "case_id,workflow_name,expected\nc,wf,ok\n")
+    with pytest.raises(csv_cases.CsvCaseError) as exc:
+        csv_cases.load_cases_from_csv(path)
+    assert "id" in str(exc.value)
+
+
+def test_load_cases_missing_file():
+    with pytest.raises(csv_cases.CsvCaseError):
+        csv_cases.load_cases_from_csv("/nonexistent/cases.csv")

--- a/test_tools/tests/unit/test_csv_cases.py
+++ b/test_tools/tests/unit/test_csv_cases.py
@@ -1,0 +1,15 @@
+import os
+import pytest
+from monocle_test_tools import csv_cases
+
+
+def _write(tmp_path, text):
+    p = tmp_path / "cases.csv"
+    p.write_text(text, encoding="utf-8")
+    return str(p)
+
+
+def test_read_rows_parses_header_and_strips(tmp_path):
+    path = _write(tmp_path, "case_id, id ,workflow_name\n a1 ,tid1, wf1 \n")
+    rows = csv_cases.read_rows(path)
+    assert rows == [{"case_id": "a1", "id": "tid1", "workflow_name": "wf1"}]

--- a/test_tools/tests/unit/test_csv_cases.py
+++ b/test_tools/tests/unit/test_csv_cases.py
@@ -164,3 +164,22 @@ def test_run_non_eval_row_maps_all_columns():
                      "has_output", "has_attribute"]
     assert ("under_duration", (1200.0,), {"units": "ms"}) in a.calls
     assert ("has_attribute", (), {"attribute_name": "model", "expected": "gpt-4o"}) in a.calls
+
+
+def test_monocle_csv_cases_parametrizes(tmp_path):
+    path = _write(tmp_path,
+        "case_id,id,workflow_name,expected\n"
+        "a,t1,wf,ok\n"
+        "b,t2,wf,ok\n")
+    mark = csv_cases.monocle_csv_cases(path)  # absolute path
+
+    @mark
+    def dummy(case):
+        pass
+
+    params = [m for m in dummy.pytestmark if m.name == "parametrize"]
+    assert params, "expected a parametrize mark"
+    argnames, argvalues = params[0].args[0], params[0].args[1]
+    assert argnames == "case"
+    assert [c.case_id for c in argvalues] == ["a", "b"]
+    assert params[0].kwargs["ids"] == ["a", "b"]

--- a/test_tools/tests/unit/test_csv_cases.py
+++ b/test_tools/tests/unit/test_csv_cases.py
@@ -10,9 +10,9 @@ def _write(tmp_path, text):
 
 
 def test_read_rows_parses_header_and_strips(tmp_path):
-    path = _write(tmp_path, "case_id, id ,workflow_name\n a1 ,tid1, wf1 \n")
+    path = _write(tmp_path, "case_id, fact_id ,workflow_name\n a1 ,tid1, wf1 \n")
     rows = csv_cases.read_rows(path)
-    assert rows == [{"case_id": "a1", "id": "tid1", "workflow_name": "wf1"}]
+    assert rows == [{"case_id": "a1", "fact_id": "tid1", "workflow_name": "wf1"}]
 
 
 def test_parse_multivalue_variants():
@@ -23,49 +23,50 @@ def test_parse_multivalue_variants():
 
 
 def test_parse_int_and_float():
-    assert csv_cases.parse_int("", "token_limit", "c1") is None
-    assert csv_cases.parse_int("5000", "token_limit", "c1") == 5000
-    assert csv_cases.parse_float("12.5", "duration_ms", "c1") == 12.5
+    assert csv_cases.parse_int("", "max_tokens", "c1") is None
+    assert csv_cases.parse_int("5000", "max_tokens", "c1") == 5000
+    assert csv_cases.parse_float("12.5", "max_duration_ms", "c1") == 12.5
     with pytest.raises(csv_cases.CsvCaseError):
-        csv_cases.parse_int("five", "token_limit", "c1")
-
-
-def test_parse_extra_json():
-    assert csv_cases.parse_extra_json("", "c1") == []
-    steps = csv_cases.parse_extra_json(
-        '[{"method":"has_attribute","kwargs":{"attribute_name":"model","expected":"gpt-4o"}}]', "c1"
-    )
-    assert steps == [{"method": "has_attribute", "kwargs": {"attribute_name": "model", "expected": "gpt-4o"}}]
-    with pytest.raises(csv_cases.CsvCaseError):
-        csv_cases.parse_extra_json('{"method":"x"}', "c1")   # not an array
-    with pytest.raises(csv_cases.CsvCaseError):
-        csv_cases.parse_extra_json('[{"kwargs":{}}]', "c1")  # missing method
+        csv_cases.parse_int("five", "max_tokens", "c1")
 
 
 def test_row_to_case_valid_eval_row():
-    row = {"case_id": "cc_t01", "id": "642d", "workflow_name": "wf",
+    row = {"case_id": "cc_t01", "fact_id": "642d", "workflow_name": "wf",
            "fact_name": "traces", "expected": "major|minor"}
     case = csv_cases._row_to_case(row, line=2)
     assert case.case_id == "cc_t01"
-    assert case.id == "642d"
+    assert case.fact_id == "642d"
     assert case.workflow_name == "wf"
     assert case.expected == ["major", "minor"]
     assert case.fact_name == "traces"
 
 
 def test_row_to_case_defaults_fact_name():
-    row = {"case_id": "c", "id": "t", "workflow_name": "wf", "expected": "ok"}
+    row = {"case_id": "c", "fact_id": "t", "workflow_name": "wf", "expected": "ok"}
     assert csv_cases._row_to_case(row, 2).fact_name == "traces"
 
 
+def test_row_to_case_not_expected_only_is_valid():
+    row = {"case_id": "c", "fact_id": "t", "workflow_name": "wf", "not_expected": "major_hallucination"}
+    case = csv_cases._row_to_case(row, 2)
+    assert case.not_expected == "major_hallucination"
+    assert case.expected is None
+
+
+def test_row_to_case_maps_guard_rails():
+    row = {"case_id": "c", "fact_id": "t", "workflow_name": "wf", "expected": "ok",
+           "max_tokens": "5000", "max_duration_ms": "4000"}
+    case = csv_cases._row_to_case(row, 2)
+    assert case.max_tokens == 5000
+    assert case.max_duration_ms == 4000.0
+
+
 @pytest.mark.parametrize("row,needle", [
-    ({"case_id": "", "id": "t", "workflow_name": "wf", "expected": "ok"}, "case_id"),
-    ({"case_id": "c", "id": "", "workflow_name": "wf", "expected": "ok"}, "id"),
-    ({"case_id": "c", "id": "t", "workflow_name": "", "expected": "ok"}, "workflow_name"),
-    ({"case_id": "c", "id": "t", "workflow_name": "wf", "fact_name": "bogus", "expected": "ok"}, "fact_name"),
-    ({"case_id": "c", "id": "t", "workflow_name": "wf"}, "no assertions"),
-    ({"case_id": "c", "id": "t", "workflow_name": "wf",
-      "extra_json": '[{"method":"not_a_method"}]'}, "not_a_method"),
+    ({"case_id": "", "fact_id": "t", "workflow_name": "wf", "expected": "ok"}, "case_id"),
+    ({"case_id": "c", "fact_id": "", "workflow_name": "wf", "expected": "ok"}, "fact_id"),
+    ({"case_id": "c", "fact_id": "t", "workflow_name": "", "expected": "ok"}, "workflow_name"),
+    ({"case_id": "c", "fact_id": "t", "workflow_name": "wf"}, "expected"),
+    ({"case_id": "c", "fact_id": "t", "workflow_name": "wf", "max_tokens": "5000"}, "expected"),
 ])
 def test_row_to_case_errors(row, needle):
     with pytest.raises(csv_cases.CsvCaseError) as exc:
@@ -73,16 +74,9 @@ def test_row_to_case_errors(row, needle):
     assert needle in str(exc.value)
 
 
-def test_row_to_case_non_eval_only_is_valid():
-    row = {"case_id": "tool_01", "id": "t", "workflow_name": "wf", "called_tool": "search_web"}
-    case = csv_cases._row_to_case(row, 2)
-    assert case.called_tool == "search_web"
-    assert case.expected is None
-
-
 def test_load_cases_from_csv_happy(tmp_path):
     path = _write(tmp_path,
-        "case_id,id,workflow_name,expected\n"
+        "case_id,fact_id,workflow_name,expected\n"
         "cc_t01,642d,wf_cc,major_hallucination\n"
         "cc_t02,8f12,wf_cc,no_hallucination\n")
     cases = csv_cases.load_cases_from_csv(path)
@@ -92,7 +86,7 @@ def test_load_cases_from_csv_happy(tmp_path):
 
 def test_load_cases_duplicate_case_id(tmp_path):
     path = _write(tmp_path,
-        "case_id,id,workflow_name,expected\n"
+        "case_id,fact_id,workflow_name,expected\n"
         "dup,t1,wf,ok\n"
         "dup,t2,wf,ok\n")
     with pytest.raises(csv_cases.CsvCaseError) as exc:
@@ -104,7 +98,7 @@ def test_load_cases_missing_required_column(tmp_path):
     path = _write(tmp_path, "case_id,workflow_name,expected\nc,wf,ok\n")
     with pytest.raises(csv_cases.CsvCaseError) as exc:
         csv_cases.load_cases_from_csv(path)
-    assert "id" in str(exc.value)
+    assert "fact_id" in str(exc.value)
 
 
 def test_load_cases_missing_file():
@@ -127,7 +121,7 @@ class _RecordingAsserter:
 
 def test_run_eval_row_issues_trace_source_and_check_eval():
     case = csv_cases._row_to_case(
-        {"case_id": "c", "id": "t1", "workflow_name": "wf", "expected": "ok"}, 2)
+        {"case_id": "c", "fact_id": "t1", "workflow_name": "wf", "expected": "ok"}, 2)
     a = _RecordingAsserter(has_eval=True)
     case.run(a, template_path="tpl.json")
     names = [c[0] for c in a.calls]
@@ -139,9 +133,21 @@ def test_run_eval_row_issues_trace_source_and_check_eval():
                      "fact_name": "traces", "template_path": "tpl.json"}
 
 
+def test_run_eval_row_maps_guard_rails():
+    case = csv_cases._row_to_case(
+        {"case_id": "c", "fact_id": "t1", "workflow_name": "wf", "expected": "ok",
+         "max_tokens": "5000", "max_duration_ms": "4000"}, 2)
+    a = _RecordingAsserter(has_eval=True)
+    case.run(a)
+    names = [c[0] for c in a.calls]
+    assert names == ["with_trace_source", "check_eval", "under_token_limit", "under_duration"]
+    assert ("under_token_limit", (5000,), {}) in a.calls
+    assert ("under_duration", (4000.0,), {"units": "ms"}) in a.calls
+
+
 def test_run_eval_row_without_evaluator_raises():
     case = csv_cases._row_to_case(
-        {"case_id": "needs_eval", "id": "t", "workflow_name": "wf", "expected": "ok"}, 2)
+        {"case_id": "needs_eval", "fact_id": "t", "workflow_name": "wf", "expected": "ok"}, 2)
     a = _RecordingAsserter(has_eval=False)
     with pytest.raises(csv_cases.CsvCaseError) as exc:
         case.run(a)
@@ -149,26 +155,9 @@ def test_run_eval_row_without_evaluator_raises():
     assert "with_evaluation" in str(exc.value)
 
 
-def test_run_non_eval_row_maps_all_columns():
-    row = {"case_id": "c", "id": "t", "workflow_name": "wf",
-           "called_tool": "search_web", "called_agent": "planner",
-           "token_limit": "5000", "duration_ms": "1200",
-           "has_input": "hello", "has_output": "world",
-           "extra_json": '[{"method":"has_attribute","kwargs":{"attribute_name":"model","expected":"gpt-4o"}}]'}
-    case = csv_cases._row_to_case(row, 2)
-    a = _RecordingAsserter(has_eval=False)
-    case.run(a)
-    names = [c[0] for c in a.calls]
-    assert names == ["with_trace_source", "called_tool", "called_agent",
-                     "under_token_limit", "under_duration", "has_input",
-                     "has_output", "has_attribute"]
-    assert ("under_duration", (1200.0,), {"units": "ms"}) in a.calls
-    assert ("has_attribute", (), {"attribute_name": "model", "expected": "gpt-4o"}) in a.calls
-
-
 def test_monocle_csv_cases_parametrizes(tmp_path):
     path = _write(tmp_path,
-        "case_id,id,workflow_name,expected\n"
+        "case_id,fact_id,workflow_name,expected\n"
         "a,t1,wf,ok\n"
         "b,t2,wf,ok\n")
     mark = csv_cases.monocle_csv_cases(path)  # absolute path


### PR DESCRIPTION
## Proposed changes

Adds a **CSV → fluent eval test-case adapter** to `monocle_test_tools` so evaluation test cases can be curated in a flat spreadsheet and run as parametrized pytest tests through the fluent `TraceAssertion` path.

**Scope (v0): evaluation tests only.** Following review, the adapter is deliberately narrow — it does **not** mirror the open fluent assertion set. Each row asserts an eval label and, optionally, two operational guard rails on the run. The loader bridges exactly **three stable, eval-relevant fluent methods**:

| CSV concern | Fluent method | Role |
| --- | --- | --- |
| `expected` / `not_expected` | `check_eval` | the label — the tuning target |
| `max_tokens` | `under_token_limit` | **budget** guard rail |
| `max_duration_ms` | `under_duration(units="ms")` | **effort** guard rail |

This keeps the adapter immune to fluent API churn (a new assertion never touches the CSV schema) and stops it competing with the JSON `TestCase` executor — it is purpose-scoped to evals, which the `TestCase`/`validate()` path does not run.

New public surface (in `monocle_test_tools`):
- `load_cases_from_csv(path) -> list[CsvCase]` — parse + validate a CSV (usable standalone)
- `CsvCase.run(asserter, **check_eval_kwargs)` — maps one row onto the fluent chain
- `@monocle_csv_cases("cases.csv")` — parametrizes a one-line test stub over the rows

**Design principle — config in code, data in CSV.** The test stub owns everything constant across the sheet (the evaluator via `with_evaluation(...)`, the eval `template_path`, and the trace source — fixed to `okahu` in this version); the CSV owns only what varies per row. Example stub:

```python
@monocle_csv_cases("cases.csv")
def test_cases(monocle_trace_asserter, case):
    case.run(monocle_trace_asserter.with_evaluation("okahu"), template_path=TEMPLATE_PATH)
```

Columns: `case_id, fact_id, workflow_name, fact_name, expected, not_expected, max_tokens, max_duration_ms, notes`.
- `expected`/`not_expected` accept multi-values (pipe-delimited or JSON array).
- `fact_id` identifies the evaluated fact — it equals the trace id when `fact_name=traces` and is a finer-grained id otherwise.
- A row must declare an `expected`/`not_expected` label; a guard rail alone is not an eval test.

**Notable design points**
- Targets the fluent `TraceAssertion` path (not `TestCase`): the `TestCase`/`validate()` path does not execute evals (`_evaluate_span` is unused) and `TestCase` has no trace source, so the fluent path is the only one that runs evals *and* replays a trace.
- Honors the PR #721 collected-assertions model: each row's independent assertions are invoked on the base asserter (not threaded), and failures surface through the existing pytest plugin.
- Fact-name validation is delegated to the Okahu evaluator (no hardcoded fact list in the adapter).
- Load-time validation with clear `line N: …` messages, including duplicate-`case_id` and required-column checks.
- Stdlib only — **no new runtime dependencies**; Python ≥3.8.

### Out of scope for v0 (future considerations)

- **General non-eval assertions from CSV** (tool/agent calls, input/output, arbitrary fluent methods) and **multi-condition rows** (e.g. asserting two different tools). Deferred; if pursued, the intended shape is a **column-agnostic raw loader + code-side mapping** — plus a `SUPPORTED_ASSERTIONS` API exposed from the fluent module — rather than a growing column→method schema. This is what avoids the backward-compat churn a full mirror would incur.
- **Non-okahu trace sources** (`local`/`file`) — v0 fixes the source to `okahu`.
- **Sub-trace fact selectors / session-scope location**, and wiring `TestSpan.eval` + trace source into `TestCase`.
- **Result-matrix capture for non-eval assertions.**

### Design note: CSV parsing uses the stdlib `csv` module (not pandas)

Recording the rationale, since reviewers may wonder why this doesn't use pandas.

**Decision:** parse with the standard-library `csv` module; **do not** add pandas (or any third-party CSV lib) as a dependency.

**Why:**
- **Dependency weight.** pandas pulls in numpy and tens of MB. `monocle_test_tools` is a pip-installed test library, and this PR deliberately adds **no new runtime dependencies**.
- **It wouldn't simplify the code.** The schema is small and flat, and the cell semantics are custom — multi-value `expected`/`not_expected` (pipe- or JSON-delimited) and friendly `path:line` error messages. None of that comes from pandas.
- **Type inference actively fights us.** pandas coerces empty cells to `NaN` and guesses dtypes, so we'd read with `dtype=str, keep_default_na=False` and re-parse every cell ourselves anyway.
- **Author-facing errors need source line numbers.** `csv.DictReader` + `enumerate` yields the true CSV line for each row, which is what non-engineer curators need. A DataFrame gives a row *index*, not the file line.

**Format-swappability is preserved.** The reader is isolated as `read_rows(path) -> list[dict]`, so a future Excel/Google-Sheets reader can be added **behind that seam without touching the mapper or `CsvCase`**. If/when that lands it would be an **optional** extra (e.g. `monocle_test_tools[excel]`), never a hard dependency.

Tracking issue: okahu/monocle_backlog_tracking#215.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

Additive only — existing suites, the fluent API, and the pytest plugin are untouched. New unit tests cover the reader, cell parsing, row mapping/validation (including the no-label rejection and guard-rail mapping), `CsvCase.run` (via a recording double), and the `monocle_csv_cases` decorator; a copy-ready example (`test_tools/examples/`) includes an offline load smoke test; and an opt-in `integration`-marked test replays an okahu trace end-to-end. Full `test_tools/tests/unit` suite: 212 passed locally (the one pre-existing collection error is an unrelated optional `google.adk` dep, not installed).

All commits are DCO `Signed-off-by`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
