### PR TITLE
docs(test-tools): document eval-matrix, CSV cases, and filtered/inline-template evals

### DIFF
--- a/docs/monocle_evaluation_api.md
+++ b/docs/monocle_evaluation_api.md
@@ -329,7 +329,16 @@ monocle_trace_asserter.with_evaluation("okahu") \
     .check_eval(template_path="path/to/my_custom_eval.json", expected="good")
 ```
 
-`template_path` and `eval_name` are mutually exclusive — use one or the other in a single `check_eval()` call. You can mix both styles in the same test:
+You can also pass the template **inline** as a dict via the keyword-only `template` parameter — handy when the template is built in code rather than stored in a file:
+
+```python
+monocle_trace_asserter.with_evaluation("okahu") \
+    .check_eval(template={"name": "my_custom_eval", "eval_prompt": "...",
+                          "structure_output": {"label": {"enums": ["good", "bad"]}}},
+                expected="good")
+```
+
+`eval_name`, `template_path`, and `template` are **mutually exclusive** — provide **exactly one** in a single `check_eval()` call. When `eval_name` is omitted, the template's `name` field is used as the eval name (falling back to `"custom_eval"`). You can mix styles across calls in the same test:
 
 ```python
 # Built-in evaluation
@@ -481,6 +490,69 @@ AssertionError: Duration limit exceeded for agent 'flight_booking_agent': agent_
 AssertionError: Duration limit exceeded for tool 'book_flight': tool_invocation took 5.5 ms (limit: 5 ms)
 ```
 
+## 9. Time-window (Filtered) Evaluation
+
+The examples above evaluate a **specific** trace or fact — one you produced by running an agent, or selected with `with_trace_source("okahu", id=...)`. Sometimes you instead want to evaluate **every fact that occurred in a time window** for one or more workflows, without knowing the trace ids in advance (for example, "grade every trace `my_app` produced overnight").
+
+Set `start_time` and `end_time` on `with_trace_source("okahu", ...)`. This runs `check_eval()` as a single **asynchronous** Okahu job that discovers the matching facts server-side, applies one **blanket** `expected`/`not_expected` to each discovered fact, and reports per fact.
+
+```python
+monocle_trace_asserter \
+    .with_trace_source("okahu", workflow_name="my_app",
+                       start_time="2026-07-21T00:00:00Z", end_time="2026-07-22T00:00:00Z") \
+    .with_evaluation("okahu") \
+    .check_eval("hallucination", expected="no_hallucination", min_facts=5)
+```
+
+**How the mode is selected.** There is no separate "filtered" method — the *same* `check_eval()` runs the filtered flow whenever the source carries a time window instead of an `id`. Rules:
+
+- Provide an `id` **or** a time window, never both (raises `ValueError`).
+- Filter mode requires **both** `start_time` and `end_time` **and** a `workflow_name`.
+- `fact_name` (default `traces`) selects the grain of fact to discover.
+
+**Filter-only parameters** (raise `ValueError` if used without a time window):
+
+| Parameter | Default | Purpose |
+|---|---|---|
+| `min_facts` | `1` | Fail the run if fewer than this many facts were discovered — guards against a vacuous pass on an empty window. |
+| `fail_threshold` | `0` | Allow up to this many non-matching facts before the assertion fails. |
+| `max_facts` | `OKAHU_MAX_FACTS` (`1000`) | Runaway guard — fail loudly if the window discovers more than this many facts. |
+
+**Reading results.** Both the filtered and single-fact paths populate the same report (filtered = N facts; single-fact = a 1-fact report), on pass **and** failure:
+
+- `get_eval_report()` — the full report dict (contains a `scenarios` list)
+- `get_eval_failures()` — the scenarios whose `status` is not `pass`
+- `write_eval_report(path)` — write the report to a JSON file
+
+## 10. Eval Result Matrix (opt-in recorder)
+
+For measuring eval **stability** and **token cost** across a run, an opt-in pytest recorder captures a per-test matrix — one row per test that calls `check_eval()`. It is **off by default** and changes no test behavior unless enabled.
+
+```bash
+pytest --monocle-eval-matrix                       # writes test-eval-replay-matrix.json
+pytest --monocle-eval-matrix=path/to/matrix.json   # custom output path
+MONOCLE_EVAL_MATRIX=1 pytest                        # enable via env var (default path)
+```
+
+At session end the recorder writes `{"generated_at": <UTC ISO8601>, "records": [ ... ]}`. Each record carries a fixed schema: `run_id`, `scenario`, `trace_id`, `expected`, `actual`, `status` (`pass` / `fail` / `error`), `explanation`, `total_tokens`, `claim_verdicts`, `hallucination_types`, `entity_match_check`, plus `fact_id`, `workflow`, and `job_id` (populated for the time-window flow; empty for interactive rows). Output-path precedence: the `--monocle-eval-matrix` value, else `MONOCLE_EVAL_MATRIX`, else the default `test-eval-replay-matrix.json`.
+
+## 11. Curating Cases from CSV
+
+To manage many eval cases as a flat spreadsheet, `monocle_test_tools` provides a CSV adapter — `load_cases_from_csv`, `CsvCase`, and the `@monocle_csv_cases` decorator — that parametrizes a one-line test stub over the CSV rows and drives each through the fluent `check_eval` path (v0 scope: **evaluation tests only**, fixed to the `okahu` trace source).
+
+```python
+import os
+from monocle_test_tools import monocle_csv_cases
+
+TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), "hallucination_test.json")
+
+@monocle_csv_cases("cases.csv")
+def test_cases(monocle_trace_asserter, case):
+    case.run(monocle_trace_asserter.with_evaluation("okahu"), template_path=TEMPLATE_PATH)
+```
+
+The stub owns everything constant across the sheet (evaluator, template, trace source); the CSV owns only what varies per row. Columns and the full schema are documented in the [test tools README — CSV eval test cases](../test_tools/README.md#csv-eval-test-cases), with a copy-ready example at `test_tools/examples/`.
+
 ## Notes
 
 ### Evaluator Configuration
@@ -504,21 +576,31 @@ check_eval(eval_name, expected=None, not_expected=None, message=None)
 check_eval(fact_name, eval_name, expected=None, not_expected=None, message=None)
 ```
 
