### PR TITLE
feat(test_tools): add AgentCore runner for remotely deployed agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - chore(deps): add `opentelemetry-exporter-otlp-proto-http` as a default dependency so the OTLP exporter works out of the box ([#570](https://github.com/monocle2ai/monocle/issues/570))
 - feat(exporters): add `MONOCLE_CONSOLE` env var to enable console output alongside any configured exporter ([#577](https://github.com/monocle2ai/monocle/pull/577))
 - fix(test_tools): lazy-load `SentenceTransformer` to prevent crash at pytest collection time in network-restricted environments ([#576](https://github.com/monocle2ai/monocle/pull/576))
+- feat(test_tools): add `agentcore` runner to invoke an agent deployed to AWS Bedrock AgentCore Runtime remotely via boto3 `invoke_agent_runtime`, with session-based retrieval of the deployed agent's spans from Okahu
 
 ## Version 0.8.11 (2026-08-03)
 - fix: Disable the second API call that stored evaluation results when `shadow_eval = True`, fixing duplicate eval result storage ([#771](https://github.com/monocle2ai/monocle/pull/771))

--- a/test_tools/README.md
+++ b/test_tools/README.md
@@ -379,6 +379,34 @@ async def test_strands_agent(test_case: TestCase):
     )
 ```
 
+### AWS Bedrock AgentCore
+
+Unlike the other runners, `agentcore` is a *remote* runner: it invokes an agent already deployed to AWS Bedrock AgentCore Runtime via boto3, so no agent framework needs to be installed locally. The agent argument is the deployed agent's Runtime ARN (the endpoint-qualified form is accepted and split automatically):
+
+```python
+ARN = "arn:aws:bedrock-agentcore:us-east-1:<account>:runtime/<agent-id>"
+
+response = monocle_trace_asserter.run_agent(
+    ARN, "agentcore",
+    "Book a flight from San Jose to Seattle for 22 Nov 2026",
+    session_id=f"monocle_test_session_{uuid.uuid4().hex}",
+)
+```
+
+- **Region** is taken from the ARN, so the agent is reached in the region it was deployed to regardless of your local AWS default region.
+- **Payload** sent to the agent is `{"prompt": <message>}`, matching the `BedrockAgentCoreApp` entrypoint contract. Pass a dict to send a different shape verbatim.
+- **Response**: the runner reads the response stream and JSON-decodes it. An agent that returns text (the common case) yields a plain `str`; an agent returning a JSON object yields a `dict`.
+- **`session_id`** is sent as `runtimeSessionId` so the deployed agent keeps conversation context across turns. AWS requires at least 33 characters — Monocle's auto-generated session ids satisfy this, and shorter ids raise a `ValueError` rather than being silently rewritten. Omit it to let AgentCore generate one.
+- **Traces**: spans are produced *inside* the deployed agent and exported by its own Monocle instrumentation, so they are not in the test process. Retrieve them by session — the agent stamps the `runtimeSessionId` onto its spans as `scope.agentic.session`, which Okahu indexes as the `agent_sessions` fact:
+
+```python
+monocle_trace_asserter.with_trace_source(
+    "okahu", id=session_id, fact_name="session", workflow_name="<agent's workflow name>",
+).called_tool("book_flight_tool")
+```
+
+Allow a few seconds for the spans to reach Okahu after the call returns.
+
 ---
 
 ## Offline Testing with Pre-Recorded Traces
@@ -911,6 +939,7 @@ A row must declare an `expected` or `not_expected` label — a guard rail alone 
 | `llamaindex` | LlamaIndex |
 | `strands` | Strands Agents |
 | `msagent` | Microsoft Semantic Kernel / AutoGen |
+| `agentcore` | AWS Bedrock AgentCore Runtime 
 
 ---
 

--- a/test_tools/pyproject.toml
+++ b/test_tools/pyproject.toml
@@ -71,7 +71,8 @@ dev = [
     'google-generativeai>=0.8.5',
     'openai-agents>=0.2.6',
     'crewai==0.95.0',
-    'langchain_openai'
+    'langchain_openai',
+    'boto3==1.42.86'  # AgentCore runner (>=1.42.86 required by bedrock-agentcore 1.6.1)
 ]
 
 all = [

--- a/test_tools/src/monocle_test_tools/runner/agentcore_runner.py
+++ b/test_tools/src/monocle_test_tools/runner/agentcore_runner.py
@@ -1,0 +1,239 @@
+import asyncio
+import json
+import logging
+from typing import Any, Optional, Union
+
+from monocle_test_tools.runner.agent_runner import AgentRunner
+
+logger = logging.getLogger(__name__)
+
+# AWS constrains the InvokeAgentRuntime runtimeSessionId header to 33-256 chars.
+MIN_RUNTIME_SESSION_ID_LENGTH = 33
+MAX_RUNTIME_SESSION_ID_LENGTH = 256
+
+# Separator in the endpoint-qualified ARN form issued by the AgentCore console/CLI.
+_ENDPOINT_MARKER = "/runtime-endpoint/"
+
+DEFAULT_CONTENT_TYPE = "application/json"
+_EVENT_STREAM_CONTENT_TYPE = "text/event-stream"
+_SSE_DATA_PREFIX = "data: "
+
+
+class AgentCoreRunner(AgentRunner):
+    """Runner that invokes an agent already deployed to AWS Bedrock AgentCore Runtime.
+
+    This is a remote runner: ``root_agent`` is the deployed agent's AgentCore
+    Runtime ARN rather than an agent object, and the agent itself runs inside
+    AWS. Only boto3 is needed locally, and it is imported lazily so the runner
+    package stays importable without AWS dependencies installed.
+
+    The request payload is ``{"prompt": <message>}``, matching what a
+    ``BedrockAgentCoreApp`` entrypoint reads via ``payload.get("prompt")``.
+    Pass a dict as the message to send a different shape verbatim.
+
+    Spans are produced inside the deployed agent and exported by its own Monocle
+    instrumentation rather than by this runner, so ``get_remote_traces_source``
+    returns None. They can be retrieved from the trace backend by session id.
+    """
+
+    def __init__(self, client: Any = None, region_name: Optional[str] = None):
+        """
+        Args:
+            client: Optional pre-built boto3 ``bedrock-agentcore`` client. When
+                omitted, one is created lazily on first use.
+            region_name: Optional AWS region for the lazily created client.
+                When omitted, the region is taken from the runtime ARN.
+        """
+        self._client = client
+        self._region_name = region_name
+
+    def _get_client(self, region_hint: Optional[str] = None) -> Any:
+        """Return the boto3 client, creating it on first use.
+
+        boto3 is imported here rather than at module scope to keep AgentCore an
+        optional integration, as the other runners do with their frameworks.
+
+        Region precedence: explicit constructor argument, then the region parsed
+        from the runtime ARN, then boto3's ambient default. The ARN is preferred
+        over the ambient default because an agent only exists in the region its
+        ARN names, and reaching another region's endpoint fails as
+        ResourceNotFoundException.
+        """
+        if self._client is None:
+            try:
+                import boto3
+            except ImportError as e:
+                raise ImportError(
+                    "boto3 is required to use the AgentCore runner. "
+                    "Install it with `pip install boto3`."
+                ) from e
+            region = self._region_name or region_hint
+            kwargs = {"region_name": region} if region else {}
+            self._client = boto3.client("bedrock-agentcore", **kwargs)
+        return self._client
+
+    @staticmethod
+    def _region_from_arn(runtime_arn: str) -> Optional[str]:
+        """Extract the region from an AgentCore Runtime ARN.
+
+        ``arn:aws:bedrock-agentcore:<region>:<account>:runtime/<id>`` -> ``<region>``.
+        Returns None for anything that isn't shaped like an ARN.
+        """
+        parts = runtime_arn.split(":")
+        if len(parts) >= 4 and parts[0] == "arn" and parts[3]:
+            return parts[3]
+        return None
+
+    @staticmethod
+    def _parse_runtime_arn(root_agent: str) -> tuple[str, Optional[str]]:
+        """Split an endpoint-qualified ARN into (runtime ARN, qualifier).
+
+        The console and CLI issue the endpoint form
+        ``arn:...:runtime/<id>/runtime-endpoint/DEFAULT``, while
+        ``invoke_agent_runtime`` expects the runtime ARN with the endpoint name
+        passed separately as ``qualifier``. Plain runtime ARNs are returned
+        unchanged with no qualifier, so AWS applies the default endpoint.
+        """
+        if _ENDPOINT_MARKER in root_agent:
+            runtime_arn, _, qualifier = root_agent.partition(_ENDPOINT_MARKER)
+            return runtime_arn, (qualifier or None)
+        return root_agent, None
+
+    @staticmethod
+    def _validate_session_id(session_id: str) -> None:
+        """Reject a session id AgentCore cannot accept.
+
+        The id is never padded or rewritten: the same value identifies the
+        session in AWS and in the deployed agent's own traces, so substituting a
+        different one would break that correspondence.
+        """
+        if len(session_id) < MIN_RUNTIME_SESSION_ID_LENGTH:
+            raise ValueError(
+                f"session_id {session_id!r} is {len(session_id)} characters, but AWS Bedrock "
+                f"AgentCore requires runtimeSessionId to be at least "
+                f"{MIN_RUNTIME_SESSION_ID_LENGTH} characters. Use a longer session id (for "
+                f"example Monocle's auto-generated 'monocle_test_session_<uuid4 hex>'), or omit "
+                f"session_id to let AgentCore generate one."
+            )
+        if len(session_id) > MAX_RUNTIME_SESSION_ID_LENGTH:
+            raise ValueError(
+                f"session_id is {len(session_id)} characters, but AWS Bedrock AgentCore allows "
+                f"runtimeSessionId of at most {MAX_RUNTIME_SESSION_ID_LENGTH} characters."
+            )
+
+    @staticmethod
+    def _build_payload(test_message: Union[str, dict, Any]) -> bytes:
+        """Encode the test message into the deployed agent's request body."""
+        if isinstance(test_message, dict):
+            body = test_message
+        else:
+            body = {"prompt": test_message}
+        return json.dumps(body).encode("utf-8")
+
+    @staticmethod
+    def _decode_response(response: dict) -> Any:
+        """Read and decode the AgentCore response stream.
+
+        ``response["response"]`` is a botocore StreamingBody and has to be
+        consumed. Server-sent-event responses are reassembled from their
+        ``data:`` lines; everything else is read whole. The result is JSON
+        decoded when possible, so an agent returning text yields a plain str and
+        one returning an object yields a dict, and is returned as raw text
+        otherwise.
+        """
+        stream = response.get("response")
+        if stream is None:
+            return None
+
+        content_type = response.get("contentType") or ""
+        if _EVENT_STREAM_CONTENT_TYPE in content_type:
+            chunks = []
+            for line in stream.iter_lines():
+                if not line:
+                    continue
+                if isinstance(line, bytes):
+                    line = line.decode("utf-8")
+                if line.startswith(_SSE_DATA_PREFIX):
+                    line = line[len(_SSE_DATA_PREFIX):]
+                chunks.append(line)
+            text = "\n".join(chunks)
+        else:
+            raw = stream.read()
+            text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else str(raw)
+
+        try:
+            return json.loads(text)
+        except (ValueError, TypeError):
+            return text
+
+    async def run_agent_async(self, root_agent: str, *args, session_id: str = None,
+                              qualifier: str = None, **kwargs) -> Any:
+        """Invoke a deployed AgentCore agent.
+
+        Args:
+            root_agent: The AgentCore Runtime ARN of the deployed agent. The
+                endpoint-qualified form is accepted and split automatically.
+            *args: The test message; the first positional argument is used.
+            session_id: Monocle session id, sent as ``runtimeSessionId`` so the
+                deployed agent keeps conversation context across turns. Omitted
+                from the request when None, in which case AgentCore generates a
+                session id and returns it.
+            qualifier: Optional AgentCore endpoint name. Takes precedence over a
+                qualifier embedded in ``root_agent``.
+            **kwargs: Extra parameters passed through to ``invoke_agent_runtime``.
+
+        Returns:
+            The decoded agent response — a str for the common case of an agent
+            returning text.
+        """
+        if root_agent is None or not isinstance(root_agent, str):
+            raise ValueError(
+                "For AgentCoreRunner, root_agent must be the AgentCore Runtime ARN string."
+            )
+
+        test_message = args[0] if args else None
+        runtime_arn, arn_qualifier = self._parse_runtime_arn(root_agent)
+
+        request = {
+            "agentRuntimeArn": runtime_arn,
+            "payload": self._build_payload(test_message),
+            "contentType": DEFAULT_CONTENT_TYPE,
+            "accept": DEFAULT_CONTENT_TYPE,
+        }
+
+        effective_qualifier = qualifier or arn_qualifier
+        if effective_qualifier:
+            request["qualifier"] = effective_qualifier
+
+        if session_id is not None:
+            self._validate_session_id(session_id)
+            request["runtimeSessionId"] = session_id
+
+        request.update(kwargs)
+
+        # AWS errors are left to propagate so the framework's expect_errors
+        # handling sees a real failure rather than an error string as a response.
+        client = self._get_client(region_hint=self._region_from_arn(runtime_arn))
+        response = client.invoke_agent_runtime(**request)
+        logger.debug(f"AgentCore response statusCode={response.get('statusCode')}")
+        return self._decode_response(response)
+
+    def run_agent(self, root_agent: str, *args, session_id: str = None,
+                  qualifier: str = None, **kwargs) -> Any:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop and loop.is_running():
+            import concurrent.futures
+            with concurrent.futures.ThreadPoolExecutor() as pool:
+                future = pool.submit(
+                    asyncio.run,
+                    self.run_agent_async(root_agent, *args, session_id=session_id,
+                                         qualifier=qualifier, **kwargs),
+                )
+                return future.result()
+        return asyncio.run(
+            self.run_agent_async(root_agent, *args, session_id=session_id,
+                                 qualifier=qualifier, **kwargs)
+        )

--- a/test_tools/src/monocle_test_tools/runner/runner.py
+++ b/test_tools/src/monocle_test_tools/runner/runner.py
@@ -11,6 +11,7 @@ class AgentTypes(str, Enum):
     MSAGENT = "msagent"
     HTTP = "http"
     HTTP_WITH_OKAHU = "http_with_okahu"
+    AGENTCORE = "agentcore"
 
 def get_agent_runner(runner_type: str) -> AgentRunner:
     if runner_type == AgentTypes.GOOGLE_ADK:
@@ -40,5 +41,8 @@ def get_agent_runner(runner_type: str) -> AgentRunner:
     elif runner_type == AgentTypes.HTTP_WITH_OKAHU:
         from .http_runner import HttpOkahuRunner
         return HttpOkahuRunner()
+    elif runner_type == AgentTypes.AGENTCORE:
+        from .agentcore_runner import AgentCoreRunner
+        return AgentCoreRunner()
     else:
         raise ValueError(f"Unknown runner type: {runner_type}")

--- a/test_tools/tests/integration/test_agentcore_remote_agent.py
+++ b/test_tools/tests/integration/test_agentcore_remote_agent.py
@@ -1,0 +1,138 @@
+"""Live integration test against an agent deployed to AWS Bedrock AgentCore Runtime.
+
+Requires a deployed AgentCore agent and AWS credentials, so it is skipped unless
+``AGENTCORE_RUNTIME_URL`` is set. Both the plain runtime ARN and the
+endpoint-qualified form are accepted:
+
+    export AGENTCORE_RUNTIME_URL=arn:aws:bedrock-agentcore:<region>:<account>:runtime/<agent-id>
+
+The AWS region is taken from the ARN, so no region variable is needed.
+
+The span test additionally needs ``AGENTCORE_TRACE_WORKFLOW`` (the Okahu
+workflow the deployed agent exports under) and an ``OKAHU_API_KEY`` for the
+tenant receiving those traces.
+"""
+import os
+import time
+import uuid
+
+import pytest
+import requests
+from dotenv import load_dotenv
+
+from monocle_test_tools import TraceAssertion
+
+load_dotenv()
+
+AGENTCORE_RUNTIME_URL = os.getenv("AGENTCORE_RUNTIME_URL")
+AGENTCORE_TRACE_WORKFLOW = os.getenv("AGENTCORE_TRACE_WORKFLOW")
+
+# Spans are exported from inside AWS, so they land in Okahu a little after the
+# call returns.
+TRACE_WAIT_SECONDS = 120
+TRACE_POLL_SECONDS = 5
+
+pytestmark = pytest.mark.skipif(
+    not AGENTCORE_RUNTIME_URL,
+    reason="AGENTCORE_RUNTIME_URL is not set; requires a deployed AgentCore agent and AWS credentials.",
+)
+
+
+def _session_id() -> str:
+    return f"monocle_test_session_{uuid.uuid4().hex}"
+
+
+def _load_session_spans(asserter: TraceAssertion, session_id: str) -> None:
+    """Load the deployed agent's spans for a session, waiting for them to arrive.
+
+    The agent stamps the ``runtimeSessionId`` it was invoked with onto its spans
+    as ``scope.agentic.session``, which Okahu indexes as the ``agent_sessions``
+    fact — so the session id generated here is enough to find them.
+    """
+    deadline = time.monotonic() + TRACE_WAIT_SECONDS
+    last_error = None
+    while time.monotonic() < deadline:
+        try:
+            asserter.with_trace_source(
+                "okahu", id=session_id, fact_name="session",
+                workflow_name=AGENTCORE_TRACE_WORKFLOW,
+            )
+            return
+        except requests.HTTPError as exc:
+            # 4xx other than "not found yet" means the query itself is rejected
+            # (e.g. the tenant has no agent_sessions fact) — retrying cannot help.
+            status = getattr(exc.response, "status_code", None)
+            if status is not None and 400 <= status < 500 and status != 404:
+                raise AssertionError(
+                    f"Okahu rejected the session lookup for workflow "
+                    f"'{AGENTCORE_TRACE_WORKFLOW}' (HTTP {status}): "
+                    f"{getattr(exc.response, 'text', '')[:200]}"
+                ) from exc
+            last_error = exc
+            time.sleep(TRACE_POLL_SECONDS)
+        except ConnectionError as exc:
+            last_error = exc
+            time.sleep(TRACE_POLL_SECONDS)
+    raise AssertionError(
+        f"No spans for session '{session_id}' appeared in Okahu workflow "
+        f"'{AGENTCORE_TRACE_WORKFLOW}' within {TRACE_WAIT_SECONDS}s: {last_error}"
+    )
+
+
+def test_agentcore_remote_agent_response(monocle_trace_asserter: TraceAssertion):
+    """End-to-end: prompt in, the deployed agent's text answer out."""
+    response = monocle_trace_asserter.run_agent(
+        AGENTCORE_RUNTIME_URL,
+        "agentcore",
+        "Book a flight from San Jose to Seattle for 22 oct 2026",
+        session_id=_session_id(),
+    )
+
+    assert isinstance(response, str), f"expected a str response, got {type(response).__name__}"
+    assert "San Jose" in response
+    assert "Seattle" in response
+
+
+def test_agentcore_remote_agent_rejects_short_session_id(monocle_trace_asserter: TraceAssertion):
+    """A session id shorter than AgentCore's minimum fails fast and clearly."""
+    with pytest.raises(ValueError, match="33"):
+        monocle_trace_asserter.run_agent(
+            AGENTCORE_RUNTIME_URL,
+            "agentcore",
+            "Book a flight from San Jose to Seattle for 22 Nov 2026",
+            session_id="short_session",
+        )
+
+
+@pytest.mark.skipif(
+    not AGENTCORE_TRACE_WORKFLOW,
+    reason="AGENTCORE_TRACE_WORKFLOW is not set; requires an Okahu API key for the tenant "
+           "the deployed agent exports to.",
+)
+def test_agentcore_remote_agent_response_and_spans(monocle_trace_asserter: TraceAssertion):
+    """Response plus the spans the deployed agent produced for that same call.
+
+    The runner itself emits no spans — everything asserted here was produced
+    inside the deployed agent and retrieved from Okahu by session id.
+    """
+    session_id = _session_id()
+
+    response = monocle_trace_asserter.run_agent(
+        AGENTCORE_RUNTIME_URL,
+        "agentcore",
+        "Book a flight from San Jose to Seattle for 22 Oct 2026",
+        session_id=session_id,
+    )
+
+    assert isinstance(response, str), f"expected a str response, got {type(response).__name__}"
+    assert "Seattle" in response
+
+    _load_session_spans(monocle_trace_asserter, session_id)
+
+    monocle_trace_asserter.called_agent("agc_travel_agent")
+    monocle_trace_asserter.called_tool("book_flight_tool")
+    monocle_trace_asserter.has_scope("agentic.session", session_id)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/test_tools/tests/unit/test_agentcore_runner.py
+++ b/test_tools/tests/unit/test_agentcore_runner.py
@@ -1,0 +1,267 @@
+"""Unit tests for the AgentCore runner.
+
+All tests use an injected fake boto3 client and a fake StreamingBody, so they
+run without boto3, AWS credentials, or any network access.
+"""
+import json
+
+import pytest
+
+from monocle_test_tools.runner.runner import get_agent_runner, AgentTypes
+from monocle_test_tools.runner.agentcore_runner import AgentCoreRunner
+
+RUNTIME_ARN = "arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/test_agent-AbCdEfGhIj"
+ENDPOINT_ARN = RUNTIME_ARN + "/runtime-endpoint/DEFAULT"
+# Same shape as Monocle's auto-generated session ids, which clear AgentCore's minimum.
+VALID_SESSION_ID = "monocle_test_session_" + "a" * 32
+
+
+class FakeStream:
+    """Stand-in for a botocore StreamingBody."""
+
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def read(self):
+        return self._body
+
+    def iter_lines(self, chunk_size=None):
+        for line in self._body.split(b"\n"):
+            yield line
+
+
+class FakeClient:
+    """Records the request and returns a canned AgentCore response."""
+
+    def __init__(self, body: bytes = b'"Booked."', content_type: str = "application/json",
+                 raise_error: Exception = None):
+        self.body = body
+        self.content_type = content_type
+        self.raise_error = raise_error
+        self.last_request = None
+        self.call_count = 0
+
+    def invoke_agent_runtime(self, **kwargs):
+        self.call_count += 1
+        self.last_request = kwargs
+        if self.raise_error is not None:
+            raise self.raise_error
+        return {
+            "response": FakeStream(self.body),
+            "contentType": self.content_type,
+            "statusCode": 200,
+            "runtimeSessionId": kwargs.get("runtimeSessionId", "generated-by-aws"),
+        }
+
+
+def test_agent_type_mapping():
+    assert isinstance(get_agent_runner(AgentTypes.AGENTCORE), AgentCoreRunner)
+    assert AgentTypes.AGENTCORE == "agentcore"
+
+
+def test_invokes_with_arn_payload_and_session():
+    client = FakeClient()
+    runner = AgentCoreRunner(client=client)
+
+    result = runner.run_agent(RUNTIME_ARN, "Book a flight", session_id=VALID_SESSION_ID)
+
+    request = client.last_request
+    assert request["agentRuntimeArn"] == RUNTIME_ARN
+    assert request["runtimeSessionId"] == VALID_SESSION_ID
+    assert json.loads(request["payload"].decode("utf-8")) == {"prompt": "Book a flight"}
+    assert request["contentType"] == "application/json"
+    # A plain runtime ARN carries no qualifier, so AWS applies the default endpoint.
+    assert "qualifier" not in request
+    assert result == "Booked."
+
+
+def test_endpoint_qualified_arn_is_split():
+    client = FakeClient()
+    runner = AgentCoreRunner(client=client)
+
+    runner.run_agent(ENDPOINT_ARN, "hi", session_id=VALID_SESSION_ID)
+
+    assert client.last_request["agentRuntimeArn"] == RUNTIME_ARN
+    assert client.last_request["qualifier"] == "DEFAULT"
+
+
+def test_explicit_qualifier_wins_over_arn():
+    client = FakeClient()
+    runner = AgentCoreRunner(client=client)
+
+    runner.run_agent(ENDPOINT_ARN, "hi", session_id=VALID_SESSION_ID, qualifier="prod")
+
+    assert client.last_request["qualifier"] == "prod"
+
+
+def test_session_id_omitted_when_not_provided():
+    client = FakeClient()
+    runner = AgentCoreRunner(client=client)
+
+    runner.run_agent(RUNTIME_ARN, "hi")
+
+    # Omitting the parameter lets AgentCore generate the session id.
+    assert "runtimeSessionId" not in client.last_request
+
+
+def test_short_session_id_raises_without_padding():
+    client = FakeClient()
+    runner = AgentCoreRunner(client=client)
+
+    with pytest.raises(ValueError) as excinfo:
+        runner.run_agent(RUNTIME_ARN, "hi", session_id="monocle_test_session")
+
+    message = str(excinfo.value)
+    assert "33" in message
+    # The id must be surfaced, not silently rewritten, and no call is made.
+    assert "monocle_test_session" in message
+    assert client.call_count == 0
+
+
+def test_monocle_generated_session_id_is_accepted():
+    client = FakeClient()
+    runner = AgentCoreRunner(client=client)
+
+    runner.run_agent(RUNTIME_ARN, "hi", session_id=VALID_SESSION_ID)
+
+    assert len(VALID_SESSION_ID) >= 33
+    assert client.last_request["runtimeSessionId"] == VALID_SESSION_ID
+
+
+def test_dict_message_is_sent_verbatim():
+    client = FakeClient()
+    runner = AgentCoreRunner(client=client)
+
+    runner.run_agent(RUNTIME_ARN, {"prompt": "hi", "locale": "en"}, session_id=VALID_SESSION_ID)
+
+    assert json.loads(client.last_request["payload"].decode("utf-8")) == {
+        "prompt": "hi", "locale": "en"
+    }
+
+
+def test_decodes_json_object_response():
+    client = FakeClient(body=json.dumps({"response": "Booked."}).encode("utf-8"))
+    runner = AgentCoreRunner(client=client)
+
+    assert runner.run_agent(RUNTIME_ARN, "hi") == {"response": "Booked."}
+
+
+def test_decodes_event_stream_response():
+    body = b'data: Hello\ndata: world\n'
+    client = FakeClient(body=body, content_type="text/event-stream")
+    runner = AgentCoreRunner(client=client)
+
+    assert runner.run_agent(RUNTIME_ARN, "hi") == "Hello\nworld"
+
+
+def test_non_json_body_returned_as_text():
+    client = FakeClient(body=b"plain text reply")
+    runner = AgentCoreRunner(client=client)
+
+    assert runner.run_agent(RUNTIME_ARN, "hi") == "plain text reply"
+
+
+def test_aws_errors_propagate():
+    class AccessDeniedException(Exception):
+        pass
+
+    client = FakeClient(raise_error=AccessDeniedException("not authorized"))
+    runner = AgentCoreRunner(client=client)
+
+    # The failure must surface rather than be returned as the agent's reply.
+    with pytest.raises(AccessDeniedException):
+        runner.run_agent(RUNTIME_ARN, "hi")
+
+
+def test_rejects_non_arn_root_agent():
+    runner = AgentCoreRunner(client=FakeClient())
+
+    with pytest.raises(ValueError):
+        runner.run_agent(None, "hi")
+
+
+@pytest.mark.asyncio
+async def test_run_agent_async_returns_decoded_response():
+    client = FakeClient()
+    runner = AgentCoreRunner(client=client)
+
+    result = await runner.run_agent_async(RUNTIME_ARN, "hi", session_id=VALID_SESSION_ID)
+
+    assert result == "Booked."
+    assert client.last_request["runtimeSessionId"] == VALID_SESSION_ID
+
+
+@pytest.mark.asyncio
+async def test_run_agent_works_inside_a_running_loop():
+    """run_agent falls back to a worker thread when a loop is already running."""
+    client = FakeClient()
+    runner = AgentCoreRunner(client=client)
+
+    assert runner.run_agent(RUNTIME_ARN, "hi") == "Booked."
+
+
+def test_injected_client_is_reused_across_calls():
+    client = FakeClient()
+    runner = AgentCoreRunner(client=client)
+
+    runner.run_agent(RUNTIME_ARN, "one")
+    runner.run_agent(RUNTIME_ARN, "two")
+
+    assert client.call_count == 2
+    assert runner._get_client() is client
+
+
+def test_region_parsed_from_arn():
+    assert AgentCoreRunner._region_from_arn(RUNTIME_ARN) == "us-west-2"
+    assert AgentCoreRunner._region_from_arn(
+        "arn:aws:bedrock-agentcore:us-east-1:123456789012:runtime/test_agent-AbCdEfGhIj"
+    ) == "us-east-1"
+    assert AgentCoreRunner._region_from_arn("not-an-arn") is None
+
+
+def test_client_is_built_in_the_arn_region(monkeypatch):
+    """The ARN's region wins over boto3's ambient default region.
+
+    Without this, an agent deployed outside the caller's default region is
+    reached at the wrong regional endpoint and fails as ResourceNotFoundException.
+    """
+    boto3 = pytest.importorskip("boto3")
+    captured = {}
+
+    def fake_client(service_name, **kwargs):
+        captured["service_name"] = service_name
+        captured["region_name"] = kwargs.get("region_name")
+        return FakeClient()
+
+    monkeypatch.setattr(boto3, "client", fake_client)
+
+    AgentCoreRunner().run_agent(RUNTIME_ARN, "hi")
+
+    assert captured["service_name"] == "bedrock-agentcore"
+    assert captured["region_name"] == "us-west-2"
+
+
+def test_explicit_region_overrides_arn_region(monkeypatch):
+    boto3 = pytest.importorskip("boto3")
+    captured = {}
+
+    monkeypatch.setattr(
+        boto3, "client",
+        lambda service_name, **kw: captured.update(region_name=kw.get("region_name")) or FakeClient(),
+    )
+
+    AgentCoreRunner(region_name="eu-west-1").run_agent(RUNTIME_ARN, "hi")
+
+    assert captured["region_name"] == "eu-west-1"
+
+
+def test_remote_trace_hooks_are_inert():
+    """The runner does not correlate the deployed agent's spans back to the test."""
+    runner = AgentCoreRunner(client=FakeClient())
+
+    assert runner.get_remote_traces_source() is None
+    assert runner.get_remote_spans() == []
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
Add an `agentcore` runner that invokes an agent already deployed to AWS Bedrock AgentCore Runtime via boto3 `invoke_agent_runtime`. Unlike the framework runners, the agent runs inside AWS, so no agent framework needs to be installed locally — only boto3, imported lazily to keep it optional.

- `root_agent` is the deployed agent's Runtime ARN; the endpoint-qualified form is split into ARN + qualifier automatically.
- The AWS region is taken from the ARN, so an agent deployed outside the caller's default region is reached correctly. botocore resolves its default region from AWS_DEFAULT_REGION only, so relying on the ambient region surfaces as a misleading ResourceNotFoundException.
- Payload is `{"prompt": <message>}`, matching the BedrockAgentCoreApp entrypoint contract; a dict message is sent verbatim.
- The response stream is consumed and JSON decoded, handling both application/json and text/event-stream.
- `session_id` is sent as `runtimeSessionId`. It is validated against AWS's 33-character minimum and never padded or rewritten, since the same value identifies the session in the deployed agent's own traces.
- AWS errors propagate instead of being returned as response strings.

Spans are produced inside the deployed agent and exported by its own Monocle instrumentation, so `get_remote_traces_source()` stays None and the spans are retrieved by session id via `with_trace_source(...)`.

Tests: 20 unit tests using an injected fake boto3 client (no AWS credentials or network; the two region tests skip when boto3 is absent), plus 3 env-gated live integration tests covering the response and the deployed agent's spans retrieved from Okahu by session.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...