### PR TITLE
WIP: adk — reuse ADK invocation id as the turn id

### DIFF
--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/adk/_helper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/adk/_helper.py
@@ -100,6 +100,10 @@ def extract_agent_request_input(arguments: Dict[str, Any]) -> Any:
     """
     return [arguments['kwargs']['new_message'].parts[0].text] if 'new_message' in arguments['kwargs'] else []
 
+def get_invocation_id(args) -> Optional[str]:
+    """Return ADK's invocation id from a BaseAgent.run_async call, if present."""
+    return args[0].invocation_id if args and hasattr(args[0], 'invocation_id') else None
+
 def extract_agent_response(result: Any) -> Any:
     """
     Extract the response data from agent result.

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/adk/adk_handler.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/adk/adk_handler.py
@@ -1,6 +1,6 @@
-from monocle_apptrace.instrumentation.common.constants import AGENT_SESSION, AGENT_EXECUTION_ID
+from monocle_apptrace.instrumentation.common.constants import AGENT_SESSION, AGENT_EXECUTION_ID, AGENT_REQUEST_SPAN_NAME
 from monocle_apptrace.instrumentation.common.span_handler import SpanHandler
-from monocle_apptrace.instrumentation.common.utils import set_scope, set_scopes
+from monocle_apptrace.instrumentation.common.utils import set_scope, set_scopes, is_scope_set, get_parent_span
 from monocle_apptrace.instrumentation.metamodel.adk import _helper
 from monocle_apptrace.instrumentation.metamodel.adk.entities.agent import AGENT_ORCHESTRATOR
 
@@ -16,6 +16,16 @@ class AdkSpanHandler(SpanHandler):
         if hasattr(instance, '__class__') and instance.__class__.__name__ == 'Runner':
             session_id = kwargs.get('session_id')
 
+        # Reuse ADK's invocation id as the turn id, set once on the root agent so the
+        # whole turn (the turn span included) carries the identifier ADK assigns it.
+        turn_scope = {}
+        turn_id = _helper.get_invocation_id(args)
+        if turn_id and not is_scope_set(AGENT_REQUEST_SPAN_NAME):
+            turn_scope[AGENT_REQUEST_SPAN_NAME] = turn_id
+            parent_span = get_parent_span()
+            if parent_span is not None:
+                parent_span.set_attribute(f"scope.{AGENT_REQUEST_SPAN_NAME}", turn_id)
+
         agent_request_wrapper = None
         try:
             agent_class = instance.config_type.model_fields['agent_class'].default
@@ -29,11 +39,12 @@ class AdkSpanHandler(SpanHandler):
                     if session_id:
                         session_id_token = set_scopes({
                             AGENT_SESSION: session_id,
-                            AGENT_EXECUTION_ID: None  # Auto-generate unique ID
+                            AGENT_EXECUTION_ID: None,  # Auto-generate unique ID
+                            **turn_scope
                         })
                     else:
                         # Set only execution scope
-                        session_id_token = set_scope(AGENT_EXECUTION_ID, None)
+                        session_id_token = set_scopes({AGENT_EXECUTION_ID: None, **turn_scope})
             elif session_id:
                 # Set only session scope for non-parallel agents
                 session_id_token = set_scope(AGENT_SESSION, session_id)
@@ -41,5 +52,9 @@ class AdkSpanHandler(SpanHandler):
             # If we still need to set session_id but agent type check failed
             if session_id and session_id_token is None:
                 session_id_token = set_scope(AGENT_SESSION, session_id)
+
+        # Non-parallel agent paths set no scope above; carry the turn id on its own.
+        if turn_scope and session_id_token is None:
+            session_id_token = set_scopes(turn_scope)
 
         return session_id_token, agent_request_wrapper

--- a/apptrace/tests/unit/test_span_handler_scope_coercion.py
+++ b/apptrace/tests/unit/test_span_handler_scope_coercion.py
@@ -4,6 +4,9 @@ from unittest.mock import MagicMock, patch
 from opentelemetry.sdk.trace import Span
 
 from monocle_apptrace.instrumentation.common.span_handler import SpanHandler
+from monocle_apptrace.instrumentation.common.constants import AGENT_REQUEST_SPAN_NAME
+from monocle_apptrace.instrumentation.common.utils import get_scopes, set_scopes, remove_scopes
+from monocle_apptrace.instrumentation.metamodel.adk import adk_handler
 
 
 class TestScopeValueCoercion(unittest.TestCase):
@@ -38,6 +41,48 @@ class TestScopeValueCoercion(unittest.TestCase):
         ), patch.object(SpanHandler, "get_workflow_name", return_value=None):
             SpanHandler.set_default_monocle_attributes(span)
         self.assertEqual(attrs["scope.agentic.session"], str(u))
+
+
+class TestAdkTurnId(unittest.TestCase):
+    """AdkSpanHandler reuses ADK's invocation id as the turn id, set once on the root agent
+    and stamped on every span in the turn (the turn span itself via a parent backfill)."""
+
+    class _Agent:  # a non-Runner, non-orchestrator agent instance
+        pass
+
+    class _Ctx:  # ADK's InvocationContext passed to BaseAgent.run_async
+        def __init__(self, invocation_id):
+            self.invocation_id = invocation_id
+
+    def setUp(self):
+        self.handler = adk_handler.AdkSpanHandler()
+        self._tokens = []
+
+    def tearDown(self):
+        for token in reversed(self._tokens):
+            remove_scopes(token)
+
+    def _pre_tracing(self, invocation_id, parent_attrs):
+        parent_span = MagicMock(spec=Span)
+        parent_span.set_attribute = MagicMock(side_effect=lambda k, v: parent_attrs.__setitem__(k, v))
+        with patch.object(adk_handler, "get_parent_span", return_value=parent_span):
+            token, _ = self.handler.pre_tracing({}, None, self._Agent(), (self._Ctx(invocation_id),), {})
+        if token:
+            self._tokens.append(token)
+        return dict(get_scopes())
+
+    def test_root_agent_reuses_invocation_id_as_turn_id(self):
+        parent_attrs = {}
+        scopes = self._pre_tracing("e-abc", parent_attrs)
+        self.assertEqual(scopes[AGENT_REQUEST_SPAN_NAME], "e-abc")
+        self.assertEqual(parent_attrs[f"scope.{AGENT_REQUEST_SPAN_NAME}"], "e-abc")
+
+    def test_nested_agent_keeps_existing_turn_id(self):
+        self._tokens.append(set_scopes({AGENT_REQUEST_SPAN_NAME: "e-outer"}))
+        parent_attrs = {}
+        scopes = self._pre_tracing("e-inner", parent_attrs)
+        self.assertEqual(scopes[AGENT_REQUEST_SPAN_NAME], "e-outer")
+        self.assertNotIn(f"scope.{AGENT_REQUEST_SPAN_NAME}", parent_attrs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Proposed changes

For ADK, reuse ADK's own `invocation_id` as the Monocle turn id (`scope.agentic.turn`) instead of auto-generating one.

ADK assigns each `Runner.run_async` turn a single `invocation_id` and shares it across every sub-agent in that turn, so it maps cleanly onto Monocle's turn concept. Today the ADK metamodel does not set an `agentic.turn` scope at all — a turn is identifiable only by the request span's OTel trace/span id, with no link back to ADK's own id. This change lets Monocle turns be reconciled with ADK's runtime (events, logs) by a shared identifier.

**How it works (minimal, additive):**
- `_helper.get_invocation_id(args)` reads `invocation_id` off the `InvocationContext` passed to `BaseAgent.run_async`.
- `AdkSpanHandler.pre_tracing` sets it once on the root agent (guarded by `is_scope_set`), so:
  - every **descendant** span (agents, tools, Gemini inference) inherits `scope.agentic.turn` via the scope, exactly the way `session_id` already flows;
  - the **top turn span** — opened by the Runner before ADK mints the id — is backfilled directly on the still-open parent span, so *every* span in the turn carries the id.
- The turn id rides on the same scope token already used by the handler. Existing behavior (Runner session scope, orchestrator swap, `ParallelAgent` execution id) is unchanged.

**Status: work in progress / draft** — not yet validated end-to-end against the live ADK integration suite (see checklist).

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The `invocation_id` is not available when `Runner.run_async` opens the turn span — ADK mints it slightly later, inside the run. So it can't be set from the Runner's `pre_tracing` (unlike `session_id`, which is a caller-supplied kwarg). The first point it reliably exists is the root agent's `InvocationContext`, which is also the moment the turn span is still the current parent — hence: set the scope there for descendants, and backfill the parent turn span directly so it isn't the one span missing the id.

Alternative considered: peeking the first yielded `Event.invocation_id` in the Runner's iterator wrapper. Rejected as more invasive — the root-agent backfill covers the turn span with less machinery.

Extends `apptrace/tests/unit/test_span_handler_scope_coercion.py` with two focused cases for the new behavior: root agent reuses the invocation id as the turn id and backfills the parent turn span, and the set-once guard (a nested agent keeps the existing turn id and does not re-backfill).
