### PR TITLE
Auto-number turns in run_agent_async and cover turn_id with fluent ha…

### DIFF
--- a/test_tools/README.md
+++ b/test_tools/README.md
@@ -180,6 +180,14 @@ Each turn is an ordinary `TestCase`, so per-turn `test_output`, `test_spans`, an
 ]
 ```
 
+This works with the fluent API too. If you run each turn as a separate `run_agent_async` call with the same `session_id`, the turns are numbered (`"1"`, `"2"`, ...). Then check a turn with `has_scope`:
+
+```python
+await monocle_trace_asserter.run_agent_async(agent, "langgraph", "Book me a flight for 26th Nov 2025.", session_id="s")  # turn "1"
+await monocle_trace_asserter.run_agent_async(agent, "langgraph", "Fly to Mumbai.", session_id="s")                      # turn "2"
+
+monocle_trace_asserter.called_tool("adk_book_flight").has_scope("turn_id", "2")   # booked in turn 2
+```
 **Chaining turn output into the next input.** Use the `{previous_output}` placeholder in a later turn's `test_input` to feed the prior turn's result forward:
 
 ```python

--- a/test_tools/src/monocle_test_tools/validator.py
+++ b/test_tools/src/monocle_test_tools/validator.py
@@ -69,6 +69,9 @@ class MonocleValidator:
         self._trace_source_fact_id: Optional[str] = None
         self._trace_source_fact_name: Optional[str] = None
         self._trace_source_workflow_name: Optional[str] = None
+        # Per-session run_agent_async count, used to default an unset turn_id to
+        # the next 1-based turn index for that session. Reset per test.
+        self._session_turn_counters: dict[str, int] = {}
         test_trace_path:str = os.path.join(".", DEFAULT_TRACE_FOLDER, "test_traces")
         os.environ["MONOCLE_TRACE_OUTPUT_PATH"] = test_trace_path
         if exporter_list is None:
@@ -110,6 +113,7 @@ class MonocleValidator:
         self._trace_source_fact_id = None
         self._trace_source_fact_name = None
         self._trace_source_workflow_name = None
+        self._session_turn_counters = {}
 
     @property
     def spans(self):
@@ -405,6 +409,12 @@ class MonocleValidator:
         if agent_runner is None:
             raise ValueError(f"Unsupported agent type: {agent_type}")
         mock_tool_token = None
+        # Unset turn_id defaults to the next 1-based turn index for this session
+        # (tags scope.turn_id on repeated run_agent_async calls). No session_id
+        # means a single turn, left untagged.
+        if turn_id is None and session_id is not None:
+            self._session_turn_counters[session_id] = self._session_turn_counters.get(session_id, 0) + 1
+            turn_id = str(self._session_turn_counters[session_id])
         turn_token = start_scopes({TURN_SCOPE_NAME: turn_id}) if turn_id is not None else None
         try:
             context = self._set_wrapper_methods(mock_tools)
@@ -502,6 +512,7 @@ class MonocleValidator:
             for index, turn in enumerate(multi_turn_case.turns, start=1):
                 self.clear_spans()
                 turn_id = turn.turn_id if turn.turn_id is not None else str(index)
+                turn.turn_id = turn_id  
                 turn_token = start_scopes({TURN_SCOPE_NAME: turn_id})
                 mock_tool_token = None
                 turn_input = self._chain_turn_input(turn.test_input, previous_output)

--- a/test_tools/tests/integration/test_multi_turn_runner.py
+++ b/test_tools/tests/integration/test_multi_turn_runner.py
@@ -19,9 +19,11 @@ import os
 import pytest
 
 from monocle_test_tools import MonocleValidator, MultiTurnTestCase
+from monocle_test_tools.fluent_api import TraceAssertion
 from monocle_test_tools.runner.agent_runner import AgentRunner
 import monocle_test_tools.validator as validator_module
 from monocle_test_tools.file_span_loader import JSONSpanLoader