-**Custom template evaluation:**
+**Custom template evaluation (file or inline):**
 ```python
 check_eval(template_path="path/to/template.json", expected=None, not_expected=None, message=None)
+check_eval(template={...}, expected=None, not_expected=None, message=None)
+```
+
+**Full signature:**
+```python
+check_eval(eval_name=None, expected=None, not_expected=None, fact_name="traces",
+           message=None, template_path=None, *,
+           template=None, min_facts=1, fail_threshold=0, max_facts=None)
 ```
 
 **Parameters:**
-- `eval_name`: **(Optional)** The metric/evaluation name (e.g., "sentiment", "bias", "hallucination"). Required unless `template_path` is provided.
-- `template_path`: **(Optional)** Filesystem path to a custom-template JSON file. `check_eval()` loads the file, parses it, and submits it to the evaluation service. Required unless `eval_name` is provided.
+- `eval_name`: **(Optional)** The metric/evaluation name (e.g., "sentiment", "bias", "hallucination"). Provide exactly one of `eval_name` / `template_path` / `template`.
+- `template_path`: **(Optional)** Filesystem path to a custom-template JSON file. `check_eval()` loads the file, parses it, and submits it to the evaluation service.
+- `template`: **(Optional, keyword-only)** An inline custom-template dict, as an alternative to `template_path`.
 - `fact_name`: **(Optional)** The fact type to evaluate (traces, agentic_sessions, agentic_turns, inferences). Defaults to "traces" if omitted.
 - `expected`: **(Optional)** Accepts a **string** or **list of strings** for values that should match
 - `not_expected`: **(Optional)** Accepts a **string** or **list of strings** for values that should NOT match
 - `message`: **(Optional)** Custom message to display on evaluation failure
