### PR TITLE
 ADK: bind turn scope to native invocation_id

### DIFF
--- a/apptrace/src/monocle_apptrace/instrumentation/common/wrapper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/common/wrapper.py
@@ -767,8 +767,9 @@ def start_as_monocle_span(tracer: Tracer, name: str, auto_close_span: bool,
 def get_builtin_scope_names(to_wrap, instance=None, args=None, kwargs=None) -> tuple:
     """Return the builtin scope to open, as a tuple splatted into monocle_trace_scope():
        (name,)         -> auto-generate a value (default);
-       (name, value)   -> use this value (entity opts in via use_builtin_scope + scope_value);
-       (None,)         -> open no scope (value is set elsewhere, e.g. by the metamodel handler).
+       (name, value)   -> entity opted in via use_builtin_scope + scope_value; use this value
+                          (value None -> monocle_trace_scope auto-generates, i.e. graceful fallback);
+       (None,)         -> open no scope (non-agentic span).
     """
     output_processor = None
     if "output_processor" in to_wrap:
@@ -782,8 +783,8 @@ def get_builtin_scope_names(to_wrap, instance=None, args=None, kwargs=None) -> t
     span_type = output_processor.get("type", None) if isinstance(output_processor, dict) else None
 
     # An entity can supply the builtin scope's value itself (instead of the random default)
-    # via a `scope_value` accessor evaluated with the call arguments. If it yields no value,
-    # the scope is left unset (the value is provided elsewhere) rather than auto-generated.
+    # via a `scope_value` accessor evaluated with the call arguments. A None result falls
+    # back to an auto-generated value, so callers that don't supply one still get a scope.
     if isinstance(output_processor, dict) and output_processor.get("use_builtin_scope", False):
         scope_name = output_processor.get("scope_name", span_type)
         accessor = output_processor.get("scope_value")
@@ -793,9 +794,7 @@ def get_builtin_scope_names(to_wrap, instance=None, args=None, kwargs=None) -> t
                 value = accessor({"instance": instance, "args": args or (), "kwargs": kwargs or {}})
             except Exception as e:
                 logger.warning("Warning: Error evaluating scope_value: %s", str(e))
-        if scope_name and value is not None:
-            return scope_name, value
-        return (None,)
+        return (scope_name, value) if scope_name else (None,)
 
     if span_type and span_type in AGENTIC_SPANS:
         return (span_type,)

--- a/apptrace/src/monocle_apptrace/instrumentation/common/wrapper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/common/wrapper.py
@@ -139,7 +139,7 @@ def monocle_wrapper_span_processor(tracer: Tracer, handler: SpanHandler, to_wrap
                 except Exception as e:
                     logger.info(f"Warning: Error occurred in hydrate_span pre_process_span: {e}")
                 try:
-                    with monocle_trace_scope(get_builtin_scope_names(to_wrap)):
+                    with monocle_trace_scope(*get_builtin_scope_names(to_wrap, instance, args, kwargs)):
                         return_value, span_status = monocle_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, False, args, kwargs)
                 except Exception as e:
                     ex = e
@@ -226,7 +226,7 @@ def monocle_iter_wrapper_span_processor(tracer: Tracer, handler: SpanHandler, to
                 except Exception as e:
                     logger.info(f"Warning: Error occurred in hydrate_span pre_process_span: {e}")
                 try:
-                    with monocle_trace_scope(get_builtin_scope_names(to_wrap)):
+                    with monocle_trace_scope(*get_builtin_scope_names(to_wrap, instance, args, kwargs)):
                         for item in monocle_iter_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, False, args, kwargs):
                             last_item = item
                             yield item
@@ -295,7 +295,7 @@ def monocle_wrapper(tracer: Tracer, handler: SpanHandler, to_wrap, wrapped, inst
             add_workflow_span = get_value(ADD_NEW_WORKFLOW) == True
             token = attach(set_value(ADD_NEW_WORKFLOW, False))
             try:
-                with monocle_trace_scope(get_builtin_scope_names(to_wrap)):
+                with monocle_trace_scope(*get_builtin_scope_names(to_wrap, instance, args, kwargs)):
                     return_value, span_status = monocle_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, add_workflow_span, args, kwargs)
             finally:
                 detach(token)
@@ -330,7 +330,7 @@ def monocle_iter_wrapper(tracer: Tracer, handler: SpanHandler, to_wrap, wrapped,
             _marker_token = MONOCLE_CONTEXT_MARKER.set(_marker)
             token = attach(set_value(ADD_NEW_WORKFLOW, False))
             try:
-                with monocle_trace_scope(get_builtin_scope_names(to_wrap)):
+                with monocle_trace_scope(*get_builtin_scope_names(to_wrap, instance, args, kwargs)):
                     for item in monocle_iter_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, add_workflow_span, args, kwargs):
                         yield item
             finally:
@@ -389,7 +389,7 @@ async def amonocle_wrapper_span_processor(tracer: Tracer, handler: SpanHandler, 
                     logger.info(f"Warning: Error occurred in hydrate_span pre_process_span: {e}")
 
                 try:
-                    with monocle_trace_scope(get_builtin_scope_names(to_wrap)):
+                    with monocle_trace_scope(*get_builtin_scope_names(to_wrap, instance, args, kwargs)):
                         return_value, span_status = await amonocle_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, False, args, kwargs)
                 except Exception as e:
                     ex = e
@@ -479,7 +479,7 @@ async def amonocle_iter_wrapper_span_processor(tracer: Tracer, handler: SpanHand
                 except Exception as e:
                     logger.info(f"Warning: Error occurred in hydrate_span pre_process_span: {e}")
                 try:
-                    with monocle_trace_scope(get_builtin_scope_names(to_wrap)):
+                    with monocle_trace_scope(*get_builtin_scope_names(to_wrap, instance, args, kwargs)):
                         async for item in amonocle_iter_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, False, args, kwargs):
                             last_item = item
                             yield item
@@ -551,7 +551,7 @@ async def amonocle_wrapper(tracer: Tracer, handler: SpanHandler, to_wrap, wrappe
             add_workflow_span = get_value(ADD_NEW_WORKFLOW) == True
             token = attach(set_value(ADD_NEW_WORKFLOW, False))
             try:
-                with monocle_trace_scope(get_builtin_scope_names(to_wrap)):
+                with monocle_trace_scope(*get_builtin_scope_names(to_wrap, instance, args, kwargs)):
                     return_value, span_status = await amonocle_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, 
                                                                         add_workflow_span, args, kwargs)
             finally:
@@ -586,7 +586,7 @@ async def amonocle_iter_wrapper(tracer: Tracer, handler: SpanHandler, to_wrap, w
             _marker_token = MONOCLE_CONTEXT_MARKER.set(_marker)
             token = attach(set_value(ADD_NEW_WORKFLOW, False))
             try:
-                with monocle_trace_scope(get_builtin_scope_names(to_wrap)):
+                with monocle_trace_scope(*get_builtin_scope_names(to_wrap, instance, args, kwargs)):
                     async for item in amonocle_iter_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, add_workflow_span, args, kwargs):
                         yield item
             finally:
@@ -764,7 +764,12 @@ def start_as_monocle_span(tracer: Tracer, name: str, auto_close_span: bool,
         if auto_close_span:
             span.end(end_time=effective_end)
 
-def get_builtin_scope_names(to_wrap) -> str:
+def get_builtin_scope_names(to_wrap, instance=None, args=None, kwargs=None) -> tuple:
+    """Return the builtin scope to open, as a tuple splatted into monocle_trace_scope():
+       (name,)         -> auto-generate a value (default);
+       (name, value)   -> use this value (entity opts in via use_builtin_scope + scope_value);
+       (None,)         -> open no scope (value is set elsewhere, e.g. by the metamodel handler).
+    """
     output_processor = None
     if "output_processor" in to_wrap:
         output_processor = to_wrap.get("output_processor", None)
@@ -774,13 +779,27 @@ def get_builtin_scope_names(to_wrap) -> str:
                 output_processor = processor
                 break
 
-    # An entity can opt out of the builtin scope when its handler sets the value itself.
-    if isinstance(output_processor, dict) and output_processor.get("skip_builtin_scope", False):
-        return None
-    span_type = output_processor.get("type", None) if output_processor and isinstance(output_processor, dict) else None
+    span_type = output_processor.get("type", None) if isinstance(output_processor, dict) else None
+
+    # An entity can supply the builtin scope's value itself (instead of the random default)
+    # via a `scope_value` accessor evaluated with the call arguments. If it yields no value,
+    # the scope is left unset (the value is provided elsewhere) rather than auto-generated.
+    if isinstance(output_processor, dict) and output_processor.get("use_builtin_scope", False):
+        scope_name = output_processor.get("scope_name", span_type)
+        accessor = output_processor.get("scope_value")
+        value = None
+        if callable(accessor):
+            try:
+                value = accessor({"instance": instance, "args": args or (), "kwargs": kwargs or {}})
+            except Exception as e:
+                logger.warning("Warning: Error evaluating scope_value: %s", str(e))
+        if scope_name and value is not None:
+            return scope_name, value
+        return (None,)
+
     if span_type and span_type in AGENTIC_SPANS:
-        return span_type
-    return None
+        return (span_type,)
+    return (None,)
 
 def get_wrapper_with_next_processor(to_wrap, handler, instance, span, parent_span, args, kwargs):
     if has_more_processors(to_wrap):

--- a/apptrace/src/monocle_apptrace/instrumentation/common/wrapper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/common/wrapper.py
@@ -767,9 +767,8 @@ def start_as_monocle_span(tracer: Tracer, name: str, auto_close_span: bool,
 def get_builtin_scope_names(to_wrap, instance=None, args=None, kwargs=None) -> tuple:
     """Return the builtin scope to open, as a tuple splatted into monocle_trace_scope():
        (name,)         -> auto-generate a value (default);
-       (name, value)   -> entity opted in via use_builtin_scope + scope_value; use this value
-                          (value None -> monocle_trace_scope auto-generates, i.e. graceful fallback);
-       (None,)         -> open no scope (non-agentic span).
+       (name, value)   -> use this value (entity opts in via use_builtin_scope + scope_value);
+       (None,)         -> open no scope (value is set elsewhere, e.g. by the metamodel handler).
     """
     output_processor = None
     if "output_processor" in to_wrap:
@@ -783,8 +782,8 @@ def get_builtin_scope_names(to_wrap, instance=None, args=None, kwargs=None) -> t
     span_type = output_processor.get("type", None) if isinstance(output_processor, dict) else None
 
     # An entity can supply the builtin scope's value itself (instead of the random default)
-    # via a `scope_value` accessor evaluated with the call arguments. A None result falls
-    # back to an auto-generated value, so callers that don't supply one still get a scope.
+    # via a `scope_value` accessor evaluated with the call arguments. If it yields no value,
+    # the scope is left unset (the value is provided elsewhere) rather than auto-generated.
     if isinstance(output_processor, dict) and output_processor.get("use_builtin_scope", False):
         scope_name = output_processor.get("scope_name", span_type)
         accessor = output_processor.get("scope_value")
@@ -794,7 +793,9 @@ def get_builtin_scope_names(to_wrap, instance=None, args=None, kwargs=None) -> t
                 value = accessor({"instance": instance, "args": args or (), "kwargs": kwargs or {}})
             except Exception as e:
                 logger.warning("Warning: Error evaluating scope_value: %s", str(e))
-        return (scope_name, value) if scope_name else (None,)
+        if scope_name and value is not None:
+            return scope_name, value
+        return (None,)
 
     if span_type and span_type in AGENTIC_SPANS:
         return (span_type,)

--- a/apptrace/src/monocle_apptrace/instrumentation/common/wrapper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/common/wrapper.py
@@ -139,7 +139,7 @@ def monocle_wrapper_span_processor(tracer: Tracer, handler: SpanHandler, to_wrap
                 except Exception as e:
                     logger.info(f"Warning: Error occurred in hydrate_span pre_process_span: {e}")
                 try:
-                    with monocle_trace_scope(*get_builtin_scope_names(to_wrap, instance, args, kwargs)):
+                    with monocle_trace_scope(get_builtin_scope_names(to_wrap)):
                         return_value, span_status = monocle_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, False, args, kwargs)
                 except Exception as e:
                     ex = e
@@ -226,7 +226,7 @@ def monocle_iter_wrapper_span_processor(tracer: Tracer, handler: SpanHandler, to
                 except Exception as e:
                     logger.info(f"Warning: Error occurred in hydrate_span pre_process_span: {e}")
                 try:
-                    with monocle_trace_scope(*get_builtin_scope_names(to_wrap, instance, args, kwargs)):
+                    with monocle_trace_scope(get_builtin_scope_names(to_wrap)):
                         for item in monocle_iter_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, False, args, kwargs):
                             last_item = item
                             yield item
@@ -295,7 +295,7 @@ def monocle_wrapper(tracer: Tracer, handler: SpanHandler, to_wrap, wrapped, inst
             add_workflow_span = get_value(ADD_NEW_WORKFLOW) == True
             token = attach(set_value(ADD_NEW_WORKFLOW, False))
             try:
-                with monocle_trace_scope(*get_builtin_scope_names(to_wrap, instance, args, kwargs)):
+                with monocle_trace_scope(get_builtin_scope_names(to_wrap)):
                     return_value, span_status = monocle_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, add_workflow_span, args, kwargs)
             finally:
                 detach(token)
@@ -330,7 +330,7 @@ def monocle_iter_wrapper(tracer: Tracer, handler: SpanHandler, to_wrap, wrapped,
             _marker_token = MONOCLE_CONTEXT_MARKER.set(_marker)
             token = attach(set_value(ADD_NEW_WORKFLOW, False))
             try:
-                with monocle_trace_scope(*get_builtin_scope_names(to_wrap, instance, args, kwargs)):
+                with monocle_trace_scope(get_builtin_scope_names(to_wrap)):
                     for item in monocle_iter_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, add_workflow_span, args, kwargs):
                         yield item
             finally:
@@ -389,7 +389,7 @@ async def amonocle_wrapper_span_processor(tracer: Tracer, handler: SpanHandler, 
                     logger.info(f"Warning: Error occurred in hydrate_span pre_process_span: {e}")
 
                 try:
-                    with monocle_trace_scope(*get_builtin_scope_names(to_wrap, instance, args, kwargs)):
+                    with monocle_trace_scope(get_builtin_scope_names(to_wrap)):
                         return_value, span_status = await amonocle_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, False, args, kwargs)
                 except Exception as e:
                     ex = e
@@ -479,7 +479,7 @@ async def amonocle_iter_wrapper_span_processor(tracer: Tracer, handler: SpanHand
                 except Exception as e:
                     logger.info(f"Warning: Error occurred in hydrate_span pre_process_span: {e}")
                 try:
-                    with monocle_trace_scope(*get_builtin_scope_names(to_wrap, instance, args, kwargs)):
+                    with monocle_trace_scope(get_builtin_scope_names(to_wrap)):
                         async for item in amonocle_iter_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, False, args, kwargs):
                             last_item = item
                             yield item
@@ -551,7 +551,7 @@ async def amonocle_wrapper(tracer: Tracer, handler: SpanHandler, to_wrap, wrappe
             add_workflow_span = get_value(ADD_NEW_WORKFLOW) == True
             token = attach(set_value(ADD_NEW_WORKFLOW, False))
             try:
-                with monocle_trace_scope(*get_builtin_scope_names(to_wrap, instance, args, kwargs)):
+                with monocle_trace_scope(get_builtin_scope_names(to_wrap)):
                     return_value, span_status = await amonocle_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, 
                                                                         add_workflow_span, args, kwargs)
             finally:
@@ -586,7 +586,7 @@ async def amonocle_iter_wrapper(tracer: Tracer, handler: SpanHandler, to_wrap, w
             _marker_token = MONOCLE_CONTEXT_MARKER.set(_marker)
             token = attach(set_value(ADD_NEW_WORKFLOW, False))
             try:
-                with monocle_trace_scope(*get_builtin_scope_names(to_wrap, instance, args, kwargs)):
+                with monocle_trace_scope(get_builtin_scope_names(to_wrap)):
                     async for item in amonocle_iter_wrapper_span_processor(tracer, handler, to_wrap, wrapped, instance, source_path, add_workflow_span, args, kwargs):
                         yield item
             finally:
@@ -764,12 +764,7 @@ def start_as_monocle_span(tracer: Tracer, name: str, auto_close_span: bool,
         if auto_close_span:
             span.end(end_time=effective_end)
 
-def get_builtin_scope_names(to_wrap, instance=None, args=None, kwargs=None) -> tuple:
-    """Return the builtin scope to open, as a tuple splatted into monocle_trace_scope():
-       (name,)         -> auto-generate a value (default);
-       (name, value)   -> use this value (entity opts in via use_builtin_scope + scope_value);
-       (None,)         -> open no scope (value is set elsewhere, e.g. by the metamodel handler).
-    """
+def get_builtin_scope_names(to_wrap) -> str:
     output_processor = None
     if "output_processor" in to_wrap:
         output_processor = to_wrap.get("output_processor", None)
@@ -779,27 +774,13 @@ def get_builtin_scope_names(to_wrap, instance=None, args=None, kwargs=None) -> t
                 output_processor = processor
                 break
 
-    span_type = output_processor.get("type", None) if isinstance(output_processor, dict) else None
-
-    # An entity can supply the builtin scope's value itself (instead of the random default)
-    # via a `scope_value` accessor evaluated with the call arguments. If it yields no value,
-    # the scope is left unset (the value is provided elsewhere) rather than auto-generated.
-    if isinstance(output_processor, dict) and output_processor.get("use_builtin_scope", False):
-        scope_name = output_processor.get("scope_name", span_type)
-        accessor = output_processor.get("scope_value")
-        value = None
-        if callable(accessor):
-            try:
-                value = accessor({"instance": instance, "args": args or (), "kwargs": kwargs or {}})
-            except Exception as e:
-                logger.warning("Warning: Error evaluating scope_value: %s", str(e))
-        if scope_name and value is not None:
-            return scope_name, value
-        return (None,)
-
+    # An entity can opt out of the builtin scope when its handler sets the value itself.
+    if isinstance(output_processor, dict) and output_processor.get("skip_builtin_scope", False):
+        return None
+    span_type = output_processor.get("type", None) if output_processor and isinstance(output_processor, dict) else None
     if span_type and span_type in AGENTIC_SPANS:
-        return (span_type,)
-    return (None,)
+        return span_type
+    return None
 
 def get_wrapper_with_next_processor(to_wrap, handler, instance, span, parent_span, args, kwargs):
     if has_more_processors(to_wrap):

--- a/apptrace/src/monocle_apptrace/instrumentation/common/wrapper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/common/wrapper.py
@@ -752,6 +752,9 @@ def get_builtin_scope_names(to_wrap) -> str:
                 output_processor = processor
                 break
 
+    # An entity can opt out of the builtin scope when its handler sets the value itself.
+    if isinstance(output_processor, dict) and output_processor.get("skip_builtin_scope", False):
+        return None
     span_type = output_processor.get("type", None) if output_processor and isinstance(output_processor, dict) else None
     if span_type and span_type in AGENTIC_SPANS:
         return span_type

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/adk/adk_handler.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/adk/adk_handler.py
@@ -1,15 +1,16 @@
-from monocle_apptrace.instrumentation.common.constants import (
-    AGENT_SESSION, AGENT_EXECUTION_ID, AGENT_REQUEST_SPAN_NAME,
-)
+from monocle_apptrace.instrumentation.common.constants import AGENT_SESSION, AGENT_EXECUTION_ID
 from monocle_apptrace.instrumentation.common.span_handler import SpanHandler
-from monocle_apptrace.instrumentation.common.utils import (
-    set_scope, set_scopes, remove_scope, is_scope_set, get_current_monocle_span,
-)
+from monocle_apptrace.instrumentation.common.utils import set_scope, set_scopes
 from monocle_apptrace.instrumentation.metamodel.adk import _helper
 from monocle_apptrace.instrumentation.metamodel.adk.entities.agent import AGENT_ORCHESTRATOR
 
 class AdkSpanHandler(SpanHandler):
-    """Custom span handler for ADK instrumentation that adds session_id and turn scopes."""
+    """Custom span handler for ADK instrumentation that adds the session_id scope.
+
+    The turn scope (agentic.turn) is handled by the core builtin-scope mechanism, which
+    reads the caller-supplied invocation_id — see the REQUEST entity's
+    use_builtin_scope / scope_value in entities/agent.py.
+    """
 
     def pre_tracing(self, to_wrap, wrapped, instance, args, kwargs):
         """Set session_id scope before tracing begins."""
@@ -46,44 +47,4 @@ class AdkSpanHandler(SpanHandler):
             if session_id and session_id_token is None:
                 session_id_token = set_scope(AGENT_SESSION, session_id)
 
-        # Bind the turn scope to ADK's invocation_id at the root agent, before child spans.
-        turn_scope_token = self._bind_turn_scope(instance, args)
-        tokens = [t for t in (session_id_token, turn_scope_token) if t is not None]
-        return (tokens or None), agent_request_wrapper
-
-    def _bind_turn_scope(self, instance, args):
-        """Bind the turn scope to ADK's invocation_id once, at the root agent call.
-
-        The id isn't known until ADK is running, so it's set here (not up-front) and stamped
-        onto the already-open turn span; is_scope_set stops sub-agents from re-setting it.
-        """
-        if getattr(instance, '__class__', None) is not None and instance.__class__.__name__ == 'Runner':
-            return None
-        if is_scope_set(AGENT_REQUEST_SPAN_NAME) or not args:
-            return None
-        invocation_id = getattr(args[0], 'invocation_id', None)
-        if not invocation_id:
-            return None
-        token = set_scope(AGENT_REQUEST_SPAN_NAME, invocation_id)
-        request_span = get_current_monocle_span()
-        if request_span is not None and request_span.is_recording():
-            request_span.set_attribute(f"scope.{AGENT_REQUEST_SPAN_NAME}", invocation_id)
-        return token
-
-    def post_tracing(self, to_wrap, wrapped, instance, args, kwargs, return_value, token=None):
-        # pre_tracing may return multiple scope tokens; detach in reverse (LIFO) order.
-        if isinstance(token, list):
-            for scope_token in reversed(token):
-                remove_scope(scope_token)
-        elif token:
-            remove_scope(token)
-
-    def post_task_processing(self, to_wrap, wrapped, instance, args, kwargs, result, ex, span, parent_span):
-        super().post_task_processing(to_wrap, wrapped, instance, args, kwargs, result, ex, span, parent_span)
-        # The workflow/root span opened before the id existed and skips scope hydration at
-        # close, so copy the turn scope onto it (only the turn span's parent is the workflow).
-        turn_scope = f"scope.{AGENT_REQUEST_SPAN_NAME}"
-        turn_id = span.attributes.get(turn_scope)
-        if (turn_id and parent_span is not None
-                and SpanHandler.is_workflow_span(parent_span) and parent_span.is_recording()):
-            parent_span.set_attribute(turn_scope, turn_id)
+        return session_id_token, agent_request_wrapper

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/adk/adk_handler.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/adk/adk_handler.py
@@ -1,16 +1,15 @@
-from monocle_apptrace.instrumentation.common.constants import AGENT_SESSION, AGENT_EXECUTION_ID
+from monocle_apptrace.instrumentation.common.constants import (
+    AGENT_SESSION, AGENT_EXECUTION_ID, AGENT_REQUEST_SPAN_NAME,
+)
 from monocle_apptrace.instrumentation.common.span_handler import SpanHandler
-from monocle_apptrace.instrumentation.common.utils import set_scope, set_scopes
+from monocle_apptrace.instrumentation.common.utils import (
+    set_scope, set_scopes, remove_scope, is_scope_set, get_current_monocle_span,
+)
 from monocle_apptrace.instrumentation.metamodel.adk import _helper
 from monocle_apptrace.instrumentation.metamodel.adk.entities.agent import AGENT_ORCHESTRATOR
 
 class AdkSpanHandler(SpanHandler):
-    """Custom span handler for ADK instrumentation that adds the session_id scope.
-
-    The turn scope (agentic.turn) is handled by the core builtin-scope mechanism, which
-    reads the caller-supplied invocation_id — see the REQUEST entity's
-    use_builtin_scope / scope_value in entities/agent.py.
-    """
+    """Custom span handler for ADK instrumentation that adds session_id and turn scopes."""
 
     def pre_tracing(self, to_wrap, wrapped, instance, args, kwargs):
         """Set session_id scope before tracing begins."""
@@ -47,4 +46,44 @@ class AdkSpanHandler(SpanHandler):
             if session_id and session_id_token is None:
                 session_id_token = set_scope(AGENT_SESSION, session_id)
 
-        return session_id_token, agent_request_wrapper
+        # Bind the turn scope to ADK's invocation_id at the root agent, before child spans.
+        turn_scope_token = self._bind_turn_scope(instance, args)
+        tokens = [t for t in (session_id_token, turn_scope_token) if t is not None]
+        return (tokens or None), agent_request_wrapper
+
+    def _bind_turn_scope(self, instance, args):
+        """Bind the turn scope to ADK's invocation_id once, at the root agent call.
+
+        The id isn't known until ADK is running, so it's set here (not up-front) and stamped
+        onto the already-open turn span; is_scope_set stops sub-agents from re-setting it.
+        """
+        if getattr(instance, '__class__', None) is not None and instance.__class__.__name__ == 'Runner':
+            return None
+        if is_scope_set(AGENT_REQUEST_SPAN_NAME) or not args:
+            return None
+        invocation_id = getattr(args[0], 'invocation_id', None)
+        if not invocation_id:
+            return None
+        token = set_scope(AGENT_REQUEST_SPAN_NAME, invocation_id)
+        request_span = get_current_monocle_span()
+        if request_span is not None and request_span.is_recording():
+            request_span.set_attribute(f"scope.{AGENT_REQUEST_SPAN_NAME}", invocation_id)
+        return token
+
+    def post_tracing(self, to_wrap, wrapped, instance, args, kwargs, return_value, token=None):
+        # pre_tracing may return multiple scope tokens; detach in reverse (LIFO) order.
+        if isinstance(token, list):
+            for scope_token in reversed(token):
+                remove_scope(scope_token)
+        elif token:
+            remove_scope(token)
+
+    def post_task_processing(self, to_wrap, wrapped, instance, args, kwargs, result, ex, span, parent_span):
+        super().post_task_processing(to_wrap, wrapped, instance, args, kwargs, result, ex, span, parent_span)
+        # The workflow/root span opened before the id existed and skips scope hydration at
+        # close, so copy the turn scope onto it (only the turn span's parent is the workflow).
+        turn_scope = f"scope.{AGENT_REQUEST_SPAN_NAME}"
+        turn_id = span.attributes.get(turn_scope)
+        if (turn_id and parent_span is not None
+                and SpanHandler.is_workflow_span(parent_span) and parent_span.is_recording()):
+            parent_span.set_attribute(turn_scope, turn_id)

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/adk/adk_handler.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/adk/adk_handler.py
@@ -1,11 +1,15 @@
-from monocle_apptrace.instrumentation.common.constants import AGENT_SESSION, AGENT_EXECUTION_ID
+from monocle_apptrace.instrumentation.common.constants import (
+    AGENT_SESSION, AGENT_EXECUTION_ID, AGENT_REQUEST_SPAN_NAME,
+)
 from monocle_apptrace.instrumentation.common.span_handler import SpanHandler
-from monocle_apptrace.instrumentation.common.utils import set_scope, set_scopes
+from monocle_apptrace.instrumentation.common.utils import (
+    set_scope, set_scopes, remove_scope, is_scope_set, get_current_monocle_span,
+)
 from monocle_apptrace.instrumentation.metamodel.adk import _helper
 from monocle_apptrace.instrumentation.metamodel.adk.entities.agent import AGENT_ORCHESTRATOR
 
 class AdkSpanHandler(SpanHandler):
-    """Custom span handler for ADK instrumentation that adds session_id scope."""
+    """Custom span handler for ADK instrumentation that adds session_id and turn scopes."""
 
     def pre_tracing(self, to_wrap, wrapped, instance, args, kwargs):
         """Set session_id scope before tracing begins."""
@@ -22,7 +26,7 @@ class AdkSpanHandler(SpanHandler):
             if agent_class in ['SequentialAgent', 'LoopAgent', 'ParallelAgent']:
                 agent_request_wrapper = to_wrap.copy()
                 agent_request_wrapper["output_processor"] = AGENT_ORCHESTRATOR
-                
+
                 # Set execution ID scope ONLY for ParallelAgent
                 if agent_class == 'ParallelAgent':
                     # Set both session and execution scopes together if session is present
@@ -42,4 +46,36 @@ class AdkSpanHandler(SpanHandler):
             if session_id and session_id_token is None:
                 session_id_token = set_scope(AGENT_SESSION, session_id)
 
-        return session_id_token, agent_request_wrapper
+        # Bind the turn scope to ADK's invocation_id at the root agent, before child spans.
+        turn_token = self._bind_turn_scope(instance, args)
+        tokens = [t for t in (session_id_token, turn_token) if t is not None]
+        return (tokens or None), agent_request_wrapper
+
+    def _bind_turn_scope(self, instance, args):
+        """Set the turn scope to ADK's invocation_id once, at the root agent call.
+
+        invocation_id isn't known until inside run_async, so it can't be set up-front
+        (the REQUEST entity skips the random builtin turn scope). args[0] is the ADK
+        InvocationContext; sub-agents inherit the scope, so is_scope_set guards a re-set.
+        Also stamps the REQUEST/turn span, which opened before the id existed.
+        """
+        if getattr(instance, '__class__', None) is not None and instance.__class__.__name__ == 'Runner':
+            return None
+        if is_scope_set(AGENT_REQUEST_SPAN_NAME) or not args:
+            return None
+        invocation_id = getattr(args[0], 'invocation_id', None)
+        if not invocation_id:
+            return None
+        token = set_scope(AGENT_REQUEST_SPAN_NAME, invocation_id)
+        request_span = get_current_monocle_span()
+        if request_span is not None and request_span.is_recording():
+            request_span.set_attribute(f"scope.{AGENT_REQUEST_SPAN_NAME}", invocation_id)
+        return token
+
+    def post_tracing(self, to_wrap, wrapped, instance, args, kwargs, return_value, token=None):
+        # pre_tracing may return multiple scope tokens; detach in reverse (LIFO) order.
+        if isinstance(token, list):
+            for scope_token in reversed(token):
+                remove_scope(scope_token)
+        elif token:
+            remove_scope(token)

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/adk/adk_handler.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/adk/adk_handler.py
@@ -47,17 +47,15 @@ class AdkSpanHandler(SpanHandler):
                 session_id_token = set_scope(AGENT_SESSION, session_id)
 
         # Bind the turn scope to ADK's invocation_id at the root agent, before child spans.
-        turn_token = self._bind_turn_scope(instance, args)
-        tokens = [t for t in (session_id_token, turn_token) if t is not None]
+        turn_scope_token = self._bind_turn_scope(instance, args)
+        tokens = [t for t in (session_id_token, turn_scope_token) if t is not None]
         return (tokens or None), agent_request_wrapper
 
     def _bind_turn_scope(self, instance, args):
-        """Set the turn scope to ADK's invocation_id once, at the root agent call.
+        """Bind the turn scope to ADK's invocation_id once, at the root agent call.
 
-        invocation_id isn't known until inside run_async, so it can't be set up-front
-        (the REQUEST entity skips the random builtin turn scope). args[0] is the ADK
-        InvocationContext; sub-agents inherit the scope, so is_scope_set guards a re-set.
-        Also stamps the REQUEST/turn span, which opened before the id existed.
+        The id isn't known until ADK is running, so it's set here (not up-front) and stamped
+        onto the already-open turn span; is_scope_set stops sub-agents from re-setting it.
         """
         if getattr(instance, '__class__', None) is not None and instance.__class__.__name__ == 'Runner':
             return None
@@ -79,3 +77,13 @@ class AdkSpanHandler(SpanHandler):
                 remove_scope(scope_token)
         elif token:
             remove_scope(token)
+
+    def post_task_processing(self, to_wrap, wrapped, instance, args, kwargs, result, ex, span, parent_span):
+        super().post_task_processing(to_wrap, wrapped, instance, args, kwargs, result, ex, span, parent_span)
+        # The workflow/root span opened before the id existed and skips scope hydration at
+        # close, so copy the turn scope onto it (only the turn span's parent is the workflow).
+        turn_scope = f"scope.{AGENT_REQUEST_SPAN_NAME}"
+        turn_id = span.attributes.get(turn_scope)
+        if (turn_id and parent_span is not None
+                and SpanHandler.is_workflow_span(parent_span) and parent_span.is_recording()):
+            parent_span.set_attribute(turn_scope, turn_id)

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/adk/entities/agent.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/adk/entities/agent.py
@@ -100,9 +100,8 @@ AGENT_ORCHESTRATOR = {
 REQUEST = {
       "type": SPAN_TYPES.AGENTIC_REQUEST,
       "subtype": SPAN_SUBTYPES.TURN,
-      # AdkSpanHandler sets the turn scope to invocation_id (not available up-front), so opt
-      # into caller-provided value handling instead of the random auto-generated builtin.
-      "use_builtin_scope": True,
+      # AdkSpanHandler binds the turn scope to invocation_id; skip the random builtin one.
+      "skip_builtin_scope": True,
       "attributes": [
         [
               {

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/adk/entities/agent.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/adk/entities/agent.py
@@ -100,9 +100,10 @@ AGENT_ORCHESTRATOR = {
 REQUEST = {
       "type": SPAN_TYPES.AGENTIC_REQUEST,
       "subtype": SPAN_SUBTYPES.TURN,
-      # AdkSpanHandler sets the turn scope to invocation_id (not available up-front), so opt
-      # into caller-provided value handling instead of the random auto-generated builtin.
+      # Turn scope value = the caller-supplied invocation_id (ADK run_async(invocation_id=...)).
+      # Set by the core builtin-scope mechanism; falls back to an auto-generated id if absent.
       "use_builtin_scope": True,
+      "scope_value": lambda arguments: arguments["kwargs"].get("invocation_id"),
       "attributes": [
         [
               {

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/adk/entities/agent.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/adk/entities/agent.py
@@ -100,8 +100,9 @@ AGENT_ORCHESTRATOR = {
 REQUEST = {
       "type": SPAN_TYPES.AGENTIC_REQUEST,
       "subtype": SPAN_SUBTYPES.TURN,
-      # AdkSpanHandler binds the turn scope to invocation_id; skip the random builtin one.
-      "skip_builtin_scope": True,
+      # AdkSpanHandler sets the turn scope to invocation_id (not available up-front), so opt
+      # into caller-provided value handling instead of the random auto-generated builtin.
+      "use_builtin_scope": True,
       "attributes": [
         [
               {

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/adk/entities/agent.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/adk/entities/agent.py
@@ -100,6 +100,8 @@ AGENT_ORCHESTRATOR = {
 REQUEST = {
       "type": SPAN_TYPES.AGENTIC_REQUEST,
       "subtype": SPAN_SUBTYPES.TURN,
+      # AdkSpanHandler binds the turn scope to invocation_id; skip the random builtin one.
+      "skip_builtin_scope": True,
       "attributes": [
         [
               {

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/adk/entities/agent.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/adk/entities/agent.py
@@ -100,10 +100,9 @@ AGENT_ORCHESTRATOR = {
 REQUEST = {
       "type": SPAN_TYPES.AGENTIC_REQUEST,
       "subtype": SPAN_SUBTYPES.TURN,
-      # Turn scope value = the caller-supplied invocation_id (ADK run_async(invocation_id=...)).
-      # Set by the core builtin-scope mechanism; falls back to an auto-generated id if absent.
+      # AdkSpanHandler sets the turn scope to invocation_id (not available up-front), so opt
+      # into caller-provided value handling instead of the random auto-generated builtin.
       "use_builtin_scope": True,
-      "scope_value": lambda arguments: arguments["kwargs"].get("invocation_id"),
       "attributes": [
         [
               {

--- a/apptrace/tests/integration/test_adk_single_agent.py
+++ b/apptrace/tests/integration/test_adk_single_agent.py
@@ -251,3 +251,12 @@ def verify_spans(memory_exporter, expected_invocation_id=None):
     ]
     assert request_turn_ids and all(t == turn_id for t in request_turn_ids), \
         f"agentic.turn span missing or mismatched turn id: {request_turn_ids}"
+
+    # The workflow/root span must also carry the turn id (propagated from the turn span).
+    workflow_turn_ids = [
+        span.attributes.get("scope.agentic.turn")
+        for span in spans
+        if span.attributes.get("span.type") == "workflow"
+    ]
+    assert workflow_turn_ids and all(t == turn_id for t in workflow_turn_ids), \
+        f"workflow span missing or mismatched turn id: {workflow_turn_ids}"

--- a/apptrace/tests/integration/test_adk_single_agent.py
+++ b/apptrace/tests/integration/test_adk_single_agent.py
@@ -112,21 +112,21 @@ runner = Runner(
     session_service=session_service
 )
 
-async def run_agent(test_message: str):
+async def run_agent(test_message: str, invocation_id: str = None):
     session = await session_service.create_session(
-        app_name=APP_NAME, 
+        app_name=APP_NAME,
         user_id=USER_ID,
         session_id=SESSION_ID
     )
     content = types.Content(role='user', parts=[types.Part(text=test_message)])
-    invocation_id = None
-    # Process events as they arrive using async for
+    # Process events as they arrive using async for. A caller-supplied invocation_id is
+    # honored by ADK (>= 2.5) and becomes the turn scope via the builtin-scope mechanism.
     async for event in runner.run_async(
         user_id=USER_ID,
         session_id=SESSION_ID,
+        invocation_id=invocation_id,
         new_message=content
     ):
-        invocation_id = event.invocation_id or invocation_id
         # For final response
         if event.is_final_response():
             logger.info(event.content)  # End line after response
@@ -135,7 +135,8 @@ async def run_agent(test_message: str):
 @pytest.mark.asyncio
 async def test_multi_agent(setup):
     test_message = "What is the current weather in New York?"
-    invocation_id = await run_agent(test_message)
+    invocation_id = "e-00000000-0000-0000-0000-0000000000ad"  # caller-supplied turn id
+    await run_agent(test_message, invocation_id)
     verify_spans(setup, invocation_id)
 
 @pytest.mark.asyncio

--- a/apptrace/tests/integration/test_adk_single_agent.py
+++ b/apptrace/tests/integration/test_adk_single_agent.py
@@ -112,21 +112,21 @@ runner = Runner(
     session_service=session_service
 )
 
-async def run_agent(test_message: str, invocation_id: str = None):
+async def run_agent(test_message: str):
     session = await session_service.create_session(
-        app_name=APP_NAME,
+        app_name=APP_NAME, 
         user_id=USER_ID,
         session_id=SESSION_ID
     )
     content = types.Content(role='user', parts=[types.Part(text=test_message)])
-    # Process events as they arrive using async for. A caller-supplied invocation_id is
-    # honored by ADK (>= 2.5) and becomes the turn scope via the builtin-scope mechanism.
+    invocation_id = None
+    # Process events as they arrive using async for
     async for event in runner.run_async(
         user_id=USER_ID,
         session_id=SESSION_ID,
-        invocation_id=invocation_id,
         new_message=content
     ):
+        invocation_id = event.invocation_id or invocation_id
         # For final response
         if event.is_final_response():
             logger.info(event.content)  # End line after response
@@ -135,8 +135,7 @@ async def run_agent(test_message: str, invocation_id: str = None):
 @pytest.mark.asyncio
 async def test_multi_agent(setup):
     test_message = "What is the current weather in New York?"
-    invocation_id = "e-00000000-0000-0000-0000-0000000000ad"  # caller-supplied turn id
-    await run_agent(test_message, invocation_id)
+    invocation_id = await run_agent(test_message)
     verify_spans(setup, invocation_id)
 
 @pytest.mark.asyncio

--- a/apptrace/tests/integration/test_adk_single_agent.py
+++ b/apptrace/tests/integration/test_adk_single_agent.py
@@ -119,21 +119,24 @@ async def run_agent(test_message: str):
         session_id=SESSION_ID
     )
     content = types.Content(role='user', parts=[types.Part(text=test_message)])
+    invocation_id = None
     # Process events as they arrive using async for
     async for event in runner.run_async(
         user_id=USER_ID,
         session_id=SESSION_ID,
         new_message=content
     ):
+        invocation_id = event.invocation_id or invocation_id
         # For final response
         if event.is_final_response():
             logger.info(event.content)  # End line after response
+    return invocation_id
 
 @pytest.mark.asyncio
 async def test_multi_agent(setup):
     test_message = "What is the current weather in New York?"
-    await run_agent(test_message)
-    verify_spans(setup)
+    invocation_id = await run_agent(test_message)
+    verify_spans(setup, invocation_id)
 
 @pytest.mark.asyncio
 async def test_invalid_api_key_error_code_in_span(setup):
@@ -157,7 +160,7 @@ async def test_invalid_api_key_error_code_in_span(setup):
                     assert "error_code" in span_output.attributes
                     assert span_output.attributes["error_code"] == 400
 
-def verify_spans(memory_exporter):
+def verify_spans(memory_exporter, expected_invocation_id=None):
     time.sleep(2)
     found_inference = found_agent = found_tool = False
     inference_span_id = None
@@ -225,3 +228,26 @@ def verify_spans(memory_exporter):
     assert found_inference, "Inference span not found"
     assert found_agent, "Agent span not found"
     assert found_tool, "Tool span not found"
+
+    # Turn scope must be the ADK invocation_id ("e-..."), consistent across the turn.
+    turn_ids = {
+        span.attributes["scope.agentic.turn"]
+        for span in spans
+        if "scope.agentic.turn" in span.attributes
+    }
+    assert turn_ids, "scope.agentic.turn not found on any span"
+    assert len(turn_ids) == 1, f"scope.agentic.turn inconsistent across the turn: {turn_ids}"
+    turn_id = turn_ids.pop()
+    assert turn_id.startswith("e-"), f"turn id is not an ADK invocation_id: {turn_id}"
+    if expected_invocation_id is not None:
+        assert turn_id == expected_invocation_id, \
+            f"Expected turn id {expected_invocation_id}, got {turn_id}"
+
+    # The REQUEST/turn span itself must carry the turn id.
+    request_turn_ids = [
+        span.attributes.get("scope.agentic.turn")
+        for span in spans
+        if span.attributes.get("span.type") == "agentic.turn"
+    ]
+    assert request_turn_ids and all(t == turn_id for t in request_turn_ids), \
+        f"agentic.turn span missing or mismatched turn id: {request_turn_ids}"


### PR DESCRIPTION
Bind the ADK turn scope (`scope.agentic.turn`) to ADK's native `invocation_id`, instead of a random, ADK-unrelated value — so a turn is identifiable end-to-end (telemetry ↔ ADK ↔ app) and the id lands on **every** span of the turn, including the workflow/root span.

This works on the ADK version Kahu runs today; it reads ADK's own generated `invocation_id`, so it does not depend on any specific ADK version or on the caller supplying an id.

## Proposed changes

### Core (`common/wrapper.py`)
`get_builtin_scope_names` gains a small opt-out flag (`skip_builtin_scope`): an entity marks that its builtin scope's value is set elsewhere (by its span handler), so the core does not auto-generate the random default. Backward-compatible — entities that don't set it behave exactly as before.

### ADK metamodel
- The `REQUEST` (turn) entity sets `skip_builtin_scope: True`, so the core does **not** mint a random turn scope for it.
- `AdkSpanHandler` sets `scope.agentic.turn = ctx.invocation_id` at the **root-agent boundary** (the earliest point ADK's id exists, before any LLM/tool child span) so the agent subtree inherits it, and stamps it onto the already-open turn/REQUEST span. `post_task_processing` copies it onto the workflow/root span (which opened before the id existed and doesn't re-hydrate scopes at close).

### Why the handler is needed
ADK mints `invocation_id` **inside** `run_async`, after the turn span and workflow span have already opened — so the value can't be set purely up-front. The handler captures it at the first point it exists and stamps the two ancestor spans. This is version-independent: it reads whatever id ADK generates.

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation Update

## Checklist
- [ ] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

**Coverage:** every span in the turn carries `scope.agentic.turn` — the REQUEST/turn span and the agentic subtree (agent, LLM, tools) via baggage, plus the workflow/root span via child→parent propagation in `post_task_processing` (reusing the existing `propogate_inference_info_to_parent_span` idiom).

**Backward compatibility:** unchanged behavior for other frameworks and for ADK apps generally — the turn id is ADK's own `invocation_id`; nothing must be passed by the caller.

**Verified end-to-end** on a real multi-agent ADK app, multi-session/multi-turn, on both `Runner.run_async` and the threaded sync `Runner.run`: turn id = ADK's `invocation_id`, unique per turn, consistent across the subtree, present on the workflow span.
