### PR TITLE
Fix duplicate evaluation result storage problem

### DIFF
--- a/test_tools/src/monocle_test_tools/evals/okahu_eval.py
+++ b/test_tools/src/monocle_test_tools/evals/okahu_eval.py
@@ -400,6 +400,11 @@ class OkahuEval(BaseEval):
             payload = {"template_name": eval_name}
         label = None
         explanation = ""
+        # A live run submits the eval in shadow mode (compute only); we persist the
+        # result via export_results below. A replay (trace already in Okahu, PR #547)
+        # submits with shadow_eval False, so the eval service persists the result
+        # itself — in that case we must not export again, or it is stored twice.
+        shadow_eval = self._trace_source != "okahu"
 
         for fact_id in fact_ids:
             params = {
@@ -409,7 +414,7 @@ class OkahuEval(BaseEval):
                 "fact_name": fact_name,
                 "start_time": start_time,
                 "end_time": end_time,
-                "shadow_eval": self._trace_source != "okahu"
+                "shadow_eval": shadow_eval
             }
             
             logger.debug("Submitting evaluation on fact_id: %s", fact_id)
@@ -460,8 +465,10 @@ class OkahuEval(BaseEval):
                     f"Unexpected response format from evaluation service. Expected 'result' key in response. Received: {data}"
                 ) from exc
             
-            # Export eval results if okahu exporter is configured
-            if "okahu" in (os.getenv("MONOCLE_EXPORTER", "")) or self._trace_source == "okahu":
+            # Only persist via export_results when the submit ran in shadow mode. On a
+            # replay (shadow_eval False) the submit already stored the result, so
+            # exporting again would create a duplicate row.
+            if shadow_eval and "okahu" in os.getenv("MONOCLE_EXPORTER", ""):
                 with OkahuEvalResultExporter(api_key=api_key, endpoint=base) as result_exporter:
                     result_exporter.export_results(
                         job_id=job_id,


### PR DESCRIPTION
## Proposed changes

When an Okahu evaluation runs against a trace loaded from Okahu (trace_source == "okahu"), the same evaluation result is written to eval_results twice, because evaluating a trace makes two calls to the eval service — the submit call (POST /v1/eval/jobs), which computes the result and, when shadow_eval is False, also stores it, and the store call (POST /v1/eval/jobs/{job_id}/results), which stores the returned result — and PR #547 (which added loading traces from Okahu) set shadow_eval = False for that case so the submit call now stores the result, but did not disable the store call, leaving both writes active and producing two identical rows under the same job_id; this PR fixes that by making the store call run only when shadow_eval is True (i.e. only when the submit call did not already store the result), so Okahu-sourced evals (shadow_eval == False) skip the now-redundant second write while live runs are unchanged.
Tested solution on google adk travel agent with success.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...