### PR TITLE
feat(exporters): add ClickHouse span exporter

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install packages and dev dependencies
         run: |
           uv pip install --system --prerelease=allow \
-            -e './apptrace[dev,azure,aws,gcp,postgres]' \
+            -e './apptrace[dev,azure,aws,gcp,postgres,clickhouse]' \
             -e './test_tools[dev]'
 
       - name: Verify dependency consistency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - feat(test_tools)!: the eval-result matrix row is now template-agnostic — `judge_output` carries the judge's structured output verbatim, and the `hallucination`-specific `claim_verdicts`, `hallucination_types` and `entity_match_check` columns are removed. Previously only those three fields were promoted, so every other template's `structure_output` (e.g. `addressed_aspects` / `missing_aspects` / `completeness_score` on `conversation_completeness`) was dropped and downstream analysis had only the free-text `explanation` to parse. **Migration:** read `row["judge_output"]["claim_verdicts"]` instead of `row["claim_verdicts"]`.
+- feat(exporters): add ClickHouse span exporter (`MONOCLE_EXPORTER=clickhouse`), configured via `MONOCLE_CLICKHOUSE_CONNECTION_URL`; install with the `clickhouse` extra
 - feat(exporters): configurable file-name prefix for file and Azure Blob exporters via `MONOCLE_FILE_PREFIX` and `MONOCLE_BLOB_FILE_PREFIX`; S3 `MONOCLE_S3_KEY_PREFIX` renamed to `MONOCLE_S3_FILE_PREFIX` (old name still works with deprecation warning) ([#149](https://github.com/monocle2ai/monocle/issues/149))
 - chore(deps): add `opentelemetry-exporter-otlp-proto-http` as a default dependency so the OTLP exporter works out of the box ([#570](https://github.com/monocle2ai/monocle/issues/570))
 - feat(exporters): add `MONOCLE_CONSOLE` env var to enable console output alongside any configured exporter ([#577](https://github.com/monocle2ai/monocle/pull/577))

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ This flexibility is especially useful when platform teams want to inject tracing
 | **LLM inference** | 🟢 OpenAI · 🟢 Azure OpenAI · 🟢 Azure AI · 🟢 Nvidia Triton · 🟢 AWS Bedrock · 🟢 AWS Sagemaker · 🟢 Google Vertex · 🟢 Google Gemini · 🟢 Hugging Face · 🟢 Deepseek · 🟢 Anthropic · 🟢 Mistral · 🟢 LiteLLM · 🔜 Azure ML |
 | **AI coding assistants** | 🟢 Claude CLI · 🟢 OpenAI Codex CLI · 🟢 GitHub Copilot (CLI + VS Code Chat) |
 | **Vector stores** | 🟢 FAISS · 🔜 OpenSearch · 🔜 Milvus |
-| **Exporters** | 🟢 stdout · 🟢 file · 🟢 Memory · 🟢 Azure Blob Storage · 🟢 AWS S3 · 🟢 Okahu cloud · 🟢 OTEL collectors · 🟢 Google Cloud Storage  · 🟢 [Paygentic](https://docs.paygentic.io/integrations/monocle) |
+| **Exporters** | 🟢 stdout · 🟢 file · 🟢 Memory · 🟢 Azure Blob Storage · 🟢 AWS S3 · 🟢 Okahu cloud · 🟢 OTEL collectors · 🟢 Google Cloud Storage · 🟢 PostgreSQL · 🟢 ClickHouse · 🟢 [Paygentic](https://docs.paygentic.io/integrations/monocle) |
 
 ## IDEs, ADK, and ecosystem integrations
 

--- a/apptrace/pyproject.toml
+++ b/apptrace/pyproject.toml
@@ -180,6 +180,10 @@ postgres = [
     'psycopg2-binary',
 ]
 
+clickhouse = [
+    'clickhouse-connect',
+]
+
 
 [project.urls]
 Homepage = "https://github.com/monocle2ai/monocle"

--- a/apptrace/src/monocle_apptrace/exporters/clickhouse/clickhouse_exporter.py
+++ b/apptrace/src/monocle_apptrace/exporters/clickhouse/clickhouse_exporter.py
@@ -1,0 +1,137 @@
+import os
+import json
+import logging
+import datetime
+from typing import Sequence
+
+import clickhouse_connect
+from clickhouse_connect.driver.exceptions import DatabaseError, OperationalError
+
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExportResult
+
+from monocle_apptrace.exporters.base_exporter import (
+    SpanExporterBase,
+    format_span_id_without_0x,
+    format_trace_id_without_0x,
+    serialize_span,
+)
+
+logger = logging.getLogger(__name__)
+
+CREATE_TABLE_SQL = """
+    CREATE TABLE IF NOT EXISTS traces (
+        name        String,
+        start_time  DateTime64(9, 'UTC'),
+        end_time    DateTime64(9, 'UTC'),
+        status      String,
+        span_id     String,
+        trace_id    String,
+        parent_id   Nullable(String),
+        attributes  String,
+        events      String,
+        metadata    Nullable(String)
+    ) ENGINE = MergeTree() ORDER BY (trace_id, span_id)
+"""
+
+INSERT_COLUMNS = [
+    "name", "start_time", "end_time", "status", "span_id", "trace_id",
+    "parent_id", "attributes", "events", "metadata",
+]
+
+# ClickHouse error code raised when the user lacks the required privilege.
+ACCESS_DENIED_CODE = "497"
+
+
+class ClickHouseSpanExporter(SpanExporterBase):
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.connection_url = os.environ.get("MONOCLE_CLICKHOUSE_CONNECTION_URL")
+        if not self.connection_url:
+            raise ValueError("MONOCLE_CLICKHOUSE_CONNECTION_URL environment variable is required")
+        self.client = clickhouse_connect.get_client(dsn=self.connection_url)
+        self._ensure_table()
+
+    def _ensure_table(self) -> None:
+        try:
+            self.client.command(CREATE_TABLE_SQL)
+        except DatabaseError as e:
+            if ACCESS_DENIED_CODE in str(e) or "ACCESS_DENIED" in str(e):
+                raise PermissionError(
+                    "ClickHouseSpanExporter could not create the 'traces' table — "
+                    "the database user lacks CREATE TABLE permission. "
+                    "Pre-create the table manually or grant the required privilege."
+                ) from e
+            raise
+
+    def _build_row(self, span: ReadableSpan) -> list:
+        serialized = serialize_span(span)
+        start_time = datetime.datetime.fromtimestamp(
+            span.start_time / 1e9, tz=datetime.timezone.utc
+        )
+        end_time = datetime.datetime.fromtimestamp(
+            span.end_time / 1e9, tz=datetime.timezone.utc
+        )
+        span_id  = "0x" + format_span_id_without_0x(span.context.span_id)
+        trace_id = "0x" + format_trace_id_without_0x(span.context.trace_id)
+        parent_id = (
+            "0x" + format_span_id_without_0x(span.parent.span_id)
+            if span.parent else None
+        )
+        return [
+            span.name,
+            start_time,
+            end_time,
+            json.dumps(serialized.get("status")),
+            span_id,
+            trace_id,
+            parent_id,
+            json.dumps(serialized.get("attributes")),
+            json.dumps(serialized.get("events")),
+            None,   # metadata — reserved for future use
+        ]
+
+    def _reconnect(self) -> None:
+        try:
+            self.client.close()
+        except Exception:
+            pass
+        self.client = clickhouse_connect.get_client(dsn=self.connection_url)
+
+    def _do_insert(self, rows: list) -> None:
+        self.client.insert("traces", rows, column_names=INSERT_COLUMNS)
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        try:
+            rows = []
+            for span in spans:
+                if self.skip_export(span):
+                    continue
+                try:
+                    rows.append(self._build_row(span))
+                except Exception as e:
+                    logger.warning("Error serializing span %s: %s", span.context.span_id, e)
+
+            if rows:
+                try:
+                    self._do_insert(rows)
+                except OperationalError as e:
+                    logger.warning("DB connection error, attempting reconnect: %s", e)
+                    self._reconnect()
+                    self._do_insert(rows)
+
+            return SpanExportResult.SUCCESS
+        except Exception as e:
+            logger.error("Error exporting spans to ClickHouse: %s", e)
+            return SpanExportResult.FAILURE
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return True
+
+    def shutdown(self) -> None:
+        try:
+            self.client.close()
+        except Exception:
+            pass
+        logger.info("ClickHouseSpanExporter has been shut down.")

--- a/apptrace/src/monocle_apptrace/exporters/clickhouse/clickhouse_exporter.py
+++ b/apptrace/src/monocle_apptrace/exporters/clickhouse/clickhouse_exporter.py
@@ -24,26 +24,22 @@ CLIENT_SETTINGS = {"enable_json_type": 1}
 CREATE_TABLE_SQL = """
     CREATE TABLE IF NOT EXISTS traces (
         name           String,
-        start_time     DateTime64(9, 'UTC'),
-        end_time       DateTime64(9, 'UTC'),
+        start_time     DateTime64(6, 'UTC'),
+        end_time       DateTime64(6, 'UTC'),
         status_code    LowCardinality(String),
         status_message Nullable(String),
         span_id        String,
         trace_id       String,
         parent_id      Nullable(String),
         attributes     JSON,
-        events         Array(JSON),
-        metadata       JSON
+        events         Array(JSON)
     ) ENGINE = MergeTree() ORDER BY (trace_id, span_id)
 """
 
 INSERT_COLUMNS = [
     "name", "start_time", "end_time", "status_code", "status_message",
-    "span_id", "trace_id", "parent_id", "attributes", "events", "metadata",
+    "span_id", "trace_id", "parent_id", "attributes", "events",
 ]
-
-# ClickHouse error code raised when the user lacks the required privilege.
-ACCESS_DENIED_CODE = "497"
 
 
 class ClickHouseSpanExporter(SpanExporterBase):
@@ -60,7 +56,7 @@ class ClickHouseSpanExporter(SpanExporterBase):
         try:
             self.client.command(CREATE_TABLE_SQL)
         except DatabaseError as e:
-            if ACCESS_DENIED_CODE in str(e) or "ACCESS_DENIED" in str(e):
+            if "ACCESS_DENIED" in str(e):
                 raise PermissionError(
                     "ClickHouseSpanExporter could not create the 'traces' table — "
                     "the database user lacks CREATE TABLE permission. "
@@ -94,7 +90,6 @@ class ClickHouseSpanExporter(SpanExporterBase):
             parent_id,
             serialized.get("attributes") or {},   # JSON
             serialized.get("events") or [],        # Array(JSON)
-            serialized.get("metadata") or {},      # JSON — reserved for future use
         ]
 
     def _reconnect(self) -> None:

--- a/apptrace/src/monocle_apptrace/exporters/clickhouse/clickhouse_exporter.py
+++ b/apptrace/src/monocle_apptrace/exporters/clickhouse/clickhouse_exporter.py
@@ -32,13 +32,14 @@ CREATE_TABLE_SQL = """
         trace_id       String,
         parent_id      Nullable(String),
         attributes     JSON,
-        events         Array(JSON)
+        events         Array(JSON),
+        metadata       JSON
     ) ENGINE = MergeTree() ORDER BY (trace_id, span_id)
 """
 
 INSERT_COLUMNS = [
     "name", "start_time", "end_time", "status_code", "status_message",
-    "span_id", "trace_id", "parent_id", "attributes", "events",
+    "span_id", "trace_id", "parent_id", "attributes", "events", "metadata",
 ]
 
 
@@ -90,6 +91,7 @@ class ClickHouseSpanExporter(SpanExporterBase):
             parent_id,
             serialized.get("attributes") or {},   # JSON
             serialized.get("events") or [],        # Array(JSON)
+            {},                                    # metadata — reserved for future use (mirrors Postgres)
         ]
 
     def _reconnect(self) -> None:

--- a/apptrace/src/monocle_apptrace/exporters/clickhouse/clickhouse_exporter.py
+++ b/apptrace/src/monocle_apptrace/exporters/clickhouse/clickhouse_exporter.py
@@ -1,5 +1,4 @@
 import os
-import json
 import logging
 import datetime
 from typing import Sequence
@@ -19,24 +18,28 @@ from monocle_apptrace.exporters.base_exporter import (
 
 logger = logging.getLogger(__name__)
 
+# The JSON / Array(JSON) columns require the JSON type to be enabled on the server.
+CLIENT_SETTINGS = {"enable_json_type": 1}
+
 CREATE_TABLE_SQL = """
     CREATE TABLE IF NOT EXISTS traces (
-        name        String,
-        start_time  DateTime64(9, 'UTC'),
-        end_time    DateTime64(9, 'UTC'),
-        status      String,
-        span_id     String,
-        trace_id    String,
-        parent_id   Nullable(String),
-        attributes  String,
-        events      String,
-        metadata    Nullable(String)
+        name           String,
+        start_time     DateTime64(9, 'UTC'),
+        end_time       DateTime64(9, 'UTC'),
+        status_code    LowCardinality(String),
+        status_message Nullable(String),
+        span_id        String,
+        trace_id       String,
+        parent_id      Nullable(String),
+        attributes     JSON,
+        events         Array(JSON),
+        metadata       JSON
     ) ENGINE = MergeTree() ORDER BY (trace_id, span_id)
 """
 
 INSERT_COLUMNS = [
-    "name", "start_time", "end_time", "status", "span_id", "trace_id",
-    "parent_id", "attributes", "events", "metadata",
+    "name", "start_time", "end_time", "status_code", "status_message",
+    "span_id", "trace_id", "parent_id", "attributes", "events", "metadata",
 ]
 
 # ClickHouse error code raised when the user lacks the required privilege.
@@ -50,7 +53,7 @@ class ClickHouseSpanExporter(SpanExporterBase):
         self.connection_url = os.environ.get("MONOCLE_CLICKHOUSE_CONNECTION_URL")
         if not self.connection_url:
             raise ValueError("MONOCLE_CLICKHOUSE_CONNECTION_URL environment variable is required")
-        self.client = clickhouse_connect.get_client(dsn=self.connection_url)
+        self.client = clickhouse_connect.get_client(dsn=self.connection_url, settings=CLIENT_SETTINGS)
         self._ensure_table()
 
     def _ensure_table(self) -> None:
@@ -79,17 +82,19 @@ class ClickHouseSpanExporter(SpanExporterBase):
             "0x" + format_span_id_without_0x(span.parent.span_id)
             if span.parent else None
         )
+        status = serialized.get("status") or {}
         return [
             span.name,
             start_time,
             end_time,
-            json.dumps(serialized.get("status")),
+            status.get("status_code") or status.get("code") or "",
+            status.get("message"),
             span_id,
             trace_id,
             parent_id,
-            json.dumps(serialized.get("attributes")),
-            json.dumps(serialized.get("events")),
-            None,   # metadata — reserved for future use
+            serialized.get("attributes") or {},   # JSON
+            serialized.get("events") or [],        # Array(JSON)
+            serialized.get("metadata") or {},      # JSON — reserved for future use
         ]
 
     def _reconnect(self) -> None:
@@ -97,7 +102,7 @@ class ClickHouseSpanExporter(SpanExporterBase):
             self.client.close()
         except Exception:
             pass
-        self.client = clickhouse_connect.get_client(dsn=self.connection_url)
+        self.client = clickhouse_connect.get_client(dsn=self.connection_url, settings=CLIENT_SETTINGS)
 
     def _do_insert(self, rows: list) -> None:
         self.client.insert("traces", rows, column_names=INSERT_COLUMNS)

--- a/apptrace/src/monocle_apptrace/exporters/monocle_exporters.py
+++ b/apptrace/src/monocle_apptrace/exporters/monocle_exporters.py
@@ -23,6 +23,7 @@ monocle_exporters: Dict[str, Any] = {
     },
     "gcs" : {"module": "monocle_apptrace.exporters.gcp.gcs_exporter", "class": "GCSSpanExporter"},
     "postgres": {"module": "monocle_apptrace.exporters.postgres.postgres_exporter", "class": "PostgresSpanExporter"},
+    "clickhouse": {"module": "monocle_apptrace.exporters.clickhouse.clickhouse_exporter", "class": "ClickHouseSpanExporter"},
     "paygentic": {"module": "monocle_apptrace.exporters.paygentic.paygentic_exporter", "class": "PaygenticSpanExporter"}
 }
 

--- a/apptrace/tests/integration/test_clickhouse_exporter_integration.py
+++ b/apptrace/tests/integration/test_clickhouse_exporter_integration.py
@@ -1,16 +1,19 @@
-"""End-to-end check that ClickHouseSpanExporter persists the same span data
-that FileSpanExporter writes to the local ``.monocle`` folder.
+"""End-to-end check that ClickHouseSpanExporter writes spans into the new
+schema and that the data is queryable there:
 
-The same spans are exported through both exporters, then the rows read back
-from ClickHouse are compared field-by-field against the JSON written to disk.
+- attributes  -> JSON        (sub-fields addressable, e.g. attributes.`span.type`)
+- events      -> Array(JSON)  (searchable per element, e.g. by event name)
+- status      -> status_code + status_message columns
+
+The stored shape intentionally differs from the local ``.monocle`` file (the
+JSON type re-nests dotted keys and status is split into columns), so this test
+verifies the ClickHouse content directly rather than byte-for-byte parity.
 
 Requires a running ClickHouse server reachable via
-``MONOCLE_CLICKHOUSE_CONNECTION_URL`` (a single-binary ``clickhouse server``
-is enough); the test skips itself otherwise.
+``MONOCLE_CLICKHOUSE_CONNECTION_URL`` (a single-binary ``clickhouse server`` is
+enough); the test skips itself otherwise.
 """
 import os
-import glob
-import json
 import logging
 
 import pytest
@@ -20,90 +23,67 @@ clickhouse_connect = pytest.importorskip("clickhouse_connect", reason="clickhous
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
-from monocle_apptrace.exporters.clickhouse.clickhouse_exporter import ClickHouseSpanExporter
-from monocle_apptrace.exporters.file_exporter import FileSpanExporter
+from monocle_apptrace.exporters.clickhouse.clickhouse_exporter import (
+    ClickHouseSpanExporter,
+    CLIENT_SETTINGS,
+)
 from monocle_apptrace.instrumentation.common.constants import MONOCLE_SDK_VERSION
 
 logger = logging.getLogger(__name__)
 
-# Fields both exporters persist and that must match between ClickHouse and .monocle.
-JSON_FIELDS = ("status", "attributes", "events")
 
-
-def _read_monocle_spans(out_dir: str, trace_hex: str) -> dict:
-    """Return {span_id: serialized_span} for the given trace from the .monocle files."""
-    spans = {}
-    for file_path in glob.glob(os.path.join(out_dir, "*.json")):
-        with open(file_path, encoding="UTF-8") as handle:
-            for obj in json.load(handle):
-                if obj["context"]["trace_id"] == trace_hex:
-                    spans[obj["context"]["span_id"]] = obj
-    return spans
-
-
-def _read_clickhouse_spans(client, trace_hex: str) -> dict:
-    """Return {span_id: row_dict} for the given trace from the traces table."""
-    result = client.query(
-        "SELECT name, span_id, parent_id, status, attributes, events "
-        "FROM traces WHERE trace_id = {tid:String}",
-        parameters={"tid": trace_hex},
-    )
-    spans = {}
-    for name, span_id, parent_id, status, attributes, events in result.result_rows:
-        spans[span_id] = {
-            "name": name,
-            "parent_id": parent_id,
-            "status": json.loads(status),
-            "attributes": json.loads(attributes),
-            "events": json.loads(events),
-        }
-    return spans
-
-
-def test_clickhouse_matches_monocle_file(tmp_path):
+def test_clickhouse_schema_roundtrip():
     conn_url = os.getenv("MONOCLE_CLICKHOUSE_CONNECTION_URL")
     if not conn_url:
         pytest.skip("MONOCLE_CLICKHOUSE_CONNECTION_URL not set")
 
-    out_dir = str(tmp_path / ".monocle")
-    file_exporter = FileSpanExporter(service_name="clickhouse_app", out_path=out_dir)
-    ch_exporter = ClickHouseSpanExporter()
-
     provider = TracerProvider()
-    provider.add_span_processor(SimpleSpanProcessor(file_exporter))
-    provider.add_span_processor(SimpleSpanProcessor(ch_exporter))
+    provider.add_span_processor(SimpleSpanProcessor(ClickHouseSpanExporter()))
     tracer = provider.get_tracer(__name__)
 
     with tracer.start_as_current_span("clickhouse.workflow") as root:
         root.set_attribute(MONOCLE_SDK_VERSION, "0.8.0")
-        root.set_attribute("entity.1.name", "clickhouse_app")
         trace_hex = f"0x{root.get_span_context().trace_id:032x}"
+        root_span_id = f"0x{root.get_span_context().span_id:016x}"
         with tracer.start_as_current_span("clickhouse.child") as child:
             child.set_attribute(MONOCLE_SDK_VERSION, "0.8.0")
             child.set_attribute("span.type", "inference")
+            child.add_event("metadata", {"total_tokens": 123})
 
-    provider.shutdown()  # flushes both exporters and finalizes the .monocle file
+    provider.shutdown()  # flushes the exporter
 
-    file_spans = _read_monocle_spans(out_dir, trace_hex)
-    query_client = clickhouse_connect.get_client(dsn=conn_url)
+    client = clickhouse_connect.get_client(dsn=conn_url, settings=CLIENT_SETTINGS)
     try:
-        ch_spans = _read_clickhouse_spans(query_client, trace_hex)
+        rows = client.query(
+            "SELECT name, span_id, parent_id, status_code "
+            "FROM traces WHERE trace_id = {tid:String} ORDER BY name",
+            parameters={"tid": trace_hex},
+        ).result_rows
+        by_name = {r[0]: r for r in rows}
+
+        # both spans landed, with the parent/child link intact
+        assert set(by_name) == {"clickhouse.workflow", "clickhouse.child"}, by_name
+        assert by_name["clickhouse.workflow"][2] is None            # root has no parent
+        assert by_name["clickhouse.child"][2] == root_span_id       # child -> root
+        # status split into its own column (unset by default)
+        assert by_name["clickhouse.workflow"][3] == "UNSET"
+
+        # attributes JSON is queryable by sub-field
+        span_type = client.query(
+            "SELECT attributes.`span.type` FROM traces "
+            "WHERE trace_id = {tid:String} AND name = 'clickhouse.child'",
+            parameters={"tid": trace_hex},
+        ).result_rows[0][0]
+        assert span_type == "inference", span_type
+
+        # events Array(JSON) is searchable per element
+        has_metadata = client.query(
+            "SELECT arrayExists(x -> x.name = 'metadata', events) FROM traces "
+            "WHERE trace_id = {tid:String} AND name = 'clickhouse.child'",
+            parameters={"tid": trace_hex},
+        ).result_rows[0][0]
+        assert has_metadata == 1
     finally:
-        query_client.close()
+        client.close()
 
-    assert file_spans, f"No spans found in .monocle for trace {trace_hex}"
-    assert set(ch_spans) == set(file_spans), (
-        f"span_id mismatch: clickhouse={sorted(ch_spans)} monocle={sorted(file_spans)}"
-    )
-
-    for span_id, file_obj in file_spans.items():
-        ch_obj = ch_spans[span_id]
-        assert ch_obj["name"] == file_obj["name"], f"name mismatch for {span_id}"
-        assert ch_obj["parent_id"] == file_obj["parent_id"], f"parent_id mismatch for {span_id}"
-        for field in JSON_FIELDS:
-            assert ch_obj[field] == file_obj[field], f"{field} mismatch for {span_id}"
-
-    logger.info(
-        "Verified %s span(s) match between ClickHouse and .monocle for trace %s",
-        len(ch_spans), trace_hex,
-    )
+    logger.info("Verified new-schema roundtrip in ClickHouse for trace %s", trace_hex)

--- a/apptrace/tests/integration/test_clickhouse_exporter_integration.py
+++ b/apptrace/tests/integration/test_clickhouse_exporter_integration.py
@@ -28,6 +28,7 @@ from monocle_apptrace.exporters.clickhouse.clickhouse_exporter import (
     CLIENT_SETTINGS,
 )
 from monocle_apptrace.instrumentation.common.constants import MONOCLE_SDK_VERSION
+from monocle_apptrace.instrumentation.common.utils import get_monocle_version
 
 logger = logging.getLogger(__name__)
 
@@ -42,11 +43,11 @@ def test_clickhouse_schema_roundtrip():
     tracer = provider.get_tracer(__name__)
 
     with tracer.start_as_current_span("clickhouse.workflow") as root:
-        root.set_attribute(MONOCLE_SDK_VERSION, "0.8.0")
+        root.set_attribute(MONOCLE_SDK_VERSION, get_monocle_version())
         trace_hex = f"0x{root.get_span_context().trace_id:032x}"
         root_span_id = f"0x{root.get_span_context().span_id:016x}"
         with tracer.start_as_current_span("clickhouse.child") as child:
-            child.set_attribute(MONOCLE_SDK_VERSION, "0.8.0")
+            child.set_attribute(MONOCLE_SDK_VERSION, get_monocle_version())
             child.set_attribute("span.type", "inference")
             child.add_event("metadata", {"total_tokens": 123})
 

--- a/apptrace/tests/integration/test_clickhouse_exporter_integration.py
+++ b/apptrace/tests/integration/test_clickhouse_exporter_integration.py
@@ -1,0 +1,109 @@
+"""End-to-end check that ClickHouseSpanExporter persists the same span data
+that FileSpanExporter writes to the local ``.monocle`` folder.
+
+The same spans are exported through both exporters, then the rows read back
+from ClickHouse are compared field-by-field against the JSON written to disk.
+
+Requires a running ClickHouse server reachable via
+``MONOCLE_CLICKHOUSE_CONNECTION_URL`` (a single-binary ``clickhouse server``
+is enough); the test skips itself otherwise.
+"""
+import os
+import glob
+import json
+import logging
+
+import pytest
+
+clickhouse_connect = pytest.importorskip("clickhouse_connect", reason="clickhouse-connect not installed")
+
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+from monocle_apptrace.exporters.clickhouse.clickhouse_exporter import ClickHouseSpanExporter
+from monocle_apptrace.exporters.file_exporter import FileSpanExporter
+from monocle_apptrace.instrumentation.common.constants import MONOCLE_SDK_VERSION
+
+logger = logging.getLogger(__name__)
+
+# Fields both exporters persist and that must match between ClickHouse and .monocle.
+JSON_FIELDS = ("status", "attributes", "events")
+
+
+def _read_monocle_spans(out_dir: str, trace_hex: str) -> dict:
+    """Return {span_id: serialized_span} for the given trace from the .monocle files."""
+    spans = {}
+    for file_path in glob.glob(os.path.join(out_dir, "*.json")):
+        with open(file_path, encoding="UTF-8") as handle:
+            for obj in json.load(handle):
+                if obj["context"]["trace_id"] == trace_hex:
+                    spans[obj["context"]["span_id"]] = obj
+    return spans
+
+
+def _read_clickhouse_spans(client, trace_hex: str) -> dict:
+    """Return {span_id: row_dict} for the given trace from the traces table."""
+    result = client.query(
+        "SELECT name, span_id, parent_id, status, attributes, events "
+        "FROM traces WHERE trace_id = {tid:String}",
+        parameters={"tid": trace_hex},
+    )
+    spans = {}
+    for name, span_id, parent_id, status, attributes, events in result.result_rows:
+        spans[span_id] = {
+            "name": name,
+            "parent_id": parent_id,
+            "status": json.loads(status),
+            "attributes": json.loads(attributes),
+            "events": json.loads(events),
+        }
+    return spans
+
+
+def test_clickhouse_matches_monocle_file(tmp_path):
+    conn_url = os.getenv("MONOCLE_CLICKHOUSE_CONNECTION_URL")
+    if not conn_url:
+        pytest.skip("MONOCLE_CLICKHOUSE_CONNECTION_URL not set")
+
+    out_dir = str(tmp_path / ".monocle")
+    file_exporter = FileSpanExporter(service_name="clickhouse_app", out_path=out_dir)
+    ch_exporter = ClickHouseSpanExporter()
+
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(file_exporter))
+    provider.add_span_processor(SimpleSpanProcessor(ch_exporter))
+    tracer = provider.get_tracer(__name__)
+
+    with tracer.start_as_current_span("clickhouse.workflow") as root:
+        root.set_attribute(MONOCLE_SDK_VERSION, "0.8.0")
+        root.set_attribute("entity.1.name", "clickhouse_app")
+        trace_hex = f"0x{root.get_span_context().trace_id:032x}"
+        with tracer.start_as_current_span("clickhouse.child") as child:
+            child.set_attribute(MONOCLE_SDK_VERSION, "0.8.0")
+            child.set_attribute("span.type", "inference")
+
+    provider.shutdown()  # flushes both exporters and finalizes the .monocle file
+
+    file_spans = _read_monocle_spans(out_dir, trace_hex)
+    query_client = clickhouse_connect.get_client(dsn=conn_url)
+    try:
+        ch_spans = _read_clickhouse_spans(query_client, trace_hex)
+    finally:
+        query_client.close()
+
+    assert file_spans, f"No spans found in .monocle for trace {trace_hex}"
+    assert set(ch_spans) == set(file_spans), (
+        f"span_id mismatch: clickhouse={sorted(ch_spans)} monocle={sorted(file_spans)}"
+    )
+
+    for span_id, file_obj in file_spans.items():
+        ch_obj = ch_spans[span_id]
+        assert ch_obj["name"] == file_obj["name"], f"name mismatch for {span_id}"
+        assert ch_obj["parent_id"] == file_obj["parent_id"], f"parent_id mismatch for {span_id}"
+        for field in JSON_FIELDS:
+            assert ch_obj[field] == file_obj[field], f"{field} mismatch for {span_id}"
+
+    logger.info(
+        "Verified %s span(s) match between ClickHouse and .monocle for trace %s",
+        len(ch_spans), trace_hex,
+    )

--- a/apptrace/tests/integration/test_clickhouse_openai_manual.py
+++ b/apptrace/tests/integration/test_clickhouse_openai_manual.py
@@ -1,18 +1,22 @@
-"""Manual end-to-end test: make a real OpenAI inference call, instrument it
-with Monocle, export the spans to ClickHouse, and verify the workflow and
+"""Manual end-to-end test: make a real Azure OpenAI inference call, instrument
+it with Monocle, export the spans to ClickHouse, and verify the workflow and
 inference spans landed.
 
-Run it manually (it hits the OpenAI API and needs a live ClickHouse). Put the
-settings in ``apptrace/.env``:
+Run it manually (it hits Azure OpenAI and needs a live ClickHouse). Put the
+settings in a ``.env`` at the repo root (or ``apptrace/.env``):
 
     MONOCLE_CLICKHOUSE_CONNECTION_URL=clickhouse://user:pass@host:8123/db
-    OPENAI_API_KEY=sk-...
+    AZURE_OPENAI_API_KEY=...
+    AZURE_OPENAI_ENDPOINT=https://<resource>.openai.azure.com/
+    AZURE_OPENAI_DEPLOYMENT_NAME=<your-deployment-name>   # or AZURE_OPENAI_API_DEPLOYMENT
+    AZURE_OPENAI_API_VERSION=2024-10-21                   # optional, defaults below
 
 Then:
 
     pytest apptrace/tests/integration/test_clickhouse_openai_manual.py -v -s
 
-The test skips itself if either variable is missing, so it is safe in CI.
+The test skips itself if the ClickHouse URL or the Azure settings are missing,
+so it is safe in CI.
 """
 import os
 import logging
@@ -20,12 +24,13 @@ import logging
 import pytest
 from dotenv import load_dotenv
 
-load_dotenv(os.path.join(os.path.dirname(__file__), "..", "..", ".env"))
+_HERE = os.path.dirname(__file__)
+load_dotenv(os.path.join(_HERE, "..", "..", ".env"), override=True)         # apptrace/.env if present
+load_dotenv(os.path.join(_HERE, "..", "..", "..", ".env"), override=True)   # repo-root .env wins
 
 clickhouse_connect = pytest.importorskip("clickhouse_connect", reason="clickhouse-connect not installed")
-pytest.importorskip("openai", reason="openai not installed")
+openai = pytest.importorskip("openai", reason="openai not installed")
 
-from openai import OpenAI
 from opentelemetry import trace as otel_trace
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -38,13 +43,20 @@ from monocle_apptrace.exporters.clickhouse.clickhouse_exporter import (
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_API_VERSION = "2024-10-21"
 
-def test_clickhouse_openai_manual():
+
+def test_clickhouse_azure_openai_manual():
     conn_url = os.getenv("MONOCLE_CLICKHOUSE_CONNECTION_URL")
     if not conn_url:
         pytest.skip("MONOCLE_CLICKHOUSE_CONNECTION_URL not set")
-    if not os.getenv("OPENAI_API_KEY"):
-        pytest.skip("OPENAI_API_KEY not set")
+
+    api_key = os.getenv("AZURE_OPENAI_API_KEY")
+    endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
+    deployment = os.getenv("AZURE_OPENAI_API_DEPLOYMENT") or os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME")
+    api_version = os.getenv("AZURE_OPENAI_API_VERSION") or DEFAULT_API_VERSION
+    if not (api_key and endpoint and deployment):
+        pytest.skip("Azure OpenAI env vars not set (need API key, endpoint, deployment)")
 
     # Capture the emitted spans locally so we know the trace_id to query for.
     memory_exporter = InMemorySpanExporter()
@@ -57,8 +69,13 @@ def test_clickhouse_openai_manual():
         wrapper_methods=[],
     )
     try:
-        response = OpenAI().chat.completions.create(
-            model="gpt-4o-mini",
+        client = openai.AzureOpenAI(
+            api_key=api_key,
+            azure_endpoint=endpoint,
+            api_version=api_version,
+        )
+        response = client.chat.completions.create(
+            model=deployment,  # Azure uses the deployment name
             messages=[{"role": "user", "content": "In one sentence, what is ClickHouse?"}],
         )
         logger.info("LLM answer: %s", response.choices[0].message.content)
@@ -70,16 +87,16 @@ def test_clickhouse_openai_manual():
         trace_id = f"0x{spans[0].context.trace_id:032x}"
         logger.info("trace_id: %s", trace_id)
 
-        client = clickhouse_connect.get_client(dsn=conn_url, settings=CLIENT_SETTINGS)
+        ch = clickhouse_connect.get_client(dsn=conn_url, settings=CLIENT_SETTINGS)
         try:
             span_types = [
-                r[0] for r in client.query(
+                r[0] for r in ch.query(
                     "SELECT attributes.`span.type` FROM traces WHERE trace_id = {tid:String}",
                     parameters={"tid": trace_id},
                 ).result_rows
             ]
         finally:
-            client.close()
+            ch.close()
 
         logger.info("span types in ClickHouse for %s: %s", trace_id, span_types)
         assert "workflow" in span_types, f"no workflow span in ClickHouse: {span_types}"

--- a/apptrace/tests/integration/test_clickhouse_openai_manual.py
+++ b/apptrace/tests/integration/test_clickhouse_openai_manual.py
@@ -1,0 +1,90 @@
+"""Manual end-to-end test: make a real OpenAI inference call, instrument it
+with Monocle, export the spans to ClickHouse, and verify the workflow and
+inference spans landed.
+
+Run it manually (it hits the OpenAI API and needs a live ClickHouse). Put the
+settings in ``apptrace/.env``:
+
+    MONOCLE_CLICKHOUSE_CONNECTION_URL=clickhouse://user:pass@host:8123/db
+    OPENAI_API_KEY=sk-...
+
+Then:
+
+    pytest apptrace/tests/integration/test_clickhouse_openai_manual.py -v -s
+
+The test skips itself if either variable is missing, so it is safe in CI.
+"""
+import os
+import logging
+
+import pytest
+from dotenv import load_dotenv
+
+load_dotenv(os.path.join(os.path.dirname(__file__), "..", "..", ".env"))
+
+clickhouse_connect = pytest.importorskip("clickhouse_connect", reason="clickhouse-connect not installed")
+pytest.importorskip("openai", reason="openai not installed")
+
+from openai import OpenAI
+from opentelemetry import trace as otel_trace
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from monocle_apptrace.instrumentation.common.instrumentor import setup_monocle_telemetry
+from monocle_apptrace.exporters.clickhouse.clickhouse_exporter import (
+    ClickHouseSpanExporter,
+    CLIENT_SETTINGS,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def test_clickhouse_openai_manual():
+    conn_url = os.getenv("MONOCLE_CLICKHOUSE_CONNECTION_URL")
+    if not conn_url:
+        pytest.skip("MONOCLE_CLICKHOUSE_CONNECTION_URL not set")
+    if not os.getenv("OPENAI_API_KEY"):
+        pytest.skip("OPENAI_API_KEY not set")
+
+    # Capture the emitted spans locally so we know the trace_id to query for.
+    memory_exporter = InMemorySpanExporter()
+    instrumentor = setup_monocle_telemetry(
+        workflow_name="clickhouse_manual_test",
+        span_processors=[
+            BatchSpanProcessor(ClickHouseSpanExporter()),
+            SimpleSpanProcessor(memory_exporter),
+        ],
+        wrapper_methods=[],
+    )
+    try:
+        response = OpenAI().chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "In one sentence, what is ClickHouse?"}],
+        )
+        logger.info("LLM answer: %s", response.choices[0].message.content)
+
+        otel_trace.get_tracer_provider().force_flush()  # flush the batch processor to ClickHouse
+
+        spans = memory_exporter.get_finished_spans()
+        assert spans, "no spans were emitted"
+        trace_id = f"0x{spans[0].context.trace_id:032x}"
+        logger.info("trace_id: %s", trace_id)
+
+        client = clickhouse_connect.get_client(dsn=conn_url, settings=CLIENT_SETTINGS)
+        try:
+            span_types = [
+                r[0] for r in client.query(
+                    "SELECT attributes.`span.type` FROM traces WHERE trace_id = {tid:String}",
+                    parameters={"tid": trace_id},
+                ).result_rows
+            ]
+        finally:
+            client.close()
+
+        logger.info("span types in ClickHouse for %s: %s", trace_id, span_types)
+        assert "workflow" in span_types, f"no workflow span in ClickHouse: {span_types}"
+        assert any(t in ("inference", "inference.framework") for t in span_types), \
+            f"no inference span in ClickHouse: {span_types}"
+    finally:
+        if instrumentor and instrumentor.is_instrumented_by_opentelemetry:
+            instrumentor.uninstrument()

--- a/apptrace/tests/unit/test_clickhouse_exporter.py
+++ b/apptrace/tests/unit/test_clickhouse_exporter.py
@@ -16,9 +16,13 @@ import monocle_apptrace.exporters.clickhouse.clickhouse_exporter as ch_mod
 from monocle_apptrace.exporters.clickhouse.clickhouse_exporter import ClickHouseSpanExporter
 from monocle_apptrace.exporters.monocle_exporters import monocle_exporters
 
+# Column positions in the row built by _build_row (mirror of INSERT_COLUMNS).
+C_NAME, C_START, C_END, C_STATUS_CODE, C_STATUS_MSG, \
+    C_SPAN_ID, C_TRACE_ID, C_PARENT_ID, C_ATTRS, C_EVENTS, C_META = range(11)
+
 
 def _make_span(name="test-span", trace_id=0xAABBCCDD, span_id=0x1111,
-               parent_span_id=None):
+               parent_span_id=None, status=None, attributes=None, events=None):
     """Build a minimal mock ReadableSpan for use in tests."""
     span = MagicMock(spec=ReadableSpan)
     span.name = name
@@ -35,9 +39,9 @@ def _make_span(name="test-span", trace_id=0xAABBCCDD, span_id=0x1111,
     span.attributes.get.return_value = "0.8.0"   # non-empty → not skipped
     span.to_json.return_value = json.dumps({
         "name": name,
-        "status": {"status_code": "OK"},
-        "attributes": {"monocle_apptrace.version": "0.8.0"},
-        "events": [],
+        "status": status if status is not None else {"status_code": "OK"},
+        "attributes": attributes if attributes is not None else {"monocle_apptrace.version": "0.8.0"},
+        "events": events if events is not None else [],
     })
     return span
 
@@ -55,7 +59,8 @@ class TestClickHouseInit(unittest.TestCase):
     def test_reads_connection_url_from_env(self, mock_get_client):
         os.environ["MONOCLE_CLICKHOUSE_CONNECTION_URL"] = "clickhouse://user:pass@localhost:8123/db"
         exporter = ClickHouseSpanExporter()
-        mock_get_client.assert_called_once_with(dsn="clickhouse://user:pass@localhost:8123/db")
+        mock_get_client.assert_called_once_with(
+            dsn="clickhouse://user:pass@localhost:8123/db", settings=ch_mod.CLIENT_SETTINGS)
         self.assertIsNotNone(exporter.client)
         del os.environ["MONOCLE_CLICKHOUSE_CONNECTION_URL"]
 
@@ -79,35 +84,50 @@ class TestBuildRow(unittest.TestCase):
 
     def test_span_id_has_0x_prefix(self):
         row = self.exporter._build_row(_make_span(span_id=0xABCDEF0123456789))
-        self.assertEqual(row[4], "0xabcdef0123456789")
+        self.assertEqual(row[C_SPAN_ID], "0xabcdef0123456789")
 
     def test_trace_id_has_0x_prefix(self):
         row = self.exporter._build_row(_make_span(trace_id=0xAABBCCDD11223344AABBCCDD11223344))
-        self.assertTrue(row[5].startswith("0x"))
+        self.assertTrue(row[C_TRACE_ID].startswith("0x"))
 
     def test_parent_id_is_none_for_root_span(self):
         row = self.exporter._build_row(_make_span())  # no parent
-        self.assertIsNone(row[6])
+        self.assertIsNone(row[C_PARENT_ID])
 
     def test_parent_id_has_0x_prefix_for_child_span(self):
         row = self.exporter._build_row(_make_span(parent_span_id=0x1111222233334444))
-        self.assertEqual(row[6], "0x1111222233334444")
+        self.assertEqual(row[C_PARENT_ID], "0x1111222233334444")
 
     def test_timestamps_are_timezone_aware_datetimes(self):
         row = self.exporter._build_row(_make_span())
-        self.assertIsInstance(row[1], datetime.datetime)
-        self.assertIsInstance(row[2], datetime.datetime)
-        self.assertIsNotNone(row[1].tzinfo)
+        self.assertIsInstance(row[C_START], datetime.datetime)
+        self.assertIsInstance(row[C_END], datetime.datetime)
+        self.assertIsNotNone(row[C_START].tzinfo)
 
-    def test_json_columns_are_serialized_strings(self):
-        row = self.exporter._build_row(_make_span())
-        self.assertEqual(json.loads(row[3]), {"status_code": "OK"})
-        self.assertEqual(json.loads(row[7]), {"monocle_apptrace.version": "0.8.0"})
-        self.assertEqual(json.loads(row[8]), [])
+    def test_status_split_into_code_and_message(self):
+        row = self.exporter._build_row(
+            _make_span(status={"status_code": "ERROR", "message": "boom"}))
+        self.assertEqual(row[C_STATUS_CODE], "ERROR")
+        self.assertEqual(row[C_STATUS_MSG], "boom")
 
-    def test_metadata_is_none(self):
+    def test_status_message_none_when_absent(self):
+        row = self.exporter._build_row(_make_span(status={"status_code": "OK"}))
+        self.assertEqual(row[C_STATUS_CODE], "OK")
+        self.assertIsNone(row[C_STATUS_MSG])
+
+    def test_attributes_is_dict_for_json_column(self):
+        row = self.exporter._build_row(
+            _make_span(attributes={"span.type": "inference"}))
+        self.assertEqual(row[C_ATTRS], {"span.type": "inference"})
+
+    def test_events_is_list_for_array_json_column(self):
+        events = [{"name": "metadata", "attributes": {"total_tokens": 42}}]
+        row = self.exporter._build_row(_make_span(events=events))
+        self.assertEqual(row[C_EVENTS], events)
+
+    def test_metadata_is_empty_dict(self):
         row = self.exporter._build_row(_make_span())
-        self.assertIsNone(row[9])
+        self.assertEqual(row[C_META], {})
 
 
 class TestExport(unittest.TestCase):

--- a/apptrace/tests/unit/test_clickhouse_exporter.py
+++ b/apptrace/tests/unit/test_clickhouse_exporter.py
@@ -18,7 +18,7 @@ from monocle_apptrace.exporters.monocle_exporters import monocle_exporters
 
 # Column positions in the row built by _build_row (mirror of INSERT_COLUMNS).
 C_NAME, C_START, C_END, C_STATUS_CODE, C_STATUS_MSG, \
-    C_SPAN_ID, C_TRACE_ID, C_PARENT_ID, C_ATTRS, C_EVENTS = range(10)
+    C_SPAN_ID, C_TRACE_ID, C_PARENT_ID, C_ATTRS, C_EVENTS, C_METADATA = range(11)
 
 
 def _make_span(name="test-span", trace_id=0xAABBCCDD, span_id=0x1111,
@@ -124,6 +124,11 @@ class TestBuildRow(unittest.TestCase):
         events = [{"name": "metadata", "attributes": {"total_tokens": 42}}]
         row = self.exporter._build_row(_make_span(events=events))
         self.assertEqual(row[C_EVENTS], events)
+
+    def test_metadata_is_empty_dict_reserved_column(self):
+        # metadata column mirrors Postgres: present but reserved (empty) for now.
+        row = self.exporter._build_row(_make_span())
+        self.assertEqual(row[C_METADATA], {})
 
     def test_name_is_first_column(self):
         row = self.exporter._build_row(_make_span(name="my-span"))

--- a/apptrace/tests/unit/test_clickhouse_exporter.py
+++ b/apptrace/tests/unit/test_clickhouse_exporter.py
@@ -1,0 +1,221 @@
+# pylint: disable=protected-access
+import os
+import json
+import datetime
+import unittest
+from importlib import reload
+from unittest.mock import MagicMock, patch
+import pytest
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExportResult
+
+# clickhouse-connect is an optional dependency (installed via the `clickhouse` extra).
+clickhouse_connect = pytest.importorskip("clickhouse_connect")
+from clickhouse_connect.driver.exceptions import DatabaseError, OperationalError
+import monocle_apptrace.exporters.clickhouse.clickhouse_exporter as ch_mod
+from monocle_apptrace.exporters.clickhouse.clickhouse_exporter import ClickHouseSpanExporter
+from monocle_apptrace.exporters.monocle_exporters import monocle_exporters
+
+
+def _make_span(name="test-span", trace_id=0xAABBCCDD, span_id=0x1111,
+               parent_span_id=None):
+    """Build a minimal mock ReadableSpan for use in tests."""
+    span = MagicMock(spec=ReadableSpan)
+    span.name = name
+    span.context = MagicMock()
+    span.context.trace_id = trace_id
+    span.context.span_id = span_id
+    span.parent = None
+    if parent_span_id is not None:
+        span.parent = MagicMock()
+        span.parent.span_id = parent_span_id
+    span.start_time = 1_000_000_000   # 1 s past epoch, in nanoseconds
+    span.end_time   = 2_000_000_000
+    span.attributes = MagicMock()
+    span.attributes.get.return_value = "0.8.0"   # non-empty → not skipped
+    span.to_json.return_value = json.dumps({
+        "name": name,
+        "status": {"status_code": "OK"},
+        "attributes": {"monocle_apptrace.version": "0.8.0"},
+        "events": [],
+    })
+    return span
+
+
+class TestClickHouseRegistry(unittest.TestCase):
+    def test_clickhouse_in_registry(self):
+        self.assertIn("clickhouse", monocle_exporters)
+        entry = monocle_exporters["clickhouse"]
+        self.assertEqual(entry["module"], "monocle_apptrace.exporters.clickhouse.clickhouse_exporter")
+        self.assertEqual(entry["class"], "ClickHouseSpanExporter")
+
+
+class TestClickHouseInit(unittest.TestCase):
+    @patch("clickhouse_connect.get_client")
+    def test_reads_connection_url_from_env(self, mock_get_client):
+        os.environ["MONOCLE_CLICKHOUSE_CONNECTION_URL"] = "clickhouse://user:pass@localhost:8123/db"
+        exporter = ClickHouseSpanExporter()
+        mock_get_client.assert_called_once_with(dsn="clickhouse://user:pass@localhost:8123/db")
+        self.assertIsNotNone(exporter.client)
+        del os.environ["MONOCLE_CLICKHOUSE_CONNECTION_URL"]
+
+    @patch("clickhouse_connect.get_client")
+    def test_raises_when_url_missing(self, mock_get_client):
+        os.environ.pop("MONOCLE_CLICKHOUSE_CONNECTION_URL", None)
+        with self.assertRaises(ValueError):
+            ClickHouseSpanExporter()
+        mock_get_client.assert_not_called()
+
+
+class TestBuildRow(unittest.TestCase):
+    def setUp(self):
+        os.environ["MONOCLE_CLICKHOUSE_CONNECTION_URL"] = "clickhouse://u:p@h:8123/db"
+        with patch("clickhouse_connect.get_client"):
+            reload(ch_mod)
+            self.exporter = ch_mod.ClickHouseSpanExporter()
+
+    def tearDown(self):
+        os.environ.pop("MONOCLE_CLICKHOUSE_CONNECTION_URL", None)
+
+    def test_span_id_has_0x_prefix(self):
+        row = self.exporter._build_row(_make_span(span_id=0xABCDEF0123456789))
+        self.assertEqual(row[4], "0xabcdef0123456789")
+
+    def test_trace_id_has_0x_prefix(self):
+        row = self.exporter._build_row(_make_span(trace_id=0xAABBCCDD11223344AABBCCDD11223344))
+        self.assertTrue(row[5].startswith("0x"))
+
+    def test_parent_id_is_none_for_root_span(self):
+        row = self.exporter._build_row(_make_span())  # no parent
+        self.assertIsNone(row[6])
+
+    def test_parent_id_has_0x_prefix_for_child_span(self):
+        row = self.exporter._build_row(_make_span(parent_span_id=0x1111222233334444))
+        self.assertEqual(row[6], "0x1111222233334444")
+
+    def test_timestamps_are_timezone_aware_datetimes(self):
+        row = self.exporter._build_row(_make_span())
+        self.assertIsInstance(row[1], datetime.datetime)
+        self.assertIsInstance(row[2], datetime.datetime)
+        self.assertIsNotNone(row[1].tzinfo)
+
+    def test_json_columns_are_serialized_strings(self):
+        row = self.exporter._build_row(_make_span())
+        self.assertEqual(json.loads(row[3]), {"status_code": "OK"})
+        self.assertEqual(json.loads(row[7]), {"monocle_apptrace.version": "0.8.0"})
+        self.assertEqual(json.loads(row[8]), [])
+
+    def test_metadata_is_none(self):
+        row = self.exporter._build_row(_make_span())
+        self.assertIsNone(row[9])
+
+
+class TestExport(unittest.TestCase):
+    def setUp(self):
+        os.environ["MONOCLE_CLICKHOUSE_CONNECTION_URL"] = "clickhouse://u:p@h:8123/db"
+        with patch("clickhouse_connect.get_client"):
+            reload(ch_mod)
+            self.exporter = ch_mod.ClickHouseSpanExporter()
+
+    def tearDown(self):
+        os.environ.pop("MONOCLE_CLICKHOUSE_CONNECTION_URL", None)
+
+    def test_export_calls_insert_once_per_batch(self):
+        child = _make_span(span_id=0x2222, parent_span_id=0x1111)
+        root = _make_span(span_id=0x1111)
+
+        result = self.exporter.export([child, root])
+
+        self.assertEqual(result, SpanExportResult.SUCCESS)
+        self.exporter.client.insert.assert_called_once()
+        args, kwargs = self.exporter.client.insert.call_args
+        self.assertEqual(args[0], "traces")
+        self.assertEqual(len(args[1]), 2)
+        self.assertEqual(kwargs["column_names"], ch_mod.INSERT_COLUMNS)
+
+    def test_export_does_not_insert_when_no_rows(self):
+        span = _make_span()
+        span.attributes.get.return_value = None  # triggers skip_export
+
+        result = self.exporter.export([span])
+
+        self.assertEqual(result, SpanExportResult.SUCCESS)
+        self.exporter.client.insert.assert_not_called()
+
+    def test_export_returns_failure_on_exception(self):
+        with patch.object(self.exporter, "skip_export", side_effect=RuntimeError("boom")):
+            result = self.exporter.export([_make_span()])
+        self.assertEqual(result, SpanExportResult.FAILURE)
+
+    def test_bad_span_skipped_good_span_inserted(self):
+        good_span = _make_span(span_id=0x1111)
+        bad_span = _make_span(span_id=0x2222)
+        bad_span.to_json.side_effect = Exception("serialization error")
+
+        self.exporter.export([good_span, bad_span])
+
+        rows = self.exporter.client.insert.call_args[0][1]
+        self.assertEqual(len(rows), 1)
+
+    def test_reconnects_and_retries_on_operational_error(self):
+        call_count = {"n": 0}
+
+        def do_insert_side_effect(_rows):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise OperationalError("server closed connection")
+
+        with patch("clickhouse_connect.get_client") as mock_get_client, \
+                patch.object(self.exporter, "_do_insert", side_effect=do_insert_side_effect):
+            result = self.exporter.export([_make_span()])
+
+        mock_get_client.assert_called()
+        self.assertEqual(call_count["n"], 2)
+        self.assertEqual(result, SpanExportResult.SUCCESS)
+
+
+class TestShutdown(unittest.TestCase):
+    def setUp(self):
+        os.environ["MONOCLE_CLICKHOUSE_CONNECTION_URL"] = "clickhouse://u:p@h:8123/db"
+        with patch("clickhouse_connect.get_client"):
+            reload(ch_mod)
+            self.exporter = ch_mod.ClickHouseSpanExporter()
+
+    def tearDown(self):
+        os.environ.pop("MONOCLE_CLICKHOUSE_CONNECTION_URL", None)
+
+    def test_shutdown_closes_client(self):
+        self.exporter.shutdown()
+        self.exporter.client.close.assert_called()
+
+
+class TestEnsureTable(unittest.TestCase):
+    def setUp(self):
+        os.environ["MONOCLE_CLICKHOUSE_CONNECTION_URL"] = "clickhouse://u:p@h:8123/db"
+
+    def tearDown(self):
+        os.environ.pop("MONOCLE_CLICKHOUSE_CONNECTION_URL", None)
+
+    @patch("clickhouse_connect.get_client")
+    def test_create_table_called_on_init(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        reload(ch_mod)
+        ch_mod.ClickHouseSpanExporter()
+
+        mock_client.command.assert_called_once()
+        self.assertIn("CREATE TABLE IF NOT EXISTS traces",
+                      mock_client.command.call_args[0][0])
+
+    @patch("clickhouse_connect.get_client")
+    def test_permission_error_on_access_denied(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.command.side_effect = DatabaseError("Code: 497. DB::Exception: ACCESS_DENIED")
+        mock_get_client.return_value = mock_client
+
+        reload(ch_mod)
+
+        with self.assertRaises(PermissionError) as ctx:
+            ch_mod.ClickHouseSpanExporter()
+        self.assertIn("lacks CREATE TABLE permission", str(ctx.exception))

--- a/apptrace/tests/unit/test_clickhouse_exporter.py
+++ b/apptrace/tests/unit/test_clickhouse_exporter.py
@@ -18,7 +18,7 @@ from monocle_apptrace.exporters.monocle_exporters import monocle_exporters
 
 # Column positions in the row built by _build_row (mirror of INSERT_COLUMNS).
 C_NAME, C_START, C_END, C_STATUS_CODE, C_STATUS_MSG, \
-    C_SPAN_ID, C_TRACE_ID, C_PARENT_ID, C_ATTRS, C_EVENTS, C_META = range(11)
+    C_SPAN_ID, C_TRACE_ID, C_PARENT_ID, C_ATTRS, C_EVENTS = range(10)
 
 
 def _make_span(name="test-span", trace_id=0xAABBCCDD, span_id=0x1111,
@@ -125,9 +125,9 @@ class TestBuildRow(unittest.TestCase):
         row = self.exporter._build_row(_make_span(events=events))
         self.assertEqual(row[C_EVENTS], events)
 
-    def test_metadata_is_empty_dict(self):
-        row = self.exporter._build_row(_make_span())
-        self.assertEqual(row[C_META], {})
+    def test_name_is_first_column(self):
+        row = self.exporter._build_row(_make_span(name="my-span"))
+        self.assertEqual(row[C_NAME], "my-span")
 
 
 class TestExport(unittest.TestCase):

--- a/docs/Monocle_User_Guide.md
+++ b/docs/Monocle_User_Guide.md
@@ -99,9 +99,13 @@ Supported exporters:
 - `memory` - Store traces in memory (useful for testing)
 - `s3` - Upload traces to AWS S3 bucket
 - `blob` - Upload traces to Azure Blob Storage
+- `gcs` - Upload traces to Google Cloud Storage
 - `okahu` - Send traces to Okahu observability platform
 - `otlp` - Send traces to any OTLP-compatible backend (e.g., Jaeger, Zipkin, Grafana Tempo, OpenTelemetry Collector)
 - `otlp-genai-semconv` - Send traces over OTLP and add OpenTelemetry `gen_ai.*` semantic attributes
+- `postgres` - Write traces to a PostgreSQL `traces` table (set `MONOCLE_POSTGRES_CONNECTION_URL`; install the `postgres` extra)
+- `clickhouse` - Write traces to a ClickHouse `traces` table (set `MONOCLE_CLICKHOUSE_CONNECTION_URL`; install the `clickhouse` extra)
+- `paygentic` - Send traces to Paygentic
 
 Examples:
 ```bash

--- a/docs/Monocle_User_Guide.md
+++ b/docs/Monocle_User_Guide.md
@@ -128,6 +128,22 @@ export MONOCLE_EXPORTER=file,console
 export MONOCLE_EXPORTER=otlp,file
 ```
 
+### Using the ClickHouse Exporter
+The `clickhouse` exporter writes each span to a `traces` table (created on first use). Install the extra and point it at a ClickHouse server:
+
+```bash
+pip install "monocle-apptrace[clickhouse]"
+export MONOCLE_EXPORTER=clickhouse
+
+# Self-hosted (native or HTTP interface)
+export MONOCLE_CLICKHOUSE_CONNECTION_URL="clickhouse://user:pass@host:8123/db"
+
+# ClickHouse Cloud — use the secure endpoint (TLS is required)
+export MONOCLE_CLICKHOUSE_CONNECTION_URL="https://user:pass@your-service.clickhouse.cloud:8443/db"
+```
+
+`attributes` and `metadata` are stored as `JSON`, `events` as `Array(JSON)`, and status as `status_code` / `status_message` columns, so span sub-fields are queryable directly (for example `attributes.\`span.type\``). This requires a ClickHouse version that supports the `JSON` type — a recent self-hosted build, or any current ClickHouse Cloud service. The database user needs `CREATE TABLE` on the first run, or you can pre-create the `traces` table and grant the user insert access.
+
 ### Using OTLP Exporter for OpenTelemetry-Compatible Backends
 The OTLP (OpenTelemetry Protocol) exporter allows you to send traces to any OTLP-compatible collectors.
 


### PR DESCRIPTION
## What this adds

A ClickHouse span exporter, so Monocle traces can be written to a ClickHouse `traces` table. It works like any other exporter:

```bash
pip install "monocle-apptrace[clickhouse]"
export MONOCLE_EXPORTER=clickhouse
export MONOCLE_CLICKHOUSE_CONNECTION_URL="clickhouse://user:pass@host:8123/db"
```

## How it's built

`ClickHouseSpanExporter` subclasses `SpanExporterBase` and reuses the shared helpers (`serialize_span`, the `0x` span/trace id formatting, `skip_export`). It writes one row per span into a `traces` table:

- Client is `clickhouse-connect` over HTTP.
- Table uses `MergeTree ORDER BY (trace_id, span_id)`. ClickHouse has no autoincrement key and needs a sort key.
- JSON fields (`status`, `attributes`, `events`) are stored as `String` columns holding `json.dumps(...)`.
- `parent_id` and `metadata` are `Nullable(String)`; timestamps are `DateTime64(9, 'UTC')`.
- On a dropped connection it reconnects and retries the insert once. A missing-privilege error surfaces as ClickHouse code 497 (`ACCESS_DENIED`) and is raised as a `PermissionError`.

## Not a new required dependency

`clickhouse-connect` is an optional extra under `[project.optional-dependencies]`, like the other optional exporter extras (`aws`, `azure`, `gcp`). Users who don't set `MONOCLE_EXPORTER=clickhouse` install nothing extra and never import it, because the registry imports the exporter module lazily.

## What changed

- New exporter under `apptrace/src/monocle_apptrace/exporters/clickhouse/`
- Registered `clickhouse` in the exporter registry
- New `clickhouse` extra in `apptrace/pyproject.toml`
- Added `clickhouse` to the unit-test CI install, so the exporter's unit tests run in CI instead of skipping on a missing optional dependency

## Tests

Unit tests use a mocked client and need no server:

```bash
pip install "monocle-apptrace[clickhouse]"
pytest apptrace/tests/unit/test_clickhouse_exporter.py
# 18 passed
```

The integration test runs against a real server. The single static ClickHouse binary is enough, no Docker:

```bash
./clickhouse server &        # HTTP on :8123
export MONOCLE_CLICKHOUSE_CONNECTION_URL="clickhouse://default:@localhost:8123/default"
pytest apptrace/tests/integration/test_clickhouse_exporter_integration.py
# 1 passed: "Verified 2 span(s) match between ClickHouse and .monocle for trace 0x..."
```

What the tests assert:

- Unit (18 cases): the exporter registers under the `clickhouse` key; it reads the connection URL from `MONOCLE_CLICKHOUSE_CONNECTION_URL` and raises when it is missing; each built row has `0x`-prefixed ids, timezone-aware timestamps, JSON stored as strings, and null metadata; a batch produces one `insert` call; non-Monocle spans are skipped; a serialization error on one span does not drop the others; a dropped connection triggers one reconnect and retry; shutdown closes the client; init creates the table; a privilege error becomes a `PermissionError`.
- Integration: it exports one trace (a root span and a child span) through both the ClickHouse exporter and the file exporter, reads the rows back from the `traces` table and the spans from the `.monocle` file, and asserts they describe the same trace: the same set of span ids, and for each span the same `name`, `parent_id`, `status`, `attributes`, and `events`.

To look at the rows directly after the integration run:

```bash
./clickhouse client --query "SELECT name, span_id, parent_id FROM traces FORMAT PrettyCompact"
```
