### PR TITLE
fix(test-tools): retry transient eval-service failures without duplicating eval jobs

### DIFF
--- a/test_tools/src/monocle_test_tools/evals/okahu_eval.py
+++ b/test_tools/src/monocle_test_tools/evals/okahu_eval.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import time
 from datetime import datetime, timezone
 from opentelemetry.sdk.trace import Span
 import requests
@@ -19,6 +20,43 @@ OKAHU_PROD_EVALUATION_ENDPOINT = "https://eval.okahu.co/api"
 # conversations, test runs) that can span multiple traces; override via
 # OKAHU_EVAL_TIME_PAD_SECONDS if a deployment needs a tighter or wider window.
 DEFAULT_EVAL_TIME_PAD_SECONDS = 8 * 60 * 60      # 8 hours
+
+# --- transient-failure retry -------------------------------------------------------
+# A dropped connection or a read timeout should not cost a scenario. Retrying is only
+# safe where re-issuing the request cannot change state, though: submitting an eval job
+# creates a NEW job id (and a new charge) on every POST, so a retry after the request may
+# already have been delivered would double-bill and skew any token accounting.
+#
+# Hence two policies:
+#   * _IDEMPOTENT_RETRY_ON  — reads (fact map, template listing). Any transport failure
+#     is retried; re-reading is free and has no side effects.
+#   * _SUBMIT_RETRY_ON      — the eval-job POST. Only `ConnectTimeout`, where the
+#     connection was never established so nothing can have reached the service. Read
+#     timeouts and resets are NOT retried: the request may have landed.
+EVAL_RETRY_ATTEMPTS = 3
+EVAL_RETRY_BASE_DELAY_SECONDS = 1.0
+_IDEMPOTENT_RETRY_ON = (requests.ConnectionError, requests.Timeout)
+_SUBMIT_RETRY_ON = (requests.ConnectTimeout,)
+
+
+def _request_with_retry(send, retry_on: tuple, what: str,
+                        attempts: int = EVAL_RETRY_ATTEMPTS):
+    """Call `send()`, retrying only the exception types in `retry_on`.
+
+    Backs off exponentially between attempts and re-raises the original exception once
+    the budget is spent, so callers keep translating errors into their own messages.
+    """
+    for attempt in range(1, attempts + 1):
+        try:
+            return send()
+        except retry_on as exc:
+            if attempt >= attempts:
+                raise
+            delay = EVAL_RETRY_BASE_DELAY_SECONDS * (2 ** (attempt - 1))
+            logger.warning("%s failed (attempt %d/%d): %s — retrying in %.1fs",
+                           what, attempt, attempts, exc, delay)
+            time.sleep(delay)
+
 
 class OkahuEval(BaseEval):
     last_judge_output: dict = {}
@@ -143,7 +181,9 @@ class OkahuEval(BaseEval):
         params = {"fact_name": fact_name}
         
         try:
-            response = requests.get(url=list_url, headers=headers, params=params, timeout=60)
+            response = _request_with_retry(
+                lambda: requests.get(url=list_url, headers=headers, params=params, timeout=60),
+                retry_on=_IDEMPOTENT_RETRY_ON, what="Template listing request")
             response.raise_for_status()
             templates = response.json().get("templates", [])
             
@@ -182,7 +222,9 @@ class OkahuEval(BaseEval):
         headers = {"x-api-key": api_key}
         
         try:
-            response = requests.get(url=fact_map_url, headers=headers, timeout=60)
+            response = _request_with_retry(
+                lambda: requests.get(url=fact_map_url, headers=headers, timeout=60),
+                retry_on=_IDEMPOTENT_RETRY_ON, what="Fact map request")
             response.raise_for_status()
             self._fact_map_cache = response.json()
             return self._fact_map_cache
@@ -394,25 +436,37 @@ class OkahuEval(BaseEval):
             logger.debug("Submitting evaluation on fact_id: %s", fact_id)
             logger.debug(f"Request params: {params}")
             
