### PR TITLE
fix(test-tools): eval reliability — stale trace source, transient retries, and why a row failed

### DIFF
--- a/test_tools/src/monocle_test_tools/eval_matrix.py
+++ b/test_tools/src/monocle_test_tools/eval_matrix.py
@@ -29,15 +29,17 @@ def build_eval_matrix_row(run_id: str, scenario: str, last_eval: dict, passed: b
     `last_eval` is expected to look like the dict stashed by
     `TraceAssertion.check_eval`:
         {"trace_id": str, "expected": ..., "fact_name": str, "label": ...,
-         "explanation": ..., "judge_output": dict, "total_tokens": ...}
+         "explanation": ..., "judge_output": dict, "total_tokens": ...,
+         "failure_reason": str}
 
     Returns a dict with exactly these keys (schema is consumed downstream,
     do not rename): run_id, scenario, trace_id, expected, actual, status,
     explanation, total_tokens, claim_verdicts, hallucination_types,
-    entity_match_check, fact_id, workflow, job_id.
+    entity_match_check, fact_id, workflow, job_id, failure_reason.
 
     The trailing fact_id/workflow/job_id are additive columns for the filtered
     flow; interactive rows carry empty-string defaults so no consumer breaks.
+    `failure_reason` is likewise additive and empty unless evaluate() raised.
     """
     last_eval = last_eval or {}
     judge_output = last_eval.get("judge_output") or {}
@@ -65,6 +67,10 @@ def build_eval_matrix_row(run_id: str, scenario: str, last_eval: dict, passed: b
         "fact_id": last_eval.get("fact_id") or "",
         "workflow": last_eval.get("workflow") or "",
         "job_id": last_eval.get("job_id") or "",
+        # Why the eval produced no label, when it produced none. Empty for passing
+        # rows and for judge disagreements (those are described by actual +
+        # explanation); populated when evaluate() raised.
+        "failure_reason": last_eval.get("failure_reason") or "",
     }
 
 

--- a/test_tools/src/monocle_test_tools/evals/base_eval.py
+++ b/test_tools/src/monocle_test_tools/evals/base_eval.py
@@ -14,6 +14,16 @@ class BaseEval(BaseModel):
         """Optional cleanup hook called at test end. Override if needed."""
         pass
 
+    def set_trace_source(self, trace_source: str) -> None:
+        """Adopt a trace source discovered after this evaluator was constructed.
+
+        `with_evaluation()` may run before `with_trace_source()` -- e.g.
+        `case.run(asserter.with_evaluation("okahu"), ...)`, where the evaluation is
+        configured while building the argument -- so the source is not always known
+        at construction time. Override if the evaluator's behaviour depends on it.
+        """
+        pass
+
     @classmethod
     def classify_eval_input(cls, name_or_path: str) -> Tuple[str, str]:
         """Classify an eval input as builtin or custom.

--- a/test_tools/src/monocle_test_tools/evals/okahu_eval.py
+++ b/test_tools/src/monocle_test_tools/evals/okahu_eval.py
@@ -54,7 +54,19 @@ class OkahuEval(BaseEval):
         self._fact_map_cache = None
         self.last_judge_output: dict = {}
         self.last_total_tokens = None
