### PR TITLE
feat: add subcommand dispatch to monocle_test_tools CLI

### DIFF
--- a/test_tools/README.md
+++ b/test_tools/README.md
@@ -369,16 +369,19 @@ Automatically generate test code by analyzing trace files. The generator scans s
 
 ```bash
 # Generate test code from a trace file
-python -m monocle_test_tools.generate_test trace.json
+python -m monocle_test_tools generate_test --trace-file trace.json
 
 # With custom test name
-python -m monocle_test_tools.generate_test trace.json --test-name test_my_agent
+python -m monocle_test_tools generate_test --trace-file trace.json --test-name test_my_agent
 
 # Only generate the loader for a specific trace source (file | okahu)
-python -m monocle_test_tools.generate_test trace.json --trace-source file
+python -m monocle_test_tools generate_test --trace-file trace.json --trace-source file
 
 # Save to file
-python -m monocle_test_tools.generate_test trace.json > test_generated.py
+python -m monocle_test_tools generate_test --trace-file trace.json > test_generated.py
+
+# The old module path still works
+python -m monocle_test_tools.generate_test trace.json
 ```
 
 By default the generated test includes loader options for every supported trace

--- a/test_tools/src/monocle_test_tools/__main__.py
+++ b/test_tools/src/monocle_test_tools/__main__.py
@@ -1,6 +1,37 @@
-"""Entry point for python -m monocle_test_tools.generate_test"""
+"""Entry point for python -m monocle_test_tools [command] [options]"""
 
-from monocle_test_tools.generate_test import main
+import sys
+import importlib
+
+SUBCOMMANDS = {
+    "generate_test": "monocle_test_tools.generate_test",
+}
+
+HELP_TEXT = """Usage: python -m monocle_test_tools <command> [options]
+
+Available commands:
+  generate_test  —  Generate test code from a trace file
+"""
+
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
+        print(HELP_TEXT, file=sys.stderr)
+        sys.exit(1 if len(sys.argv) < 2 else 0)
+
+    command = sys.argv.pop(1)
+    module_path = SUBCOMMANDS.get(command)
+    if module_path is None:
+        print(
+            f"Unknown command: {command}\n"
+            f"Available: {', '.join(SUBCOMMANDS)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    module = importlib.import_module(module_path)
+    sys.exit(module.main())
+
 
 if __name__ == "__main__":
     main()

--- a/test_tools/src/monocle_test_tools/generate_test.py
+++ b/test_tools/src/monocle_test_tools/generate_test.py
@@ -16,7 +16,8 @@ def main():
         epilog=__doc__
     )
     
-    parser.add_argument("trace_file", help="Path to trace JSON file")
+    parser.add_argument("trace_file", nargs="?", default=None, help="Path to trace JSON file")
+    parser.add_argument("--trace-file", dest="_trace_file_flag", metavar="TRACE_FILE", default=None, help="Path to trace JSON file")
     parser.add_argument("--test-name", default="test_generated", help="Test function name (default: test_generated)")
     
     parser.add_argument(
@@ -28,10 +29,14 @@ def main():
     )
     args = parser.parse_args()
     
+    trace_file = args._trace_file_flag if args._trace_file_flag else args.trace_file
+    if not trace_file:
+        parser.error("trace file is required: provide it as a positional argument or via --trace-file")
+    
     from monocle_test_tools.test_generator import TestGenerator
     
     try:
-        generator = TestGenerator.from_json_file(args.trace_file, trace_source=args.trace_source)
+        generator = TestGenerator.from_json_file(trace_file, trace_source=args.trace_source)
         test_code = generator.generate_test_code(test_name=args.test_name)
         print(test_code)
     except Exception as e:

--- a/test_tools/tests/unit/test_cli_dispatch.py
+++ b/test_tools/tests/unit/test_cli_dispatch.py
@@ -1,0 +1,57 @@
+"""Tests for CLI subcommand dispatch in __main__.py and generate_test.py."""
+
+import sys
+from unittest.mock import patch
+import pytest
+
+
+def test_dispatch_help_exits_0():
+    """--help should print usage and exit with code 0."""
+    from monocle_test_tools.__main__ import main
+    with patch.object(sys, "argv", ["monocle_test_tools", "--help"]):
+        with pytest.raises(SystemExit) as exc:
+            main()
+    assert exc.value.code == 0
+
+
+def test_dispatch_no_args_exits_1():
+    """No args should print usage and exit with code 1."""
+    from monocle_test_tools.__main__ import main
+    with patch.object(sys, "argv", ["monocle_test_tools"]):
+        with pytest.raises(SystemExit) as exc:
+            main()
+    assert exc.value.code == 1
+
+
+def test_dispatch_unknown_command_exits_1():
+    """Unknown command should print error and exit with code 1."""
+    from monocle_test_tools.__main__ import main
+    with patch.object(sys, "argv", ["monocle_test_tools", "bogus"]):
+        with pytest.raises(SystemExit) as exc:
+            main()
+    assert exc.value.code == 1
+
+
+def test_dispatch_generate_test_without_trace_file_exits_2():
+    """generate_test without --trace-file should exit with code 2."""
+    from monocle_test_tools.__main__ import main
+    with patch.object(sys, "argv", ["monocle_test_tools", "generate_test"]):
+        with pytest.raises(SystemExit) as exc:
+            main()
+    assert exc.value.code == 2
+
+
+def test_generate_test_accepts_positional_trace_file():
+    """generate_test should accept trace_file as positional argument."""
+    from monocle_test_tools.generate_test import main
+    with patch.object(sys, "argv", ["generate_test", "trace.json"]):
+        result = main()
+    assert result != 2  # Not an arg-parse error
+
+
+def test_generate_test_accepts_trace_file_flag():
+    """generate_test should accept --trace-file as named argument."""
+    from monocle_test_tools.generate_test import main
+    with patch.object(sys, "argv", ["generate_test", "--trace-file", "trace.json"]):
+        result = main()
+    assert result != 2  # Not an arg-parse error


### PR DESCRIPTION
## Proposed changes

Adds subcommand dispatch to `python -m monocle_test_tools` so the test
generator can be invoked as:

    python -m monocle_test_tools generate_test --trace-file trace.json

instead of only the longer form:

    python -m monocle_test_tools.generate_test trace.json

The old invocation path continues to work unchanged.

Changes:
1.  __main__.py — Rewritten as a subcommand dispatcher. Reads `sys.argv[1]`
  as the command name, strips it from argv, and imports + calls the matching
  module's `main()`.
2.  generate_test.py — Added `--trace-file` as a named argument alongside
  the existing positional `trace_file`. Both resolve to the same variable.
  Added validation requiring at least one to be provided.
3.  test_cli_dispatch.py  (new) — 6 unit tests covering help, unknown
  commands, missing args, and both positional/flag invocation paths.

Closes #685 
## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...