-            # submit evaluation job to okahu and handle response/errors with retries for timeouts
-            max_attempts = 3
-            for attempts in range(1, max_attempts + 1):
-                try:
-                    response = requests.post(
+            # Submit the eval job. Retried ONLY on ConnectTimeout: every POST creates a
+            # new job id and a new charge, so resubmitting a request that may already
+            # have been delivered would duplicate the job. A failed connect cannot have
+            # been delivered, so that one is safe to retry.
+            try:
+                response = _request_with_retry(
+                    lambda: requests.post(
                         url=submit_url,
                         headers=headers,
                         json=payload,
                         params=params,
                         timeout=120
-                    )
-                    break # successfully received a response, exit loop
-                except requests.Timeout as exc:
-                    if attempts < max_attempts:
-                        logger.warning(f"Evaluation request timed out (attempt {attempts}/{max_attempts}), retrying...")
-                    else:
-                        raise AssertionError(f"Evaluation service timed out after {max_attempts} attempts. Service may be overloaded or unreachable.") from exc
-                except requests.RequestException as exc:
-                    raise AssertionError(f"Failed to reach evaluation service: {exc}. Check network connectivity and endpoint configuration.") from exc
+                    ),
+                    retry_on=_SUBMIT_RETRY_ON, what="Evaluation job submission")
+            except requests.ConnectTimeout as exc:
+                raise AssertionError(
+                    f"Could not connect to the evaluation service after {EVAL_RETRY_ATTEMPTS} "
+                    f"attempts: {exc}. Service may be overloaded or unreachable."
+                ) from exc
+            except requests.Timeout as exc:
+                raise AssertionError(
+                    f"Evaluation service did not respond in time: {exc}. Not retried, because "
+                    "the job was already submitted and resubmitting would create a duplicate "
+                    "eval job."
+                ) from exc
+            except requests.RequestException as exc:
+                raise AssertionError(
+                    f"Failed to reach evaluation service: {exc}. Not retried, because the "
+                    "request may have been delivered and resubmitting would create a duplicate "
+                    "eval job. Check network connectivity and endpoint configuration."
+                ) from exc
             try:
                 response.raise_for_status()
             except requests.HTTPError as exc:

--- a/test_tools/tests/unit/test_okahu_eval_transient_retry.py
+++ b/test_tools/tests/unit/test_okahu_eval_transient_retry.py
@@ -1,0 +1,181 @@
+"""Transient transport failures must not cost a scenario -- but a retry must never
+create a duplicate eval job.
+
+Observed on a 3-run x 20-scenario replay matrix: 3 of 60 evals were lost to
+`ConnectionResetError` and a fact-map read timeout. None was retried:
+
+  * `get_fact_map()` had no retry at all.
+  * the eval-submit POST retried only `requests.Timeout`, so a connection reset
+    (a `RequestException`) fell straight through.
+
+Retrying is only safe where the request is idempotent. Submitting an eval job is NOT:
+each POST creates a new job id (and bills for it), so a retry after the request may
+already have been delivered can double-charge. Hence two policies:
+
+  * idempotent reads (fact map, template listing) -- retry any transport failure.
+  * the submit POST -- retry ONLY `requests.ConnectTimeout`, where the connection was
+    never established and nothing can have reached the service. This deliberately
+    NARROWS the previous behaviour, which retried read timeouts too.
+"""
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from monocle_test_tools.evals.okahu_eval import OkahuEval
+
+MODULE = "monocle_test_tools.evals.okahu_eval"
+TEMPLATE = {"name": "t", "eval_prompt": "x",
+            "structure_output": {"label": {"enums": ["a"], "description": "x"},
+                                 "explanation": {"description": "x"}}}
+JUDGE = {"label": "a", "explanation": "why", "total_tokens": 7}
+
+
+def _json_response(payload):
+    m = MagicMock()
+    m.headers = {"Content-Type": "application/json"}
+    m.raise_for_status.return_value = None
+    m.json.return_value = payload
+    return m
+
+
+def _eval(monkeypatch):
+    monkeypatch.setenv("OKAHU_API_KEY", "k")
+    return OkahuEval(eval_options={"trace_source": "okahu"})
+
+
+def _span():
+    span = MagicMock()
+    span.attributes = {"workflow.name": "wf"}
+    span.start_time = 1_000_000_000
+    span.end_time = 2_000_000_000
+    return span
+
+
+def _submit(ev, post_side_effect):
+    """Drive evaluate() far enough to hit the submit POST, isolating it from the
+    fact-map and export paths."""
+    with patch.object(OkahuEval, "export_trace", return_value="traceid"), \
+         patch.object(OkahuEval, "enumerate_fact_ids", return_value=["traceid"]), \
+         patch(f"{MODULE}.OkahuEvalResultExporter"), \
+         patch(f"{MODULE}.time.sleep") as sleep, \
+         patch(f"{MODULE}.requests.post", side_effect=post_side_effect) as post:
+        try:
+            result = ev.evaluate(filtered_spans=[_span()], template=TEMPLATE, fact_name="traces")
+        except AssertionError as exc:
+            return post, sleep, exc
+        return post, sleep, result
+
+
+# --- idempotent reads: retry freely -----------------------------------------------
+
+def test_fact_map_retries_a_connection_reset_then_succeeds(monkeypatch):
+    ev = _eval(monkeypatch)
+    effects = [requests.ConnectionError("Connection aborted"),
+               _json_response({"traces": "trace_id"})]
+
+    with patch(f"{MODULE}.requests.get", side_effect=effects) as get, \
+         patch(f"{MODULE}.time.sleep") as sleep:
+        assert ev.get_fact_map() == {"traces": "trace_id"}
+
+    assert get.call_count == 2, "a reset on an idempotent read must be retried"
+    assert sleep.called, "retries must back off rather than hammer the service"
+
+
+def test_fact_map_retries_a_read_timeout_then_succeeds(monkeypatch):
+    # Safe here precisely because the request is a read: re-issuing it cannot create
+    # state or a charge.
+    ev = _eval(monkeypatch)
+    effects = [requests.ReadTimeout("read timeout=60"), _json_response({"traces": "trace_id"})]
+
+    with patch(f"{MODULE}.requests.get", side_effect=effects) as get, \
+         patch(f"{MODULE}.time.sleep"):
+        assert ev.get_fact_map() == {"traces": "trace_id"}
+
+    assert get.call_count == 2
+
+
+def test_fact_map_gives_up_after_the_attempt_budget(monkeypatch):
+    ev = _eval(monkeypatch)
+
+    with patch(f"{MODULE}.requests.get",
+               side_effect=requests.ConnectionError("Connection aborted")) as get, \
+         patch(f"{MODULE}.time.sleep"):
+        with pytest.raises(AssertionError, match="Failed to reach fact map service"):
+            ev.get_fact_map()
+
+    assert get.call_count == 3, "should stop at the attempt budget, not loop forever"
+
+
+def test_backoff_grows_between_attempts(monkeypatch):
+    ev = _eval(monkeypatch)
+
+    with patch(f"{MODULE}.requests.get",
+               side_effect=requests.ConnectionError("boom")), \
+         patch(f"{MODULE}.time.sleep") as sleep:
+        with pytest.raises(AssertionError):
+            ev.get_fact_map()
+
+    delays = [c.args[0] for c in sleep.call_args_list]
+    assert delays == sorted(delays) and len(set(delays)) > 1, (
+        f"expected increasing backoff, got {delays}")
+
+
+def test_successful_read_does_not_sleep(monkeypatch):
+    ev = _eval(monkeypatch)
+
+    with patch(f"{MODULE}.requests.get", return_value=_json_response({"traces": "trace_id"})), \
+         patch(f"{MODULE}.time.sleep") as sleep:
+        ev.get_fact_map()
+
+    sleep.assert_not_called()
+
+
+# --- the submit POST: retry only when nothing could have been delivered -----------
+
+def test_submit_retries_a_connect_timeout_then_succeeds(monkeypatch):
+    # ConnectTimeout means the connection was never established, so no job exists yet.
+    ev = _eval(monkeypatch)
+    effects = [requests.ConnectTimeout("connect timed out"),
+               _json_response({"job_id": "j1", "result": [{"result": json.dumps(JUDGE)}]})]
+
+    post, sleep, result = _submit(ev, effects)
+
+    assert post.call_count == 2
+    assert result == ("a", "why")
+
+
+def test_submit_does_not_retry_a_connection_reset(monkeypatch):
+    # The request may already have reached the service; a retry could create a second
+    # billable eval job. Fail instead, and say why.
+    ev = _eval(monkeypatch)
+
+    post, sleep, exc = _submit(ev, requests.ConnectionError("Connection aborted"))
+
+    assert post.call_count == 1, "must not resubmit a possibly-delivered eval job"
+    assert isinstance(exc, AssertionError)
+    assert "duplicate" in str(exc).lower(), (
+        f"the error must explain why no retry happened, got: {exc}")
+
+
+def test_submit_does_not_retry_a_read_timeout(monkeypatch):
+    # Deliberate narrowing: the previous implementation retried read timeouts, but the
+    # request WAS sent, so that risked duplicate jobs.
+    ev = _eval(monkeypatch)
+
+    post, sleep, exc = _submit(ev, requests.ReadTimeout("read timeout=120"))
+
+    assert post.call_count == 1
+    assert isinstance(exc, AssertionError)
+    assert "duplicate" in str(exc).lower()
+
+
+def test_submit_gives_up_after_the_attempt_budget_on_connect_timeout(monkeypatch):
+    ev = _eval(monkeypatch)
+
+    post, sleep, exc = _submit(ev, requests.ConnectTimeout("connect timed out"))
+
+    assert post.call_count == 3
+    assert isinstance(exc, AssertionError)
+    assert "connect" in str(exc).lower()