-    
+
+    def set_trace_source(self, trace_source: str) -> None:
+        """Adopt a trace source configured after construction.
+
+        Both `shadow_eval` and `_trace_exported` derive from `_trace_source`, so a
+        stale value here means the eval is submitted as a shadow eval (the service
+        then returns an empty `result`) and the trace is needlessly re-exported.
+        Keep the two in step whenever the source changes.
+        """
+        self._trace_source = trace_source or ""
+        # An okahu source is already holding the trace, so there is nothing to export.
+        self._trace_exported = self._trace_source == "okahu"
+
     @staticmethod
     def _map_fact_name(fact_name: str) -> str:
         """

--- a/test_tools/src/monocle_test_tools/evals/okahu_eval.py
+++ b/test_tools/src/monocle_test_tools/evals/okahu_eval.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import time
 from datetime import datetime, timezone
 from opentelemetry.sdk.trace import Span
 import requests
@@ -19,6 +20,43 @@ OKAHU_PROD_EVALUATION_ENDPOINT = "https://eval.okahu.co/api"
 # conversations, test runs) that can span multiple traces; override via
 # OKAHU_EVAL_TIME_PAD_SECONDS if a deployment needs a tighter or wider window.
 DEFAULT_EVAL_TIME_PAD_SECONDS = 8 * 60 * 60      # 8 hours
+
+# --- transient-failure retry -------------------------------------------------------
+# A dropped connection or a read timeout should not cost a scenario. Retrying is only
+# safe where re-issuing the request cannot change state, though: submitting an eval job
+# creates a NEW job id (and a new charge) on every POST, so a retry after the request may
+# already have been delivered would double-bill and skew any token accounting.
+#
+# Hence two policies:
+#   * _IDEMPOTENT_RETRY_ON  — reads (fact map, template listing). Any transport failure
+#     is retried; re-reading is free and has no side effects.
+#   * _SUBMIT_RETRY_ON      — the eval-job POST. Only `ConnectTimeout`, where the
+#     connection was never established so nothing can have reached the service. Read
+#     timeouts and resets are NOT retried: the request may have landed.
+EVAL_RETRY_ATTEMPTS = 3
+EVAL_RETRY_BASE_DELAY_SECONDS = 1.0
+_IDEMPOTENT_RETRY_ON = (requests.ConnectionError, requests.Timeout)
+_SUBMIT_RETRY_ON = (requests.ConnectTimeout,)
+
+
+def _request_with_retry(send, retry_on: tuple, what: str,
+                        attempts: int = EVAL_RETRY_ATTEMPTS):
+    """Call `send()`, retrying only the exception types in `retry_on`.
+
+    Backs off exponentially between attempts and re-raises the original exception once
+    the budget is spent, so callers keep translating errors into their own messages.
+    """
+    for attempt in range(1, attempts + 1):
+        try:
+            return send()
+        except retry_on as exc:
+            if attempt >= attempts:
+                raise
+            delay = EVAL_RETRY_BASE_DELAY_SECONDS * (2 ** (attempt - 1))
+            logger.warning("%s failed (attempt %d/%d): %s — retrying in %.1fs",
+                           what, attempt, attempts, exc, delay)
+            time.sleep(delay)
+
 
 class OkahuEval(BaseEval):
     last_judge_output: dict = {}
@@ -176,7 +214,9 @@ class OkahuEval(BaseEval):
         params = {"fact_name": fact_name}
         
         try:
-            response = requests.get(url=list_url, headers=headers, params=params, timeout=60)
+            response = _request_with_retry(
+                lambda: requests.get(url=list_url, headers=headers, params=params, timeout=60),
+                retry_on=_IDEMPOTENT_RETRY_ON, what="Template listing request")
             response.raise_for_status()
             templates = response.json().get("templates", [])
             
@@ -215,7 +255,9 @@ class OkahuEval(BaseEval):
         headers = {"x-api-key": api_key}
         
         try:
-            response = requests.get(url=fact_map_url, headers=headers, timeout=60)
+            response = _request_with_retry(
+                lambda: requests.get(url=fact_map_url, headers=headers, timeout=60),
+                retry_on=_IDEMPOTENT_RETRY_ON, what="Fact map request")
             response.raise_for_status()
             self._fact_map_cache = response.json()
             return self._fact_map_cache
@@ -432,25 +474,37 @@ class OkahuEval(BaseEval):
             logger.debug("Submitting evaluation on fact_id: %s", fact_id)
             logger.debug(f"Request params: {params}")
             
-            # submit evaluation job to okahu and handle response/errors with retries for timeouts
-            max_attempts = 3
-            for attempts in range(1, max_attempts + 1):
-                try:
-                    response = requests.post(
+            # Submit the eval job. Retried ONLY on ConnectTimeout: every POST creates a
+            # new job id and a new charge, so resubmitting a request that may already
+            # have been delivered would duplicate the job. A failed connect cannot have
+            # been delivered, so that one is safe to retry.
+            try:
+                response = _request_with_retry(
+                    lambda: requests.post(
                         url=submit_url,
                         headers=headers,
                         json=payload,
                         params=params,
                         timeout=120
-                    )
-                    break # successfully received a response, exit loop
-                except requests.Timeout as exc:
-                    if attempts < max_attempts:
-                        logger.warning(f"Evaluation request timed out (attempt {attempts}/{max_attempts}), retrying...")
-                    else:
-                        raise AssertionError(f"Evaluation service timed out after {max_attempts} attempts. Service may be overloaded or unreachable.") from exc
-                except requests.RequestException as exc:
-                    raise AssertionError(f"Failed to reach evaluation service: {exc}. Check network connectivity and endpoint configuration.") from exc
+                    ),
+                    retry_on=_SUBMIT_RETRY_ON, what="Evaluation job submission")
+            except requests.ConnectTimeout as exc:
+                raise AssertionError(
+                    f"Could not connect to the evaluation service after {EVAL_RETRY_ATTEMPTS} "
+                    f"attempts: {exc}. Service may be overloaded or unreachable."
+                ) from exc
+            except requests.Timeout as exc:
+                raise AssertionError(
+                    f"Evaluation service did not respond in time: {exc}. Not retried, because "
+                    "the job was already submitted and resubmitting would create a duplicate "
+                    "eval job."
+                ) from exc
+            except requests.RequestException as exc:
+                raise AssertionError(
+                    f"Failed to reach evaluation service: {exc}. Not retried, because the "
+                    "request may have been delivered and resubmitting would create a duplicate "
+                    "eval job. Check network connectivity and endpoint configuration."
+                ) from exc
             try:
                 response.raise_for_status()
             except requests.HTTPError as exc:

--- a/test_tools/src/monocle_test_tools/fluent_api.py
+++ b/test_tools/src/monocle_test_tools/fluent_api.py
@@ -899,7 +899,15 @@ class TraceAssertion():
             "total_tokens": None,
         }
 
-        eval_result, explanation = self._eval.evaluate(filtered_spans=self._filtered_spans, eval_name=eval_name, fact_name=fact_name, template=template)
+        try:
+            eval_result, explanation = self._eval.evaluate(filtered_spans=self._filtered_spans, eval_name=eval_name, fact_name=fact_name, template=template)
+        except Exception as exc:
+            # evaluate() never produced a label (transport error, read timeout, an
+            # empty `result` from the service...). Record WHY on the stash before
+            # re-raising, so the eval-result-matrix row is self-describing instead of
+            # an empty actual whose cause only exists in the pytest log.
+            self._last_eval.update(failure_reason=str(exc))
+            raise
 
         self._last_eval.update(
             label=eval_result,

--- a/test_tools/src/monocle_test_tools/fluent_api.py
+++ b/test_tools/src/monocle_test_tools/fluent_api.py
@@ -226,6 +226,13 @@ class TraceAssertion():
         window_kwargs = ("start_time", "end_time")
         has_window = any(kwargs.get(k) is not None for k in window_kwargs)
 
+        # with_evaluation() copies the validator's trace source into the evaluator at
+        # construction time, so an evaluator configured BEFORE this call holds a stale
+        # (usually empty) source. Push the real one down so fluent call order does not
+        # change how the eval is submitted.
+        if isinstance(self._eval, BaseEval):
+            self._eval.set_trace_source(source)
+
         if source == "local":
             # Default behavior: use traces already in memory.
             if has_window:

--- a/test_tools/tests/unit/test_eval_matrix.py
+++ b/test_tools/tests/unit/test_eval_matrix.py
@@ -37,6 +37,8 @@ def test_build_eval_matrix_row_pass_includes_tokens():
         "fact_id": "",
         "workflow": "",
         "job_id": "",
+        # Populated only when evaluate() raised; empty on a passing row.
+        "failure_reason": "",
     }
 
 

--- a/test_tools/tests/unit/test_eval_matrix_failure_reason.py
+++ b/test_tools/tests/unit/test_eval_matrix_failure_reason.py
@@ -1,0 +1,120 @@
+"""A non-pass matrix row must say WHY it failed.
+
+When `evaluate()` raises -- connection reset, read timeout, an empty `result` from
+the eval service -- the matrix row previously carried `actual: ""` and an empty
+`explanation`, so the reason was only recoverable from the pytest log. Anyone
+reading the matrix afterwards (or a stability analyzer consuming it) could not tell
+an infrastructure failure from a judge that returned nothing.
+"""
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from monocle_test_tools.eval_matrix import build_eval_matrix_row
+from monocle_test_tools.fluent_api import TraceAssertion
+
+TEMPLATE = {
+    "name": "t",
+    "eval_prompt": "x",
+    "structure_output": {
+        "label": {"enums": ["a", "b"], "description": "x"},
+        "explanation": {"description": "x"},
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def _reset_shared_state():
+    TraceAssertion._assertion_errors = []
+    TraceAssertion._eval_report = None
+    TraceAssertion._okahu_filter = None
+    TraceAssertion._last_eval = None
+    yield
+    TraceAssertion._assertion_errors = []
+    TraceAssertion._eval_report = None
+    TraceAssertion._okahu_filter = None
+    TraceAssertion._last_eval = None
+
+
+def test_row_exposes_failure_reason_field():
+    last_eval = {
+        "trace_id": "abc", "expected": "a", "fact_name": "traces", "label": None,
+        "explanation": "", "judge_output": {}, "total_tokens": None,
+        "failure_reason": "Failed to reach evaluation service: Connection aborted.",
+    }
+
+    row = build_eval_matrix_row(run_id="r", scenario="test_x", last_eval=last_eval, passed=False)
+
+    assert row["status"] == "error"
+    assert row["failure_reason"] == "Failed to reach evaluation service: Connection aborted."
+
+
+def test_row_defaults_failure_reason_empty_when_absent():
+    # Passing rows and older stashes carry no reason; the column must still exist so
+    # the schema is stable for consumers.
+    last_eval = {"trace_id": "abc", "expected": "a", "label": "a", "explanation": "ok",
+                 "judge_output": {}, "total_tokens": 5}
+
+    row = build_eval_matrix_row(run_id="r", scenario="test_x", last_eval=last_eval, passed=True)
+
+    assert row["failure_reason"] == ""
+
+
+def test_check_eval_records_why_evaluate_raised():
+    """The reason must be captured inside the library, at the raise site -- not
+    scraped from a pytest report -- so it is available to every consumer."""
+    span = MagicMock()
+    eval_mock = MagicMock()
+    eval_mock.evaluate.side_effect = AssertionError(
+        "Unexpected response format from evaluation service. Expected 'result' key "
+        "in response. Received: {'message': 'Job submitted', 'result': []}")
+    asserter = TraceAssertion(filtered_spans=[span], _eval=eval_mock)
+
+    try:
+        asserter.check_eval(template=TEMPLATE, expected="a")
+
+        stash = TraceAssertion._last_eval
+        assert stash is not None
+        assert "Job submitted" in (stash.get("failure_reason") or ""), (
+            f"failure reason was not stashed, got {stash.get('failure_reason')!r}")
+
+        row = build_eval_matrix_row(run_id="r", scenario="test_x",
+                                    last_eval=stash, passed=False)
+        assert row["status"] == "error"
+        assert "Job submitted" in row["failure_reason"]
+    finally:
+        TraceAssertion._assertion_errors = []
+
+
+def test_judge_mismatch_row_still_carries_the_judge_explanation():
+    """A judge disagreement is not an infrastructure failure: evaluate() returned a
+    label, so the row stays self-describing via actual + explanation and needs no
+    failure_reason."""
+    span = MagicMock()
+    eval_mock = MagicMock()
+    eval_mock.evaluate.return_value = ("b", "the judge reasoned thus")
+    asserter = TraceAssertion(filtered_spans=[span], _eval=eval_mock)
+
+    try:
+        asserter.check_eval(template=TEMPLATE, expected="a")
+
+        row = build_eval_matrix_row(run_id="r", scenario="test_x",
+                                    last_eval=TraceAssertion._last_eval, passed=False)
+        assert row["status"] == "fail"
+        assert row["actual"] == "b"
+        assert row["explanation"] == "the judge reasoned thus"
+        assert row["failure_reason"] == ""
+    finally:
+        TraceAssertion._assertion_errors = []
+
+
+def test_failure_reason_survives_json_serialisation():
+    # The recorder writes with json.dump(..., default=str); the reason must round-trip.
+    last_eval = {"trace_id": "abc", "expected": "a", "label": None, "explanation": "",
+                 "judge_output": {}, "total_tokens": None,
+                 "failure_reason": "Fact map request timed out: read timeout=60"}
+    row = build_eval_matrix_row(run_id="r", scenario="test_x", last_eval=last_eval, passed=False)
+
+    assert json.loads(json.dumps({"records": [row]}, default=str))["records"][0][
+        "failure_reason"] == "Fact map request timed out: read timeout=60"

--- a/test_tools/tests/unit/test_eval_trace_source_ordering.py
+++ b/test_tools/tests/unit/test_eval_trace_source_ordering.py
@@ -1,0 +1,146 @@
+"""Trace-source wiring must not depend on fluent-call ORDER.
+
+Regression tests for the "first test of a session loses its scenario" bug.
+
+`with_evaluation()` used to snapshot `validator._trace_source` into the evaluator at
+construction time. The CSV adapter (and any test written as
+`case.run(asserter.with_evaluation("okahu"), ...)`) configures the evaluation BEFORE
+the trace source is known, so on the first test of a session the evaluator was built
+with an empty trace source. That produced two wrong behaviours against a real
+service:
+
+  * `shadow_eval` was sent as True, so the service ran a shadow eval and returned
+    `{"message": "Job submitted", "result": []}` -> the client raised
+    "Unexpected response format ... Expected 'result' key".
+  * `_trace_exported` was False, so the client tried to re-export a trace that the
+    okahu source already holds.
+
+Later tests in the same session accidentally worked because `MonocleValidator` is a
+process-wide singleton: the first test's `with_trace_source` left the source set.
+"""
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from monocle_test_tools.evals.okahu_eval import OkahuEval
+from monocle_test_tools.fluent_api import TraceAssertion
+from monocle_test_tools.validator import MonocleValidator
+
+TEMPLATE = {
+    "name": "t",
+    "eval_prompt": "x",
+    "structure_output": {
+        "label": {"enums": ["a", "b"], "description": "x"},
+        "explanation": {"description": "x"},
+    },
+}
+JUDGE = {"label": "a", "explanation": "why", "total_tokens": 7}
+
+
+def _resp():
+    m = MagicMock()
+    m.headers = {"Content-Type": "application/json"}
+    m.raise_for_status.return_value = None
+    m.json.return_value = {"job_id": "interactive_x_1",
+                           "result": [{"result": json.dumps(JUDGE)}]}
+    return m
+
+
+def _fake_import_traces(self, trace_source=None, **kwargs):
+    """Stand-in for MonocleValidator.import_traces: records the source the same way
+    the real implementation does, without touching the network."""
+    self._trace_source = trace_source
+
+
+@pytest.fixture(autouse=True)
+def _reset_shared_state():
+    # TraceAssertion carries class-level state; MonocleValidator is a singleton whose
+    # _trace_source starts empty in a real session. Reset both so each test here
+    # genuinely reproduces "first test of the session".
+    TraceAssertion._assertion_errors = []
+    TraceAssertion._eval_report = None
+    TraceAssertion._okahu_filter = None
+    MonocleValidator()._trace_source = ""
+    yield
+    TraceAssertion._assertion_errors = []
+    TraceAssertion._eval_report = None
+    TraceAssertion._okahu_filter = None
+    MonocleValidator()._trace_source = ""
+
+
+def _eval_with_order(monkeypatch, evaluation_first: bool):
+    """Run one check_eval through the real OkahuEval, returning (asserter, post_mock,
+    export_mock). `evaluation_first` selects the fluent call order."""
+    span = MagicMock()
+    span.attributes = {"workflow.name": "wf"}
+    span.start_time = 1_000_000_000
+    span.end_time = 2_000_000_000
+    monkeypatch.setenv("OKAHU_API_KEY", "k")
+
+    asserter = TraceAssertion(filtered_spans=[span])
+
+    with patch.object(MonocleValidator, "import_traces", _fake_import_traces):
+        if evaluation_first:
+            asserter = asserter.with_evaluation("okahu")
+            asserter = asserter.with_trace_source("okahu", id="traceid", workflow_name="wf")
+        else:
+            asserter = asserter.with_trace_source("okahu", id="traceid", workflow_name="wf")
+            asserter = asserter.with_evaluation("okahu")
+
+    with patch.object(OkahuEval, "export_trace", return_value="traceid") as export_mock, \
+         patch.object(OkahuEval, "enumerate_fact_ids", return_value=["traceid"]), \
+         patch("monocle_test_tools.evals.okahu_eval.OkahuEvalResultExporter"), \
+         patch("monocle_test_tools.evals.okahu_eval.requests.post",
+               return_value=_resp()) as post_mock:
+        asserter.check_eval(template=TEMPLATE, expected="a")
+
+    return asserter, post_mock, export_mock
+
+
+def test_shadow_eval_is_false_when_evaluation_configured_before_trace_source(monkeypatch):
+    asserter, post_mock, _ = _eval_with_order(monkeypatch, evaluation_first=True)
+
+    assert not asserter.has_assertions(), asserter.get_assertion_messages()
+    params = post_mock.call_args.kwargs["params"]
+    assert params["shadow_eval"] is False, (
+        "an okahu trace source must never be evaluated as a shadow eval; "
+        "the service returns an empty result for shadow evals"
+    )
+
+
+def test_okahu_source_is_not_re_exported_when_evaluation_configured_first(monkeypatch):
+    _, _, export_mock = _eval_with_order(monkeypatch, evaluation_first=True)
+
+    export_mock.assert_not_called()
+
+
+def test_shadow_eval_is_false_when_trace_source_configured_first(monkeypatch):
+    # The already-working order must keep working.
+    asserter, post_mock, _ = _eval_with_order(monkeypatch, evaluation_first=False)
+
+    assert not asserter.has_assertions(), asserter.get_assertion_messages()
+    assert post_mock.call_args.kwargs["params"]["shadow_eval"] is False
+
+
+def test_non_okahu_source_still_shadow_evals(monkeypatch):
+    # Guard against over-correcting: a file/local source IS a shadow eval.
+    span = MagicMock()
+    span.attributes = {"workflow.name": "wf"}
+    span.start_time = 1_000_000_000
+    span.end_time = 2_000_000_000
+    monkeypatch.setenv("OKAHU_API_KEY", "k")
+
+    asserter = TraceAssertion(filtered_spans=[span])
+    with patch.object(MonocleValidator, "import_traces", _fake_import_traces):
+        asserter = asserter.with_evaluation("okahu")
+        asserter = asserter.with_trace_source("file", path="somewhere.json")
+
+    with patch.object(OkahuEval, "export_trace", return_value="traceid"), \
+         patch.object(OkahuEval, "enumerate_fact_ids", return_value=["traceid"]), \
+         patch("monocle_test_tools.evals.okahu_eval.OkahuEvalResultExporter"), \
+         patch("monocle_test_tools.evals.okahu_eval.requests.post",
+               return_value=_resp()) as post_mock:
+        asserter.check_eval(template=TEMPLATE, expected="a")
+
+    assert post_mock.call_args.kwargs["params"]["shadow_eval"] is True

--- a/test_tools/tests/unit/test_okahu_eval_transient_retry.py
+++ b/test_tools/tests/unit/test_okahu_eval_transient_retry.py
@@ -1,0 +1,181 @@
+"""Transient transport failures must not cost a scenario -- but a retry must never
+create a duplicate eval job.
+
+Observed on a 3-run x 20-scenario replay matrix: 3 of 60 evals were lost to
+`ConnectionResetError` and a fact-map read timeout. None was retried:
+
+  * `get_fact_map()` had no retry at all.
+  * the eval-submit POST retried only `requests.Timeout`, so a connection reset
+    (a `RequestException`) fell straight through.
+
+Retrying is only safe where the request is idempotent. Submitting an eval job is NOT:
+each POST creates a new job id (and bills for it), so a retry after the request may
+already have been delivered can double-charge. Hence two policies:
+
+  * idempotent reads (fact map, template listing) -- retry any transport failure.
+  * the submit POST -- retry ONLY `requests.ConnectTimeout`, where the connection was
+    never established and nothing can have reached the service. This deliberately
+    NARROWS the previous behaviour, which retried read timeouts too.
+"""
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from monocle_test_tools.evals.okahu_eval import OkahuEval
+
+MODULE = "monocle_test_tools.evals.okahu_eval"
+TEMPLATE = {"name": "t", "eval_prompt": "x",
+            "structure_output": {"label": {"enums": ["a"], "description": "x"},
+                                 "explanation": {"description": "x"}}}
+JUDGE = {"label": "a", "explanation": "why", "total_tokens": 7}
+
+
+def _json_response(payload):
+    m = MagicMock()
+    m.headers = {"Content-Type": "application/json"}
+    m.raise_for_status.return_value = None
+    m.json.return_value = payload
+    return m
+
+
+def _eval(monkeypatch):
+    monkeypatch.setenv("OKAHU_API_KEY", "k")
+    return OkahuEval(eval_options={"trace_source": "okahu"})
+
+
+def _span():
+    span = MagicMock()
+    span.attributes = {"workflow.name": "wf"}
+    span.start_time = 1_000_000_000
+    span.end_time = 2_000_000_000
+    return span
+
+
+def _submit(ev, post_side_effect):
+    """Drive evaluate() far enough to hit the submit POST, isolating it from the
+    fact-map and export paths."""
+    with patch.object(OkahuEval, "export_trace", return_value="traceid"), \
+         patch.object(OkahuEval, "enumerate_fact_ids", return_value=["traceid"]), \
+         patch(f"{MODULE}.OkahuEvalResultExporter"), \
+         patch(f"{MODULE}.time.sleep") as sleep, \
+         patch(f"{MODULE}.requests.post", side_effect=post_side_effect) as post:
+        try:
+            result = ev.evaluate(filtered_spans=[_span()], template=TEMPLATE, fact_name="traces")
+        except AssertionError as exc:
+            return post, sleep, exc
+        return post, sleep, result
+
+
+# --- idempotent reads: retry freely -----------------------------------------------
+
+def test_fact_map_retries_a_connection_reset_then_succeeds(monkeypatch):
+    ev = _eval(monkeypatch)
+    effects = [requests.ConnectionError("Connection aborted"),
+               _json_response({"traces": "trace_id"})]
+
+    with patch(f"{MODULE}.requests.get", side_effect=effects) as get, \
+         patch(f"{MODULE}.time.sleep") as sleep:
+        assert ev.get_fact_map() == {"traces": "trace_id"}
+
+    assert get.call_count == 2, "a reset on an idempotent read must be retried"
+    assert sleep.called, "retries must back off rather than hammer the service"
+
+
+def test_fact_map_retries_a_read_timeout_then_succeeds(monkeypatch):
+    # Safe here precisely because the request is a read: re-issuing it cannot create
+    # state or a charge.
+    ev = _eval(monkeypatch)
+    effects = [requests.ReadTimeout("read timeout=60"), _json_response({"traces": "trace_id"})]
+
+    with patch(f"{MODULE}.requests.get", side_effect=effects) as get, \
+         patch(f"{MODULE}.time.sleep"):
+        assert ev.get_fact_map() == {"traces": "trace_id"}
+
+    assert get.call_count == 2
+
+
+def test_fact_map_gives_up_after_the_attempt_budget(monkeypatch):
+    ev = _eval(monkeypatch)
+
+    with patch(f"{MODULE}.requests.get",
+               side_effect=requests.ConnectionError("Connection aborted")) as get, \
+         patch(f"{MODULE}.time.sleep"):
+        with pytest.raises(AssertionError, match="Failed to reach fact map service"):
+            ev.get_fact_map()
+
+    assert get.call_count == 3, "should stop at the attempt budget, not loop forever"
+
+
+def test_backoff_grows_between_attempts(monkeypatch):
+    ev = _eval(monkeypatch)
+
+    with patch(f"{MODULE}.requests.get",
+               side_effect=requests.ConnectionError("boom")), \
+         patch(f"{MODULE}.time.sleep") as sleep:
+        with pytest.raises(AssertionError):
+            ev.get_fact_map()
+
+    delays = [c.args[0] for c in sleep.call_args_list]
+    assert delays == sorted(delays) and len(set(delays)) > 1, (
+        f"expected increasing backoff, got {delays}")
+
+
+def test_successful_read_does_not_sleep(monkeypatch):
+    ev = _eval(monkeypatch)
+
+    with patch(f"{MODULE}.requests.get", return_value=_json_response({"traces": "trace_id"})), \
+         patch(f"{MODULE}.time.sleep") as sleep:
+        ev.get_fact_map()
+
+    sleep.assert_not_called()
+
+
+# --- the submit POST: retry only when nothing could have been delivered -----------
+
+def test_submit_retries_a_connect_timeout_then_succeeds(monkeypatch):
+    # ConnectTimeout means the connection was never established, so no job exists yet.
+    ev = _eval(monkeypatch)
+    effects = [requests.ConnectTimeout("connect timed out"),
+               _json_response({"job_id": "j1", "result": [{"result": json.dumps(JUDGE)}]})]
+
+    post, sleep, result = _submit(ev, effects)
+
+    assert post.call_count == 2
+    assert result == ("a", "why")
+
+
+def test_submit_does_not_retry_a_connection_reset(monkeypatch):
+    # The request may already have reached the service; a retry could create a second
+    # billable eval job. Fail instead, and say why.
+    ev = _eval(monkeypatch)
+
+    post, sleep, exc = _submit(ev, requests.ConnectionError("Connection aborted"))
+
+    assert post.call_count == 1, "must not resubmit a possibly-delivered eval job"
+    assert isinstance(exc, AssertionError)
+    assert "duplicate" in str(exc).lower(), (
+        f"the error must explain why no retry happened, got: {exc}")
+
+
+def test_submit_does_not_retry_a_read_timeout(monkeypatch):
+    # Deliberate narrowing: the previous implementation retried read timeouts, but the
+    # request WAS sent, so that risked duplicate jobs.
+    ev = _eval(monkeypatch)
+
+    post, sleep, exc = _submit(ev, requests.ReadTimeout("read timeout=120"))
+
+    assert post.call_count == 1
+    assert isinstance(exc, AssertionError)
+    assert "duplicate" in str(exc).lower()
+
+
+def test_submit_gives_up_after_the_attempt_budget_on_connect_timeout(monkeypatch):
+    ev = _eval(monkeypatch)
+
+    post, sleep, exc = _submit(ev, requests.ConnectTimeout("connect timed out"))
+
+    assert post.call_count == 3
+    assert isinstance(exc, AssertionError)
+    assert "connect" in str(exc).lower()


### PR DESCRIPTION
Tracking issues: okahu/monocle_backlog_tracking#222 and okahu/monocle_backlog_tracking#223

Three commits hardening the eval path. All three came out of one 3-run × 20-scenario
hallucination replay matrix in which **10 of 60 evals** did not produce a usable result: one
scenario was lost in every run to a stale trace source, three more to transport failures, and
none of them said why in the recorded matrix.

## 1. `fix`: resolve the trace source independent of fluent call order

The **first** `check_eval` of every pytest session failed, and every later test passed:

```
Unexpected response format from evaluation service. Expected 'result' key in response.
Received: {'message': 'Job submitted', 'job_id': 'interactive_..._1785173415', 'result': []}
```

The message is misleading: `result` **is** present and empty, and the real error is an
`IndexError` on `result[0]` that a blanket `except Exception` relabels.

`MonocleValidator` is a process-wide singleton whose `_trace_source` starts `""`.
`with_evaluation()` snapshots that value into the evaluator at construction, and the CSV adapter
(or any test shaped like `case.run(asserter.with_evaluation("okahu"), ...)`) configures the
evaluation *before* `with_trace_source()` runs. So the session’s first test built an evaluator
with an empty source, and two derived fields were wrong:

| derived | wrong value | consequence |
|---|---|---|
| `shadow_eval = _trace_source != "okahu"` | `True` | the service runs a **shadow** eval, which returns `result: []` by design |
| `_trace_exported = _trace_source == "okahu"` | `False` | re-exports a trace the okahu source already holds → a spurious `401` |

Later tests worked only because the singleton retained `"okahu"` from the first test. Retrying
could not help — a retry faithfully resubmits `shadow_eval=True` (confirmed: 3 retries, all
empty, each minting a new `job_id`). The failure follows position, not trace:
`test_cc_t02`/`test_cc_t03` each fail this way when run first and pass when run second.

Fix: a `BaseEval.set_trace_source()` hook, an `OkahuEval` override keeping `_trace_source` and
`_trace_exported` in step, and `with_trace_source()` pushing the real source into an
already-constructed evaluator. Call order no longer changes how an eval is submitted.

## 2. `feat`: record why an eval produced no label

A failed row carried `actual: ""` and an empty `explanation`, so the cause lived only in the
pytest log — which is precisely why the bug above read as "a bad trace" for hours.
`check_eval` now stashes the exception message at the raise site and the matrix row exposes an
additive `failure_reason` column. Empty for passes and for judge disagreements (already
described by `actual` + `explanation`); existing consumers unaffected.

## 3. `fix`: retry transient failures without duplicating eval jobs

Three further scenarios were lost and none was retried: `get_fact_map()` had no retry at all,
and the submit POST retried only `requests.Timeout`, so `ConnectionResetError` (a
`RequestException`) fell straight through.

Retrying is only safe where re-issuing cannot change state. Submitting is **not** idempotent —
every POST creates a new job id and a new charge, confirmed by observation (identical params
returned four different job ids). So two policies:

- **idempotent reads** (fact map, template listing) — retry any transport failure with
  exponential backoff.
- **the submit POST** — retry **only** `requests.ConnectTimeout`, where the connection was never
  established so nothing reached the service.

This deliberately **narrows** the submit path, which previously retried `ReadTimeout` — requests
that *were* sent — a pre-existing double-charge exposure. Those now fail fast with a message
saying why no retry was attempted, so an operator can distinguish "never ran" from "may have
run" (and with commit 2 that reason lands in the matrix). Say the word if you would rather
recover those at the risk of duplicate jobs and I will widen `_SUBMIT_RETRY_ON`.

`_submit_eval_job()` is untouched — it has no callers.

## Tests

18 new tests, each driven red→green:

- `test_eval_trace_source_ordering.py` (4) — `shadow_eval=False` and no re-export for the
  eval-configured-first order, plus two controls: the working order keeps working, and a `file`
  source still correctly shadow-evals (guards against over-correcting).
- `test_eval_matrix_failure_reason.py` (5) — schema field, empty default, capture at the raise
  site, judge mismatches still described by `explanation`, JSON round-trip.
- `test_okahu_eval_transient_retry.py` (9) — both policies, growing backoff, no sleep on
  success, and two **safety** tests: a reset and a read timeout on submit must each produce
  exactly ONE POST.
- Updated `test_build_eval_matrix_row_pass_includes_tokens`, an exact-schema snapshot, for the
  additive key.

Full `test_tools/tests/unit`: **350 passed** (`test_non_llm_core_examples.py` excluded —
pre-existing `ModuleNotFoundError: google.adk`, unrelated).

## Live verification

Against the prod eval service, the first scenario of a session:

| | before | after |
|---|---|---|
| `shadow_eval` sent | `True` | `False` |
| `result` length | 0 | 1 |
| outcome | fail | pass |
| trace-exporter 401 | yes | no |
| 2-scenario runtime | 101s | 34s |

Retry verified separately against a refused endpoint: the fact-map read now makes 3 attempts
with 1s/2s backoff instead of failing instantly. And the **combined** branch re-verified live:
first-of-session scenario `shadow=False`, judged, 5,901 tokens, `failure_reason` empty on a pass,
no 401.

## Note

On a hard outage `get_fact_map()` retries once per call, because its cache only populates on
success — so a scenario can spend two backoff cycles. Harmless; left alone to keep the change
narrow.

---

Supersedes #764, which contained commit 3 alone and is now closed in favour of this PR.