+- `min_facts` / `fail_threshold` / `max_facts`: **(Optional, keyword-only)** Apply **only** to time-window (filtered) evaluation — see [Section 9](#9-time-window-filtered-evaluation). Using them without a time-window source raises a `ValueError`.
 
 **Important:**
-- `eval_name` and `template_path` are mutually exclusive — provide one or the other, never both
+- `eval_name`, `template_path`, and `template` are mutually exclusive — provide exactly one, never more than one
 - At least one of `expected` or `not_expected` must be provided — omitting both will raise a `ValueError`
 - Both parameters can be used together for comprehensive validation
 - The method validates that there's no overlap between `expected` and `not_expected`

--- a/docs/monocle_test_assertions.md
+++ b/docs/monocle_test_assertions.md
@@ -18,8 +18,8 @@ This document provides a comprehensive reference for all assertions supported by
 | Method | Parameters | Description |
 |--------|-----------|-------------|
 | `under_token_limit()` | `token_limit` | **Asserts:** The total token count across all spans is below the specified limit. Fails if limit is exceeded. |
-| `under_duration()` | `duration_limit` | **Asserts:** The workflow execution time is under the specified limit (in seconds). Fails if duration exceeds limit. |
-| `check_eval()` | `eval_name`, `expected_eval`, `fact_name="traces"` | **Asserts:** The evaluation result matches the expected value. Fails if evaluation result differs from expected. |
+| `under_duration()` | `duration_limit`, `units="seconds"`, `span_type="workflow"` | **Asserts:** Span durations are under the specified limit. `units`: `seconds` (default), `ms`, `minutes`. Fails if duration exceeds limit. |
+| `check_eval()` | `eval_name=None`, `expected=None`, `not_expected=None`, `fact_name="traces"`, `template_path=None`, `template=None`, `min_facts=1`, `fail_threshold=0`, `max_facts=None` | **Asserts:** The evaluation result matches (`expected`) / avoids (`not_expected`) the given label(s). Provide **exactly one** of `eval_name` (Okahu template), `template_path` (custom-template JSON file), or `template` (inline dict). `min_facts`/`fail_threshold`/`max_facts` apply only in time-window (filtered) mode. See the [evaluation API guide](monocle_evaluation_api.md) for filtered evaluation and result-report accessors. |
 
 ## Configuration Methods
 

--- a/test_tools/README.md
+++ b/test_tools/README.md
@@ -680,15 +680,95 @@ The following eval template names have been validated against real traces in tes
 
 ### Custom Evaluation Templates
 
-Instead of a built-in `eval_name`, pass `template_path` to `check_eval` to send your own template JSON to the eval service. Provide exactly one of `eval_name` or `template_path`.
+Instead of a built-in `eval_name`, you can send your own template to the eval service. `check_eval` accepts **exactly one** of three mutually exclusive selectors: `eval_name` (a standard Okahu template), `template_path` (a path to a custom-template JSON file), or `template` (an inline custom-template dict).
 
 ```python
+# From a file
 monocle_trace_asserter.called_agent("adk_flight_booking_agent")
 monocle_trace_asserter.with_evaluation("okahu") \
     .check_eval(template_path="templates/my_custom_eval.json", expected="pass")
+
+# Inline dict (no file needed) — pass the template as a keyword-only argument
+monocle_trace_asserter.with_evaluation("okahu") \
+    .check_eval(template={"name": "my_eval", "eval_prompt": "...", "structure_output": {...}},
+                expected="pass")
 ```
 
-The file may be either the inner template (`{"name": ..., "eval_prompt": ..., ...}`) or the full API request body (`{"template": {...}}`) — the outer `template` key is unwrapped automatically. Server-side validation errors (HTTP 400) surface as an `AssertionError` prefixed with `Custom template validation failed:`.
+For `template_path`, the file may be either the inner template (`{"name": ..., "eval_prompt": ..., ...}`) or the full API request body (`{"template": {...}}`) — the outer `template` key is unwrapped automatically. When `eval_name` is omitted, the template's `name` field is used as the eval name (falling back to `"custom_eval"`). Server-side validation errors (HTTP 400) surface as an `AssertionError` prefixed with `Custom template validation failed:`.
+
+### Time-window (filtered) evaluation
+
+The examples above evaluate a **specific** trace/fact that you selected (by running an agent, or by `with_trace_source("okahu", id=...)`). You can instead evaluate **every fact discovered in a time window** for one or more workflows — without knowing the trace ids up front — by setting `start_time`/`end_time` on `with_trace_source("okahu", ...)`. This runs the evaluation as a single asynchronous Okahu job that discovers the matching facts server-side, applies one **blanket** `expected`/`not_expected` to each, and reports per fact.
+
+```python
+# Evaluate all traces for "my_app" in a time window against one blanket expectation
+monocle_trace_asserter \
+    .with_trace_source("okahu", workflow_name="my_app",
+                       start_time="2026-07-21T00:00:00Z", end_time="2026-07-22T00:00:00Z") \
+    .with_evaluation("okahu") \
+    .check_eval("hallucination", expected="no_hallucination", min_facts=5)
+```
+
+- **Mode is chosen by the source, not a separate method.** Supplying a time window (vs. an `id`) makes the *same* `check_eval` run the filtered flow. Providing both `id` and a time window raises; filter mode requires both `start_time` and `end_time` **and** a `workflow_name`.
+- `fact_name` (defaults to `traces`) selects the fact grain to discover.
+- **Filter-only `check_eval` parameters** (raise a `ValueError` if used without a time window):
+  - `min_facts` (default `1`) — fail the run if fewer than this many facts were discovered (guards against a vacuous pass on an empty window).
+  - `fail_threshold` (default `0`) — allow up to this many non-matching facts before the assertion fails.
+  - `max_facts` (default from `OKAHU_MAX_FACTS`, `1000`) — runaway guard; fail loudly if the window discovers more than this many facts.
+- **Results are uniform.** Both the filtered and the single-fact paths populate the same report, readable via the accessors below (filtered mode = N facts; single-fact mode = a 1-fact report), on pass **and** failure.
+
+| Method | Description |
+|---|---|
+| `get_eval_report()` | The eval report stashed by the last `check_eval` (dict with a `scenarios` list) |
+| `get_eval_failures()` | The subset of report scenarios whose `status` is not `pass` |
+| `write_eval_report(path)` | Write the report to a JSON file |
+
+### Eval result matrix
+
+An **opt-in** pytest recorder captures a per-test eval-result matrix (scenario, expected/actual label, judge output, token cost, pass/fail/error) across a whole run — useful for measuring eval stability and token cost without hand-rolling a `conftest.py` recorder. It is **off by default** and changes no behavior unless enabled.
+
+Enable it either way:
+
+```bash
+pytest --monocle-eval-matrix                       # writes test-eval-replay-matrix.json
+pytest --monocle-eval-matrix=path/to/matrix.json   # custom path
+MONOCLE_EVAL_MATRIX=1 pytest                        # via env var (default path)
+```
+
+A row is recorded for every test that calls `check_eval`. At session end the recorder writes `{"generated_at": <UTC ISO8601>, "records": [ ... ]}`, where each record has a fixed schema: `run_id`, `scenario`, `trace_id`, `expected`, `actual`, `status` (`pass`/`fail`/`error`), `explanation`, `total_tokens`, `claim_verdicts`, `hallucination_types`, `entity_match_check`, and (for the filtered flow) `fact_id`, `workflow`, `job_id`. Path precedence: the `--monocle-eval-matrix` value, else `MONOCLE_EVAL_MATRIX`, else the default `test-eval-replay-matrix.json`.
+
+### CSV eval test cases
+
+For curating many eval cases as a flat spreadsheet, `monocle_test_tools` exports a CSV adapter — `load_cases_from_csv`, `CsvCase`, and the `@monocle_csv_cases` decorator — that parametrizes a one-line test stub over the rows and drives each through the fluent `check_eval` path. **Scope (v0): evaluation tests only** (fixed to the `okahu` trace source).
+
+**Config in code, data in CSV.** The test stub owns everything constant across the sheet (the evaluator, the eval template, the trace source); the CSV owns only what varies per row. One row = one test.
+
+```python
+import os
+from monocle_test_tools import monocle_csv_cases
+
+TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), "hallucination_test.json")
+
+@monocle_csv_cases("cases.csv")
+def test_cases(monocle_trace_asserter, case):
+    case.run(monocle_trace_asserter.with_evaluation("okahu"), template_path=TEMPLATE_PATH)
+```
+
+Each row maps onto exactly three stable, eval-relevant fluent methods — `check_eval` (the label being tuned) plus two optional operational guard rails, `under_token_limit` and `under_duration`:
+
+| Column | Required | Maps to | Notes |
+|---|---|---|---|
+| `case_id` | ✅ | (test id) | Unique per row; duplicates are rejected at load time |
+| `fact_id` | ✅ | `with_trace_source(id=...)` | Identifier of the evaluated fact — equals the trace id when `fact_name=traces`, a finer-grained id otherwise |
+| `workflow_name` | ✅ | `with_trace_source(workflow_name=...)` | Okahu workflow name |
+| `fact_name` | | `check_eval(fact_name=...)` | Fact grain (defaults to `traces`) |
+| `expected` | one of these | `check_eval(expected=...)` | Multi-value: pipe-delimited (`a\|b`) or a JSON array |
+| `not_expected` | one of these | `check_eval(not_expected=...)` | Multi-value, same as `expected` |
+| `max_tokens` | | `under_token_limit(...)` | Token-budget guard rail |
+| `max_duration_ms` | | `under_duration(..., units="ms")` | Effort/latency guard rail |
+| `notes` | | (ignored) | Free-form documentation for curators |
+
+A row must declare an `expected` or `not_expected` label — a guard rail alone is not an eval test. `load_cases_from_csv(path)` can also be used standalone (returns a list of `CsvCase`) and reports load errors with the offending `line N`. A copy-ready example ships at [`examples/cases.example.csv`](examples/cases.example.csv) + [`examples/csv_cases_example.py`](examples/csv_cases_example.py).
 
 ---
 
@@ -716,7 +796,7 @@ Configure the asserter before running assertions. These methods return `self` fo
 
 | Method | Description |
 |---|---|
-| `with_trace_source(source="local", **kwargs)` | Choose where spans come from: `"local"` (in-memory, default), `"file"` (local `.monocle/*.json`), or `"okahu"` (cloud). File/Okahu kwargs: `id`, `trace_path` (file), `fact_name` (`trace`/`session`/`scope`), `scope_name`, `workflow_name` (required for Okahu) |
+| `with_trace_source(source="local", **kwargs)` | Choose where spans come from: `"local"` (in-memory, default), `"file"` (local `.monocle/*.json`), or `"okahu"` (cloud). File/Okahu kwargs: `id`, `trace_path` (file), `fact_name` (`trace`/`session`/`scope`), `scope_name`, `workflow_name` (required for Okahu). **Okahu time-window (filtered) mode:** pass `start_time` + `end_time` (both required) with `workflow_name` and no `id` to evaluate all discovered facts in a window (see [Time-window evaluation](#time-window-filtered-evaluation)) |
 | `with_comparer(comparer)` | Override the comparer for subsequent `has_*` assertions (see the Comparers table). Accepts a string key or `BaseComparer` instance |
 | `with_evaluation(eval, eval_options=None)` | Configure the evaluator (`"okahu"`, `"bert_score"`, or a `BaseEval` instance) before `check_eval` |
 | `with_mock_tool(mock_tool)` | Register a `MockTool` to simulate tool behavior during a subsequent `run_agent`/`run_agent_async` (fluent equivalent of `TestCase.mock_tools`). Call once per mock tool |
@@ -806,7 +886,8 @@ Configure the evaluator with `with_evaluation` (see the Configuration table) bef
 
 | Method | Description |
 |---|---|
-| `check_eval(eval_name=None, expected=None, not_expected=None, fact_name="traces", template_path=None)` | Run an evaluation and assert the result. Provide **either** `eval_name` (a standard Okahu template) **or** `template_path` (a custom-template JSON file), not both. `expected` and `not_expected` each accept a string or list of strings |
+| `check_eval(eval_name=None, expected=None, not_expected=None, fact_name="traces", template_path=None, *, template=None, min_facts=1, fail_threshold=0, max_facts=None)` | Run an evaluation and assert the result. Provide **exactly one** of `eval_name` (a standard Okahu template), `template_path` (a custom-template JSON file), or `template` (an inline custom-template dict). `expected`/`not_expected` each accept a string or list of strings. `min_facts`/`fail_threshold`/`max_facts` apply **only** in time-window (filtered) mode (see [Time-window evaluation](#time-window-filtered-evaluation)) and raise otherwise |
+| `get_eval_report()` / `get_eval_failures()` / `write_eval_report(path)` | Read the report stashed by the last `check_eval` — the full report dict, the non-`pass` scenarios, or write it to JSON. Same shape in single-fact and filtered modes |
 
 ---
 
@@ -843,6 +924,8 @@ validator.check_duration_limits(max_duration=30.0, units="seconds", span_type="w
 | `MONOCLE_TRACE_OUTPUT_PATH` | Directory for file-based trace output | `.monocle/test_traces` |
 | `OKAHU_API_KEY` | API key for Okahu evaluation and trace export | — |
 | `OKAHU_EVALUATION_ENDPOINT` | Override the Okahu evaluation endpoint | `https://eval.okahu.co/api` |
+| `OKAHU_MAX_FACTS` | Runaway guard for time-window (filtered) evals: fail loudly if a filter discovers more than this many facts (see [Time-window evaluation](#time-window-filtered-evaluation)) | `1000` |
+| `MONOCLE_EVAL_MATRIX` | Set (to any value, optionally a path) to enable the opt-in eval-result-matrix recorder (see [Eval result matrix](#eval-result-matrix)). Off when unset | unset (off) |
 | `LOCAL_RUN_ID` | Run identifier applied to all spans in a session | ISO datetime at session start |
 
 ---


### PR DESCRIPTION
## Proposed changes

Documentation-only follow-up for four recently-merged PRs that added user-facing surface **without docs**: #703, #722, #730, and #731. None of the new symbols appeared in any `.md` before this change.

### What changed

**`test_tools/README.md`**
- Environment Variables: added `MONOCLE_EVAL_MATRIX` (#722) and `OKAHU_MAX_FACTS` (#731).
- Custom Evaluation Templates: corrected to the **three-way** `eval_name` / `template_path` / `template` (inline dict) selector (#731).
- New sections: **Time-window (filtered) evaluation** (#731), **Eval result matrix** recorder (#722), **CSV eval test cases** (#730, with the column schema and a pointer to `examples/`).
- Fluent API Reference: updated `with_trace_source` and `check_eval` rows to the merged signatures; added the `get_eval_report` / `get_eval_failures` / `write_eval_report` accessors.

**`docs/monocle_evaluation_api.md`**
- Section 7 + the `check_eval()` signature block: inline `template`, three-way mutual exclusivity, and the `min_facts` / `fail_threshold` / `max_facts` filter-mode params.
- New sections 9–11: time-window (filtered) evaluation, the eval-result matrix recorder, and curating cases from CSV.

**`docs/monocle_test_assertions.md`**
- Refreshed the `check_eval()` row (full parameter set, cross-link to the eval-API guide) and fixed the stale `under_duration` description.

### Notes
- #703 (LiteLLM `temperature`) has minimal doc surface — there is no per-framework "captured inference metadata attributes" reference to update, so it is covered by the tracking issue only.
- CHANGELOG updates are intentionally out of scope for this doc-only PR.

## Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation Update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes (docs-only; no code changed)
- [x] Any dependent changes have been merged and published in downstream modules

## Tracking issue

okahu/monocle_backlog_tracking#218