### PR DESCRIPTION
Tracking issue: okahu/monocle_backlog_tracking#223

## Problem

A dropped connection to the eval service costs a whole scenario. On a 3-run × 20-scenario
replay matrix, 3 of 60 evals were lost and none was retried:

| scenario | failure | why no retry |
|---|---|---|
| `cc_t13` | `ConnectionResetError(54)` on submit | a reset is a `RequestException`; the submit loop caught only `requests.Timeout` |
| `cc_t15` | `ConnectionResetError(54)` on submit | same |
| `cc_t17` | `Fact map request timed out (read timeout=60)` | `get_fact_map()` had no retry at all |

## The constraint

Submitting an eval job is **not idempotent**: every POST to `/v1/eval/jobs` creates a new
job id and a new charge. Confirmed by observation — replaying identical params returned
four different job ids (`..._1785176597`, `..._608`, `..._617`, `..._646`). A blind retry
would double-bill and corrupt token accounting.

## Two policies

- **`_IDEMPOTENT_RETRY_ON`** — fact map and template listing. Retry any transport failure
  (`ConnectionError`, `Timeout`) with exponential backoff. Re-reading is free.
- **`_SUBMIT_RETRY_ON`** — the eval-job POST. Retry **only** `requests.ConnectTimeout`,
  where the connection was never established, so nothing reached the service.

### This narrows existing behaviour, on purpose

The submit path previously retried `requests.Timeout`, which includes `ReadTimeout` —
requests that *were* sent. That was a pre-existing double-charge exposure. Now a read
timeout or reset on submit fails immediately, and the message says why it was not retried:

```
Evaluation service did not respond in time: ... Not retried, because the job was already
submitted and resubmitting would create a duplicate eval job.
```

so an operator can distinguish "never ran" from "may have run". If you would rather keep
recovering those at the risk of duplicate jobs, say so and I will widen `_SUBMIT_RETRY_ON`.

`_submit_eval_job()` is untouched — it has no callers.

## Tests

9 new tests in `test_okahu_eval_transient_retry.py`, driven red→green:

- fact map retries a reset, and a read timeout, then succeeds
- fact map stops at the attempt budget and still raises its usual message
- backoff grows between attempts; a successful read never sleeps
- submit retries a `ConnectTimeout` then succeeds, and stops at the budget
- **safety:** a reset on submit produces exactly ONE POST
- **safety:** a read timeout on submit produces exactly ONE POST

Full `test_tools/tests/unit`: **288 passed** (`test_non_llm_core_examples.py` excluded —
pre-existing `ModuleNotFoundError: google.adk`, unrelated).

## Live verification

Against a refused endpoint, the fact-map read now makes 3 attempts with 1s/2s backoff
(11.5s) instead of failing instantly (2.4s).

## Note

On a hard outage `get_fact_map()` retries once per call, because the cache is only
populated on success — so a scenario can spend two backoff cycles (~6s) rather than one.
Harmless, and left alone to keep this change narrow.

## Relationship to #763

Independent, and based on `main` rather than that branch. #763 fixes a stale trace source
(and records `failure_reason`); this hardens the transport layer. They compose: with both,
a transient failure is retried where safe, and when it is not recoverable the reason lands
in the eval-result matrix instead of only the pytest log.