### PR TITLE
methods.py: changed scope_name from agent.invocation to agentic.invoc…

### DIFF
--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/langgraph_processor.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/langgraph_processor.py
@@ -2,7 +2,7 @@ import logging
 from opentelemetry.context import set_value, attach, detach, get_value
 from monocle_apptrace.instrumentation.common.constants import (
     AGENT_PREFIX_KEY, SCOPE_NAME, AGENT_NAME_KEY, AGENT_INVOCATION_SPAN_NAME,
-    LAST_AGENT_INVOCATION_ID, LAST_AGENT_NAME, AGENT_SESSION
+    AGENT_REQUEST_SPAN_NAME, LAST_AGENT_INVOCATION_ID, LAST_AGENT_NAME, AGENT_SESSION
 )
 from monocle_apptrace.instrumentation.common.span_handler import SpanHandler
 from monocle_apptrace.instrumentation.metamodel.langgraph._helper import (
@@ -47,10 +47,10 @@ class LanggraphAgentHandler(SpanHandler):
         """Skip span creation for internal stream/astream calls made by invoke/ainvoke"""
         method = to_wrap.get("method")
         if method in ["stream", "astream"]:
-            # Check if we're already in an agentic.invocation scope
+            # Check if we're already in an agentic.invocation or agentic.turn scope
             # This happens when invoke() internally calls stream()
-            if is_scope_set("agentic.invocation"):
-                logger.debug(f"Skipping internal {method}() call within invoke() - preventing duplicate agentic.invocation span")
+            if is_scope_set(AGENT_INVOCATION_SPAN_NAME) or is_scope_set(AGENT_REQUEST_SPAN_NAME):
+                logger.debug(f"Skipping internal {method}() call within invoke/ainvoke - preventing duplicate agentic.invocation span")
                 return True
         return super().skip_span(to_wrap, wrapped, instance, args, kwargs)
 

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/methods.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/langgraph/methods.py
@@ -1,4 +1,5 @@
 from monocle_apptrace.instrumentation.common.wrapper import task_wrapper, atask_wrapper, atask_iter_wrapper, task_iter_wrapper
+from monocle_apptrace.instrumentation.common.constants import AGENT_INVOCATION_SPAN_NAME
 from monocle_apptrace.instrumentation.metamodel.langgraph.entities.inference import (
     AGENT,
     AGENT_STREAM,
@@ -12,7 +13,7 @@ LANGGRAPH_METHODS = [
         "method": "invoke",
         "wrapper_method": task_wrapper,
         "span_handler": "langgraph_agent_handler",
-        "scope_name": "agent.invocation",
+        "scope_name": AGENT_INVOCATION_SPAN_NAME,
         "output_processor": AGENT,
     },
     {
@@ -21,7 +22,7 @@ LANGGRAPH_METHODS = [
         "method": "ainvoke",
         "wrapper_method": atask_wrapper,
         "span_handler": "langgraph_agent_handler",
-        "scope_name": "agent.invocation",
+        "scope_name": AGENT_INVOCATION_SPAN_NAME,
         "output_processor": AGENT,
     },
     {
@@ -30,7 +31,7 @@ LANGGRAPH_METHODS = [
         "method": "astream",
         "wrapper_method": atask_iter_wrapper,
         "span_handler": "langgraph_agent_handler",
-        "scope_name": "agent.invocation",
+        "scope_name": AGENT_INVOCATION_SPAN_NAME,
         "output_processor": AGENT_STREAM,
     },
     {
@@ -39,7 +40,7 @@ LANGGRAPH_METHODS = [
         "method": "stream",
         "wrapper_method": task_iter_wrapper,
         "span_handler": "langgraph_agent_handler",
-        "scope_name": "agent.invocation",
+        "scope_name": AGENT_INVOCATION_SPAN_NAME,
         "output_processor": AGENT_STREAM,
     },
     {
@@ -48,7 +49,7 @@ LANGGRAPH_METHODS = [
         "method": "astream_events",
         "wrapper_method": atask_iter_wrapper,
         "span_handler": "langgraph_agent_handler",
-        "scope_name": "agent.invocation",
+        "scope_name": AGENT_INVOCATION_SPAN_NAME,
         "output_processor": AGENT,
     },
     {

--- a/apptrace/tests/unit/test_langgraph_skip_span_fix.py
+++ b/apptrace/tests/unit/test_langgraph_skip_span_fix.py
@@ -10,6 +10,10 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from monocle_apptrace.instrumentation.common.scope_wrapper import start_scope, stop_scope
+from monocle_apptrace.instrumentation.common.constants import (
+    AGENT_INVOCATION_SPAN_NAME,
+    AGENT_REQUEST_SPAN_NAME,
+)
 from monocle_apptrace.instrumentation.metamodel.langgraph.langgraph_processor import (
     LanggraphAgentHandler,
 )
@@ -43,7 +47,7 @@ class TestLanggraphSkipSpanFix(unittest.TestCase):
         to_wrap = self._to_wrap("astream")
         
         # Simulate being inside an agentic.invocation scope (as when ainvoke calls astream)
-        scope_token = start_scope("agentic.invocation", "test-invocation-id")
+        scope_token = start_scope(AGENT_INVOCATION_SPAN_NAME, "test-invocation-id")
         try:
             # skip_span should return True to prevent duplicate span
             result = self.handler.skip_span(
@@ -74,7 +78,7 @@ class TestLanggraphSkipSpanFix(unittest.TestCase):
         to_wrap = self._to_wrap("stream")
         
         # Simulate being inside an agentic.invocation scope (as when invoke calls stream)
-        scope_token = start_scope("agentic.invocation", "test-invocation-id")
+        scope_token = start_scope(AGENT_INVOCATION_SPAN_NAME, "test-invocation-id")
         try:
             result = self.handler.skip_span(
                 to_wrap, self.mock_wrapped, self.instance, self.mock_args, self.mock_kwargs
@@ -104,7 +108,7 @@ class TestLanggraphSkipSpanFix(unittest.TestCase):
         to_wrap = self._to_wrap("ainvoke")
         
         # Even if there's an existing scope, ainvoke should not be skipped by this logic
-        scope_token = start_scope("agentic.invocation", "existing-scope")
+        scope_token = start_scope(AGENT_INVOCATION_SPAN_NAME, "existing-scope")
         try:
             result = self.handler.skip_span(
                 to_wrap, self.mock_wrapped, self.instance, self.mock_args, self.mock_kwargs
@@ -122,7 +126,7 @@ class TestLanggraphSkipSpanFix(unittest.TestCase):
         """Test that invoke() is never skipped."""
         to_wrap = self._to_wrap("invoke")
         
-        scope_token = start_scope("agentic.invocation", "existing-scope")
+        scope_token = start_scope(AGENT_INVOCATION_SPAN_NAME, "existing-scope")
         try:
             result = self.handler.skip_span(
                 to_wrap, self.mock_wrapped, self.instance, self.mock_args, self.mock_kwargs
@@ -134,20 +138,18 @@ class TestLanggraphSkipSpanFix(unittest.TestCase):
         finally:
             stop_scope(scope_token)
 
-    def test_different_scope_does_not_trigger_skip(self):
-        """Test that stream/astream are only skipped for agentic.invocation scope, not other scopes."""
+    def test_agentic_turn_scope_also_triggers_skip(self):
+        """Test that stream/astream are skipped when already in agentic.turn scope."""
         to_wrap = self._to_wrap("astream")
         
-        # Set a different scope (not agentic.invocation)
-        scope_token = start_scope("agentic.turn", "some-turn-id")
+        scope_token = start_scope(AGENT_REQUEST_SPAN_NAME, "some-turn-id")
         try:
             result = self.handler.skip_span(
                 to_wrap, self.mock_wrapped, self.instance, self.mock_args, self.mock_kwargs
             )
-            # Should not skip because we're checking for agentic.invocation specifically
-            self.assertFalse(
+            self.assertTrue(
                 result,
-                "skip_span should not skip astream() when only agentic.turn scope is set"
+                "skip_span should skip astream() when agentic.turn scope is set"
             )
         finally:
             stop_scope(scope_token)
@@ -172,7 +174,7 @@ class TestLanggraphSkipSpanIntegration(unittest.TestCase):
         """
         # Step 1: ainvoke creates a scope
         ainvoke_to_wrap = self._to_wrap("ainvoke")
-        scope_token = start_scope("agentic.invocation", "ainvoke-scope-123")
+        scope_token = start_scope(AGENT_INVOCATION_SPAN_NAME, "ainvoke-scope-123")
         
         try:
             # Step 2: During ainvoke's execution, astream() is called


### PR DESCRIPTION
…ation for invoke/ainvoke/stream/astream paths to fix scope mismatch in child-agent internal invokes.

langgraph_processor.py: updated skip_span to skip stream/astream when either agentic.invocation or agentic.turn scope is already set, preventing extra top-level wrapper spans during internal astream calls.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...