### PR TITLE
fix(exporters): require explicit bucket/container name in cloud exporters

### DIFF
--- a/apptrace/src/monocle_apptrace/exporters/aws/s3_exporter.py
+++ b/apptrace/src/monocle_apptrace/exporters/aws/s3_exporter.py
@@ -46,7 +46,12 @@ class S3SpanExporter(SpanExporterBase):
                 aws_secret_access_key=os.getenv('AWS_SECRET_ACCESS_KEY'),
                 region_name=region_name,
             )
-        self.bucket_name = bucket_name or os.getenv('MONOCLE_S3_BUCKET_NAME','default-bucket')
+        self.bucket_name = bucket_name or os.getenv('MONOCLE_S3_BUCKET_NAME')
+        if not self.bucket_name:
+            raise ValueError(
+                "S3 bucket name is not provided. Please provide the bucket_name parameter "
+                "or set the MONOCLE_S3_BUCKET_NAME environment variable."
+            )
         # MONOCLE_S3_KEY_PREFIX is deprecated in favour of MONOCLE_S3_FILE_PREFIX —
         # the new name is consistent across exporters (file/blob/s3) and is not
         # confused with S3 access key configuration. The old name still wins if it

--- a/apptrace/src/monocle_apptrace/exporters/aws/s3_exporter_opendal.py
+++ b/apptrace/src/monocle_apptrace/exporters/aws/s3_exporter_opendal.py
@@ -36,7 +36,12 @@ class OpenDALS3Exporter(SpanExporterBase):
         self.time_format = DEFAULT_TIME_FORMAT
         self.export_queue = []
         self.last_export_time = time.time()
-        self.bucket_name = bucket_name or os.getenv("MONOCLE_S3_BUCKET_NAME", "default-bucket")
+        self.bucket_name = bucket_name or os.getenv("MONOCLE_S3_BUCKET_NAME")
+        if not self.bucket_name:
+            raise ValueError(
+                "S3 bucket name is not provided. Please provide the bucket_name parameter "
+                "or set the MONOCLE_S3_BUCKET_NAME environment variable."
+            )
 
         # Initialize OpenDAL S3 operator
         self.op = Operator(

--- a/apptrace/src/monocle_apptrace/exporters/azure/blob_exporter.py
+++ b/apptrace/src/monocle_apptrace/exporters/azure/blob_exporter.py
@@ -31,7 +31,12 @@ class AzureBlobSpanExporter(SpanExporterBase):
                 raise ValueError("Azure Storage connection string is not provided or set in environment variables.")
 
         if not container_name:
-            container_name = os.getenv('MONOCLE_BLOB_CONTAINER_NAME', 'default-container')
+            container_name = os.getenv('MONOCLE_BLOB_CONTAINER_NAME')
+            if not container_name:
+                raise ValueError(
+                    "Azure Blob container name is not provided. Please provide the container_name "
+                    "parameter or set the MONOCLE_BLOB_CONTAINER_NAME environment variable."
+                )
 
         self.blob_service_client = BlobServiceClient.from_connection_string(connection_string)
         self.container_name = container_name

--- a/apptrace/src/monocle_apptrace/exporters/azure/blob_exporter_opendal.py
+++ b/apptrace/src/monocle_apptrace/exporters/azure/blob_exporter_opendal.py
@@ -22,7 +22,6 @@ class OpenDALAzureExporter(SpanExporterBase):
         DEFAULT_TIME_FORMAT = "%Y-%m-%d_%H.%M.%S"
         self.max_batch_size = 500
         self.export_interval = 1
-        self.container_name = container_name
 
         # Default values
         self.file_prefix = os.getenv('MONOCLE_BLOB_FILE_PREFIX', DEFAULT_FILE_PREFIX)
@@ -37,7 +36,13 @@ class OpenDALAzureExporter(SpanExporterBase):
                 raise ValueError("Azure Storage connection string is not provided or set in environment variables.")
 
         if not container_name:
-            container_name = os.getenv('MONOCLE_BLOB_CONTAINER_NAME', 'default-container')
+            container_name = os.getenv('MONOCLE_BLOB_CONTAINER_NAME')
+            if not container_name:
+                raise ValueError(
+                    "Azure Blob container name is not provided. Please provide the container_name "
+                    "parameter or set the MONOCLE_BLOB_CONTAINER_NAME environment variable."
+                )
+        self.container_name = container_name
         endpoint, account_name , account_key = self.parse_connection_string(connection_string)
 
         if not account_name or not account_key:


### PR DESCRIPTION
## Summary

Cloud exporters silently fell back to placeholder names when no bucket or
container was configured (`default-bucket` for S3, `default-container` for
Azure Blob). These are not real resources - with S3 the fallback would try to
auto-create a bucket literally named `default-bucket`, and with Azure it would
target a container the user never intended.

This PR drops the hardcoded defaults and raises a clear `ValueError` when
neither the constructor argument nor the environment variable is set, matching
the existing `GCSSpanExporter` behaviour. This makes the four cloud exporters
consistent, which is the subject of #75.

## Changes

- `S3SpanExporter`, `OpenDALS3Exporter`: require `bucket_name` or `MONOCLE_S3_BUCKET_NAME`
- `AzureBlobSpanExporter`, `OpenDALAzureExporter`: require `container_name` or `MONOCLE_BLOB_CONTAINER_NAME`
- Fix a latent bug in `OpenDALAzureExporter` where `self.container_name` was set from the raw arg before the env-var fallback ran, so the resolved name was never stored

## Notes

The other two points in #75 (base exporter depending on the Azure package, and
the hardcoded `us-east-1` S3 region) appear already resolved on `main` by later
refactors.

## Testing

Instantiated each exporter with and without configuration: missing
bucket/container now raises `ValueError`; with the env var set, construction
proceeds past the name check as expected.