### PR TITLE
fix(test-tools): record test outcome for local runners exporting to Okahu

### DIFF
--- a/test_tools/src/monocle_test_tools/validator.py
+++ b/test_tools/src/monocle_test_tools/validator.py
@@ -26,7 +26,7 @@ from monocle_test_tools.schema import SpanType, TestSpan, TestCase, MultiTurnTes
 from monocle_test_tools.constants import TEST_SCOPE_NAME, SESSION_SCOPE_NAME, DEFAULT_WORKFLOW_NAME, TEST_STATUS_ATTRIBUTE, TEST_ASSERTION_ATTRIBUTE, TEST_WORKFLOW_ENV
 from monocle_test_tools.comparer.base_comparer import BaseComparer
 from monocle_test_tools.runner.runner import get_agent_runner
-from monocle_test_tools.trace_sources import get_trace_source
+from monocle_test_tools.trace_sources import get_trace_source, OkahuTraceSource
 from monocle_test_tools import trace_utils
 from monocle_apptrace.instrumentation.metamodel.adk.methods import ADK_METHODS
 from monocle_apptrace.instrumentation.metamodel.adk.entities.tool import TOOL as ADK_TOOL
@@ -207,6 +207,13 @@ class MonocleValidator:
         """
         try:
             trace_source = get_trace_source(self._trace_source)
+            if trace_source is None and not self._trace_source:
+                # No trace source was declared (all local runners — ADK, LangGraph,
+                # CrewAI, LlamaIndex, etc. — leave this unset). If spans are being
+                # exported to Okahu, record the outcome there. Explicit sources like
+                # "file" keep their existing behavior (this stays a no-op for them).
+                if OkahuTraceSource._okahu_exporter_active(self.exporters):
+                    trace_source = OkahuTraceSource()
             if trace_source is None:
                 return
             fact_id = self._trace_source_fact_id or self._get_current_trace_id()

--- a/test_tools/tests/unit/test_validator_record_result.py
+++ b/test_tools/tests/unit/test_validator_record_result.py
@@ -72,6 +72,42 @@ class TestPostTestCleanupRecords:
             token=None, test_name="test_x", test_failed=False, skip_export=True
         )
 
+    def test_records_for_undeclared_source_with_okahu_exporter(self, validator):
+        # Local runners (ADK, LangGraph, CrewAI, LlamaIndex, ...) never declare a
+        # remote trace source, so _trace_source is unset. When an Okahu exporter is
+        # active, the outcome must still be recorded via the exporter-derived source.
+        validator._trace_source = ""
+        validator._trace_source_fact_id = "trace-1"
+        validator._trace_source_workflow_name = "my_app"
+
+        with patch("monocle_test_tools.validator.get_trace_source", return_value=None), \
+             patch("monocle_test_tools.validator.OkahuTraceSource") as okahu_cls:
+            okahu_cls._okahu_exporter_active.return_value = True
+            fake_source = okahu_cls.return_value
+            validator.post_test_cleanup(
+                token=None, test_name="test_x", test_failed=False, skip_export=True
+            )
+
+        okahu_cls._okahu_exporter_active.assert_called_once_with(validator.exporters)
+        fake_source.record_test_result.assert_called_once()
+        _, kwargs = fake_source.record_test_result.call_args
+        assert kwargs["fact_id"] == "trace-1"
+        assert kwargs["workflow_name"] == "my_app"
+        assert kwargs["test_name"] == "test_x"
+        assert kwargs["exporters"] is validator.exporters
+
+    def test_noop_for_undeclared_source_without_okahu_exporter(self, validator):
+        # Undeclared source + no Okahu exporter (e.g. file-only export) must remain
+        # a no-op: nothing recorded, no error raised.
+        validator._trace_source = ""
+        with patch("monocle_test_tools.validator.get_trace_source", return_value=None), \
+             patch("monocle_test_tools.validator.OkahuTraceSource") as okahu_cls:
+            okahu_cls._okahu_exporter_active.return_value = False
+            validator.post_test_cleanup(
+                token=None, test_name="test_x", test_failed=False, skip_export=True
+            )
+            okahu_cls.return_value.record_test_result.assert_not_called()
+
     def test_recording_failure_never_raises(self, validator):
         validator._trace_source = "okahu"
         validator._trace_source_fact_id = "trace-1"


### PR DESCRIPTION
## Proposed changes

PR #760 records a pytest's pass/fail to Okahu as an eval label via `POST /v1/eval/label`
during `post_test_cleanup`. But `_maybe_record_test_result` resolves the trace source only
from `self._trace_source`, which is set from the agent runner's `get_remote_traces_source()`.
Every local runner (ADK, LangGraph, CrewAI, LlamaIndex, Strands, MSAgent, OpenAI) inherits
the base implementation returning `None`, so the early `return` fires and the label is never
recorded — even though spans are being exported to Okahu. Only `HttpOkahuRunner` (which
returns `"okahu"`) triggered recording.

This fix should support all agentic frameworks. Currently validated against Google ADK and LangGraph Agents

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...