+from monocle_apptrace.instrumentation.common.utils import get_scopes
 
 
 def _load_spans():
@@ -106,6 +108,81 @@ async def test_multi_turn_auto_assigns_session_id(monkeypatch):
     assert mtc.session_id is not None
     assert fake.session_ids_seen == [mtc.session_id]
 
+    validator.cleanup()
+
+
+@pytest.fixture(autouse=True)
+def _reset_trace_assertion_state():
+    """Keep the class-level assertion list clean around the fluent tests below."""
+    TraceAssertion._assertion_errors = []
+    yield
+    TraceAssertion._assertion_errors = []
+
+
+class TurnStampingRunner(AgentRunner):
+    """Emits one span per call, tagged with the active turn_id scope — the same
+    thing the SpanHandler does at runtime — so fluent has_scope can read it back."""
+
+    def __init__(self, validator, spans):
+        self._validator = validator
+        self._spans = list(spans)
+        self._i = 0
+
+    async def run_agent_async(self, root_agent, *args, session_id: str = None):
+        span = self._spans[self._i]
+        self._i += 1
+        turn_id = get_scopes("turn_id").get("turn_id")
+        if turn_id is not None:
+            span._attributes["scope.turn_id"] = turn_id
+        self._validator.memory_exporter.export([span])
+        return "ok"
+
+
+@pytest.mark.asyncio
+async def test_auto_turn_id_readable_with_has_scope(monkeypatch):
+    """Two run_agent_async calls in one session tag their spans turn "1" and "2",
+    read back with the same fluent has_scope agent tests use."""
+    validator = MonocleValidator()
+    validator.cleanup()
+    monkeypatch.setattr(validator_module, "get_agent_runner",
+                        lambda t: TurnStampingRunner(validator, _load_spans()))
+
+    await validator.run_agent_async(None, "fake", "turn one", session_id="s")
+    await validator.run_agent_async(None, "fake", "turn two", session_id="s")
+
+    asserter = TraceAssertion(filtered_spans=list(validator.spans))
+    assert not asserter.has_scope("turn_id", "1").is_assertion_failed
+    assert not asserter.has_scope("turn_id", "2").is_assertion_failed
+    validator.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_explicit_turn_id_readable_with_has_scope(monkeypatch):
+    """An explicit turn_id is used as-is."""
+    validator = MonocleValidator()
+    validator.cleanup()
+    monkeypatch.setattr(validator_module, "get_agent_runner",
+                        lambda t: TurnStampingRunner(validator, _load_spans()))
+
+    await validator.run_agent_async(None, "fake", "x", session_id="s", turn_id="book")
+
+    asserter = TraceAssertion(filtered_spans=list(validator.spans))
+    assert not asserter.has_scope("turn_id", "book").is_assertion_failed
+    validator.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_no_session_has_no_turn_scope(monkeypatch):
+    """A run with no session_id is a single turn: its spans carry no turn_id."""
+    validator = MonocleValidator()
+    validator.cleanup()
+    monkeypatch.setattr(validator_module, "get_agent_runner",
+                        lambda t: TurnStampingRunner(validator, _load_spans()))
+
+    await validator.run_agent_async(None, "fake", "just one")
+
+    asserter = TraceAssertion(filtered_spans=list(validator.spans))
+    assert not asserter.does_not_have_scope("turn_id").is_assertion_failed
     validator.cleanup()
 
 


### PR DESCRIPTION
…s_scope tests

Follow-up to #775: the default 1-based turn_id existed only in the multi-turn runner. run_agent_async (the fluent path) left an unset turn_id untagged. Add a per-session turn counter so repeated run_agent_async calls that share a session_id auto-number turns ("1", "2", ...), matching the documented default. Also persist the resolved turn id back onto the turn in the runner, add fluent has_scope tests, and document the fluent path in the README.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...