### PR TITLE
Shambhavi/agentcore session traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - feat(exporters): add `MONOCLE_CONSOLE` env var to enable console output alongside any configured exporter ([#577](https://github.com/monocle2ai/monocle/pull/577))
 - fix(test_tools): lazy-load `SentenceTransformer` to prevent crash at pytest collection time in network-restricted environments ([#576](https://github.com/monocle2ai/monocle/pull/576))
 - feat(test_tools): add `agentcore` runner to invoke an agent deployed to AWS Bedrock AgentCore Runtime remotely via boto3 `invoke_agent_runtime`, with session-based retrieval of the deployed agent's spans from Okahu
+- feat(test_tools): runners can identify their remote spans by a fact other than the trace id via `AgentRunner.get_remote_trace_query()`; the `agentcore` runner uses it to correlate the deployed agent's spans by the AgentCore session, so existing assertions apply to them
 
 ## Version 0.8.11 (2026-08-03)
 - fix: Disable the second API call that stored evaluation results when `shadow_eval = True`, fixing duplicate eval result storage ([#771](https://github.com/monocle2ai/monocle/pull/771))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - fix(test_tools): lazy-load `SentenceTransformer` to prevent crash at pytest collection time in network-restricted environments ([#576](https://github.com/monocle2ai/monocle/pull/576))
 - feat(test_tools): add `agentcore` runner to invoke an agent deployed to AWS Bedrock AgentCore Runtime remotely via boto3 `invoke_agent_runtime`, with session-based retrieval of the deployed agent's spans from Okahu
 - feat(test_tools): runners can identify their remote spans by a fact other than the trace id via `AgentRunner.get_remote_trace_query()`; the `agentcore` runner uses it to correlate the deployed agent's spans by the AgentCore session, so existing assertions apply to them
+- feat: an agent deployed to AWS Bedrock AgentCore returns its spans in the invocation response when `MONOCLE_ENABLE_TRACE_RETURN` is set, and the `agentcore` runner strips them off before the caller sees the response — no trace backend needed. Falls back to session-based retrieval when the deployed agent does not return them
 
 ## Version 0.8.11 (2026-08-03)
 - fix: Disable the second API call that stored evaluation results when `shadow_eval = True`, fixing duplicate eval result storage ([#771](https://github.com/monocle2ai/monocle/pull/771))

--- a/apptrace/src/monocle_apptrace/instrumentation/common/wrapper_method.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/common/wrapper_method.py
@@ -37,6 +37,7 @@ from monocle_apptrace.instrumentation.metamodel.gemini.methods import GEMINI_MET
 from monocle_apptrace.instrumentation.metamodel.fastapi.methods import FASTAPI_METHODS
 from monocle_apptrace.instrumentation.metamodel.fastapi._helper import FastAPISpanHandler, FastAPIResponseSpanHandler
 from monocle_apptrace.instrumentation.metamodel.fastmcp.methods import FASTMCP_METHODS
+from monocle_apptrace.instrumentation.metamodel.agentcore.agentcore_handler import AgentCoreSpanHandler
 from monocle_apptrace.instrumentation.metamodel.lambdafunc._helper import lambdaSpanHandler
 from monocle_apptrace.instrumentation.metamodel.lambdafunc.methods import LAMBDA_HTTP_METHODS
 from monocle_apptrace.instrumentation.metamodel.mcp.methods import MCP_METHODS
@@ -168,6 +169,7 @@ MONOCLE_SPAN_HANDLERS: Dict[str, SpanHandler] = {
     "llamaindex_workflow_handler": LlamaIndexWorkflowHandler(),
     "llamaindex_single_agent_tool_handler": LlamaIndexSingleAgenttToolHandlerWrapper(),
     "lambda_func_handler": lambdaSpanHandler(),
+    "agentcore_handler": AgentCoreSpanHandler(),
     "adk_handler": AdkSpanHandler(),
     "strands_handler": StrandsSpanHandler(),
     "claude_handler": ClaudeSpanHandler(),

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/agentcore/agentcore_handler.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/agentcore/agentcore_handler.py
@@ -1,0 +1,85 @@
+import logging
+
+from monocle_apptrace.instrumentation.common.constants import (
+    TRACE_RETURN_RESPONSE_HEADER,
+    TRACE_RETURN_SCOPE_NAME,
+)
+from monocle_apptrace.instrumentation.common import trace_return as tr
+from monocle_apptrace.instrumentation.common.span_handler import SpanHandler
+from monocle_apptrace.instrumentation.common.utils import (
+    get_current_monocle_span,
+    remove_scopes,
+    set_scopes,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["AgentCoreSpanHandler"]
+
+
+class AgentCoreSpanHandler(SpanHandler):
+    """Returns an invocation's spans to the caller inside the AgentCore response.
+
+    Same idea as the HTTP trace-return path, adapted to how AgentCore builds a
+    response. FastAPI appends the trailer to the response body as it is sent;
+    AgentCore serializes whatever the entrypoint returned, so there is no such
+    hook. The trailer is instead appended to the ``Response`` object that
+    ``_handle_invocation`` produces, which happens after serialization and is
+    mutable — the same shape the Lambda handler uses on its response dict.
+
+    Unlike the HTTP path there is no per-request authorization: boto3 can only
+    send parameters AgentCore models, so a caller cannot supply the
+    ``x-monocle-retrieve-traces`` header. Returning traces is therefore opt-in
+    on the deployment itself through ``MONOCLE_ENABLE_TRACE_RETURN``, which only
+    whoever deploys the agent controls, and IAM already governs who may invoke
+    it at all.
+    """
+
+    def pre_tracing(self, to_wrap, wrapped, instance, args, kwargs):
+        """Tag this invocation's spans so the trace-return exporter keeps them.
+
+        The scope has to be active while the agent runs, which is why this hooks
+        ``_handle_invocation`` (the caller) rather than the entrypoint itself.
+        """
+        if not tr.is_trace_return_enabled():
+            return None, None
+        return set_scopes({TRACE_RETURN_SCOPE_NAME: "true"}), None
+
+    def post_tracing(self, to_wrap, wrapped, instance, args, kwargs, return_value, token=None):
+        if token is not None:
+            remove_scopes(token)
+
+    def post_task_processing(self, to_wrap, wrapped, instance, args, kwargs, result, ex, span, parent_span):
+        try:
+            self._inject_trailer(result, span)
+        except Exception as e:
+            # Returning traces is a diagnostic convenience; never let it affect
+            # the response the agent actually produced.
+            logger.debug(f"agentcore trace-return injection skipped: {e}")
+        super().post_task_processing(to_wrap, wrapped, instance, args, kwargs, result, ex, span, parent_span)
+
+    @staticmethod
+    def _inject_trailer(result, span) -> None:
+        """Append the trailer to a buffered Response, leaving its body otherwise intact.
+
+        Skipped for streaming responses, which have no ``body`` to extend, and
+        when this trace produced no captured spans.
+        """
+        if not tr.is_trace_return_enabled():
+            return
+        body = getattr(result, "body", None)
+        if not isinstance(body, (bytes, bytearray)):
+            return
+
+        current_span = span if span is not None else get_current_monocle_span()
+        trace_id = current_span.get_span_context().trace_id if current_span is not None else 0
+        payload = tr.get_response_trailer(trace_id)
+        if payload is None:
+            return
+        header_value, trailer = payload
+
+        result.body = bytes(body) + trailer
+        # Starlette fixed Content-Length when the Response was built, so it has
+        # to be corrected or the trailer is truncated off the wire.
+        result.headers["content-length"] = str(len(result.body))
+        result.headers[TRACE_RETURN_RESPONSE_HEADER] = header_value

--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/agentcore/methods.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/agentcore/methods.py
@@ -8,5 +8,18 @@ AGENTCORE_METHODS = [
         "method": "_invoke_handler",
         "wrapper_method": atask_wrapper,
         "output_processor": AGENTCORE_PROCESSOR
+    },
+    {
+        # Wraps the caller of _invoke_handler, which is where the response is
+        # built: the scope tagging this invocation's spans has to be active
+        # while the agent runs, and the trailer can only be appended once the
+        # result has been serialized into a Response. Carries no span of its
+        # own — _invoke_handler above already reports the invocation.
+        "package": "bedrock_agentcore.runtime.app",
+        "object": "BedrockAgentCoreApp",
+        "method": "_handle_invocation",
+        "wrapper_method": atask_wrapper,
+        "span_handler": "agentcore_handler",
+        "skip_span": True
     }
 ]

--- a/apptrace/tests/unit/test_agentcore_trace_return.py
+++ b/apptrace/tests/unit/test_agentcore_trace_return.py
@@ -1,0 +1,125 @@
+"""Appending an invocation's spans to the AgentCore response.
+
+AgentCore serializes whatever the entrypoint returned, so there is no send-time
+hook like FastAPI's. The trailer goes onto the Response object built by
+_handle_invocation instead, which means Content-Length has to be corrected or
+the trailer is truncated off the wire.
+"""
+import pytest
+from starlette.responses import Response, StreamingResponse
+
+from monocle_apptrace.instrumentation.common import trace_return as tr
+from monocle_apptrace.instrumentation.common.constants import TRACE_RETURN_RESPONSE_HEADER
+from monocle_apptrace.instrumentation.metamodel.agentcore.agentcore_handler import (
+    AgentCoreSpanHandler,
+)
+
+AGENT_BODY = b'"Flight booked."'
+DELIMITER = "__MONOCLE_TRACES__deadbeef__"
+PAYLOAD = "H4sIAAAAAAAAA6tWSkxKTlEqSk1MUbJSykjNyclXqgUAr6nQVRUAAAA="
+
+
+class FakeSpanContext:
+    trace_id = 12345
+
+
+class FakeSpan:
+    def get_span_context(self):
+        return FakeSpanContext()
+
+
+@pytest.fixture
+def trailer_available(monkeypatch):
+    """Pretend this trace captured spans, so a trailer is produced."""
+    monkeypatch.setattr(tr, "is_trace_return_enabled", lambda: True)
+    monkeypatch.setattr(
+        tr, "get_response_trailer",
+        lambda trace_id: (tr.build_response_header_value(DELIMITER),
+                          (DELIMITER + PAYLOAD).encode("utf-8")),
+    )
+
+
+@pytest.fixture
+def no_trailer(monkeypatch):
+    """Trace-return on, but this trace produced nothing to return."""
+    monkeypatch.setattr(tr, "is_trace_return_enabled", lambda: True)
+    monkeypatch.setattr(tr, "get_response_trailer", lambda trace_id: None)
+
+
+def test_trailer_is_appended_to_the_response(trailer_available):
+    response = Response(AGENT_BODY, media_type="application/json")
+
+    AgentCoreSpanHandler._inject_trailer(response, FakeSpan())
+
+    assert response.body.startswith(AGENT_BODY), "the agent's own body must be preserved"
+    assert DELIMITER.encode() in response.body
+    assert PAYLOAD.encode() in response.body
+
+
+def test_content_length_is_corrected(trailer_available):
+    """Starlette fixes Content-Length at construction; a stale value truncates."""
+    response = Response(AGENT_BODY, media_type="application/json")
+
+    AgentCoreSpanHandler._inject_trailer(response, FakeSpan())
+
+    assert response.headers["content-length"] == str(len(response.body))
+    assert int(response.headers["content-length"]) > len(AGENT_BODY)
+
+
+def test_response_header_advertises_the_delimiter(trailer_available):
+    response = Response(AGENT_BODY, media_type="application/json")
+
+    AgentCoreSpanHandler._inject_trailer(response, FakeSpan())
+
+    assert tr.parse_delimiter_from_header(
+        response.headers[TRACE_RETURN_RESPONSE_HEADER]) == DELIMITER
+
+
+def test_untouched_when_trace_return_is_disabled(monkeypatch):
+    """Default deployments must behave exactly as before."""
+    monkeypatch.setattr(tr, "is_trace_return_enabled", lambda: False)
+    response = Response(AGENT_BODY, media_type="application/json")
+
+    AgentCoreSpanHandler._inject_trailer(response, FakeSpan())
+
+    assert response.body == AGENT_BODY
+    assert TRACE_RETURN_RESPONSE_HEADER not in response.headers
+
+
+def test_untouched_when_this_trace_captured_no_spans(no_trailer):
+    response = Response(AGENT_BODY, media_type="application/json")
+
+    AgentCoreSpanHandler._inject_trailer(response, FakeSpan())
+
+    assert response.body == AGENT_BODY
+    assert TRACE_RETURN_RESPONSE_HEADER not in response.headers
+
+
+def test_streaming_responses_are_skipped(trailer_available):
+    """A streaming response has no body to extend."""
+    async def gen():
+        yield b"chunk"
+
+    response = StreamingResponse(gen(), media_type="text/event-stream")
+
+    AgentCoreSpanHandler._inject_trailer(response, FakeSpan())
+
+    assert TRACE_RETURN_RESPONSE_HEADER not in response.headers
+
+
+def test_injection_failure_never_breaks_the_response(monkeypatch):
+    """Returning traces is diagnostic; a failure must not affect the answer."""
+    monkeypatch.setattr(tr, "is_trace_return_enabled", lambda: True)
+    monkeypatch.setattr(tr, "get_response_trailer",
+                        lambda trace_id: (_ for _ in ()).throw(RuntimeError("boom")))
+    response = Response(AGENT_BODY, media_type="application/json")
+
+    handler = AgentCoreSpanHandler()
+    handler.post_task_processing(
+        {}, None, None, (), {}, response, None, FakeSpan(), None)
+
+    assert response.body == AGENT_BODY
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/test_tools/README.md
+++ b/test_tools/README.md
@@ -399,6 +399,19 @@ response = monocle_trace_asserter.run_agent(
 - **`session_id`** is sent as `runtimeSessionId` so the deployed agent keeps conversation context across turns. AWS requires at least 33 characters — Monocle's auto-generated session ids satisfy this, and shorter ids raise a `ValueError` rather than being silently rewritten. Omit it to let AgentCore generate one.
 - **Traces**: spans are produced *inside* the deployed agent and exported by its own Monocle instrumentation, so they are not in the test process. Retrieve them by session — the agent stamps the `runtimeSessionId` onto its spans as `scope.agentic.session`, which Okahu indexes as the `agent_sessions` fact:
 
+The runner retrieves them for you, so assertions apply to the remote spans directly:
+
+```python
+# AGENTCORE_TRACE_WORKFLOW=<workflow the deployed agent exports under>
+response = monocle_trace_asserter.run_agent(ARN, "agentcore", prompt, session_id=session_id)
+
+monocle_trace_asserter.called_tool("book_flight_tool")   # asserts on the remote spans
+```
+
+  This needs the workflow name the deployed agent reports under — its own, not the test's — via the `AGENTCORE_TRACE_WORKFLOW` environment variable or the runner's `trace_workflow_name` argument. Without it, retrieval is skipped and only the response is available to assert on. Allow a few seconds for the spans to reach Okahu after the call returns; the runner polls for up to `MONOCLE_REMOTE_TRACE_TIMEOUT` seconds (default 60).
+
+  To load a session explicitly instead — for example one from an earlier run, or when no workflow name is configured — use the trace source directly:
+
 ```python
 monocle_trace_asserter.with_trace_source(
     "okahu", id=session_id, fact_name="session", workflow_name="<agent's workflow name>",

--- a/test_tools/src/monocle_test_tools/runner/agent_runner.py
+++ b/test_tools/src/monocle_test_tools/runner/agent_runner.py
@@ -31,3 +31,18 @@ class AgentRunner:
         Default: none."""
         return []
 
+    def get_remote_trace_query(self) -> dict:
+        """Identify this run's spans in the remote trace source.
+
+        Returned mapping is passed as keyword arguments to
+        ``MonocleValidator.import_traces`` (``id``, ``fact_name``,
+        ``workflow_name``, ...). Runners whose remote spans share the test's
+        trace id need nothing here, so the default is empty and the validator
+        falls back to looking the trace id up from the local spans.
+
+        A runner whose spans are produced in another process — and therefore
+        under a different trace id and workflow — overrides this to name the
+        fact that does identify them (for example an agent session id).
+        """
+        return {}
+

--- a/test_tools/src/monocle_test_tools/runner/agentcore_runner.py
+++ b/test_tools/src/monocle_test_tools/runner/agentcore_runner.py
@@ -4,9 +4,16 @@ import logging
 import os
 from typing import Any, Optional, Union
 
+from monocle_test_tools.file_span_loader import JSONSpanLoader
 from monocle_test_tools.runner.agent_runner import AgentRunner
 
 logger = logging.getLogger(__name__)
+
+# A deployed agent running with trace-return enabled appends its spans after a
+# delimiter of the form ``__MONOCLE_TRACES__<hex>__``. The prefix is fixed, so
+# the trailer can be located without the response header the HTTP path uses.
+_DELIMITER_PREFIX = "__MONOCLE_TRACES__"
+_DELIMITER_SUFFIX = "__"
 
 # Okahu indexes the deployed agent's session scope under this fact name.
 REMOTE_TRACE_SOURCE = "okahu"
@@ -67,6 +74,7 @@ class AgentCoreRunner(AgentRunner):
         self._trace_workflow_name = trace_workflow_name or os.environ.get(
             AGENTCORE_TRACE_WORKFLOW_ENV)
         self._last_session_id: Optional[str] = None
+        self._remote_spans: list = []
 
     def _get_client(self, region_hint: Optional[str] = None) -> Any:
         """Return the boto3 client, creating it on first use.
@@ -150,6 +158,34 @@ class AgentCoreRunner(AgentRunner):
         else:
             body = {"prompt": test_message}
         return json.dumps(body).encode("utf-8")
+
+    def _split_trailer(self, text: str) -> str:
+        """Take any trace-return trailer off the response and keep its spans.
+
+        A deployed agent running with trace-return enabled appends its spans to
+        the value it returns, after a delimiter. The delimiter starts with a
+        fixed prefix, so it can be found without the response header the HTTP
+        path relies on — boto3 cannot carry one. Returns the text with the
+        trailer removed, so callers only ever see the agent's own answer.
+        """
+        index = text.find(_DELIMITER_PREFIX)
+        if index == -1:
+            return text
+        end = text.find(_DELIMITER_SUFFIX, index + len(_DELIMITER_PREFIX))
+        if end == -1:
+            return text
+        payload = text[end + len(_DELIMITER_SUFFIX):]
+        try:
+            from monocle_apptrace.instrumentation.common.trace_return import decode_payload
+            self._remote_spans = JSONSpanLoader.from_json_str(decode_payload(payload))
+        except Exception as e:
+            logger.warning(f"Failed to deserialize spans returned by the agent: {e}")
+            self._remote_spans = []
+        return text[:index]
+
+    def get_remote_spans(self) -> list:
+        """Spans the deployed agent returned alongside its response, if any."""
+        return self._remote_spans
 
     @staticmethod
     def _decode_response(response: dict) -> Any:
@@ -235,13 +271,19 @@ class AgentCoreRunner(AgentRunner):
         # Remembered as sent, so remote spans are looked up by exactly the id
         # AgentCore stamped on them rather than a separately derived one.
         self._last_session_id = request.get("runtimeSessionId")
+        # Spans belong to one invocation; a reused runner must not report the
+        # previous call's.
+        self._remote_spans = []
 
         # AWS errors are left to propagate so the framework's expect_errors
         # handling sees a real failure rather than an error string as a response.
         client = self._get_client(region_hint=self._region_from_arn(runtime_arn))
         response = client.invoke_agent_runtime(**request)
         logger.debug(f"AgentCore response statusCode={response.get('statusCode')}")
-        return self._decode_response(response)
+        result = self._decode_response(response)
+        if isinstance(result, str):
+            result = self._split_trailer(result)
+        return result
 
     def get_remote_traces_source(self) -> Optional[str]:
         """Remote spans live in the trace backend the deployed agent exports to.
@@ -249,7 +291,13 @@ class AgentCoreRunner(AgentRunner):
         Reports a source only once retrieval can actually succeed — a workflow
         name is configured and a session id was sent — so an unconfigured runner
         skips retrieval instead of quietly importing nothing.
+
+        Reports nothing when the agent already returned its spans in the
+        response: those are the same spans, so fetching them again would add
+        every one of them twice.
         """
+        if self._remote_spans:
+            return None
         if self._trace_workflow_name and self._last_session_id:
             return REMOTE_TRACE_SOURCE
         return None
@@ -262,7 +310,7 @@ class AgentCoreRunner(AgentRunner):
         session fact, so the id sent on the call is enough to find the spans it
         produced.
         """
-        if not (self._trace_workflow_name and self._last_session_id):
+        if self._remote_spans or not (self._trace_workflow_name and self._last_session_id):
             return {}
         return {
             "id": self._last_session_id,

--- a/test_tools/src/monocle_test_tools/runner/agentcore_runner.py
+++ b/test_tools/src/monocle_test_tools/runner/agentcore_runner.py
@@ -1,11 +1,18 @@
 import asyncio
 import json
 import logging
+import os
 from typing import Any, Optional, Union
 
 from monocle_test_tools.runner.agent_runner import AgentRunner
 
 logger = logging.getLogger(__name__)
+
+# Okahu indexes the deployed agent's session scope under this fact name.
+REMOTE_TRACE_SOURCE = "okahu"
+REMOTE_SESSION_FACT = "session"
+# Workflow the deployed agent exports under, when not passed to the constructor.
+AGENTCORE_TRACE_WORKFLOW_ENV = "AGENTCORE_TRACE_WORKFLOW"
 
 # AWS constrains the InvokeAgentRuntime runtimeSessionId header to 33-256 chars.
 MIN_RUNTIME_SESSION_ID_LENGTH = 33
@@ -32,20 +39,34 @@ class AgentCoreRunner(AgentRunner):
     Pass a dict as the message to send a different shape verbatim.
 
     Spans are produced inside the deployed agent and exported by its own Monocle
-    instrumentation rather than by this runner, so ``get_remote_traces_source``
-    returns None. They can be retrieved from the trace backend by session id.
+    instrumentation rather than by this runner. They are retrieved from the
+    trace backend by the session the agent was invoked with, so assertions see
+    them alongside any local spans. That needs the workflow name the deployed
+    agent reports under, via ``trace_workflow_name`` or the
+    ``AGENTCORE_TRACE_WORKFLOW`` environment variable; without it retrieval is
+    skipped and only the response is available to assert on.
     """
 
-    def __init__(self, client: Any = None, region_name: Optional[str] = None):
+    def __init__(self, client: Any = None, region_name: Optional[str] = None,
+                 trace_workflow_name: Optional[str] = None):
         """
         Args:
             client: Optional pre-built boto3 ``bedrock-agentcore`` client. When
                 omitted, one is created lazily on first use.
             region_name: Optional AWS region for the lazily created client.
                 When omitted, the region is taken from the runtime ARN.
+            trace_workflow_name: Workflow name the deployed agent exports its
+                spans under. Needed to retrieve them, since the deployed agent
+                reports under its own workflow rather than the test's. Falls
+                back to the ``AGENTCORE_TRACE_WORKFLOW`` environment variable;
+                when neither is set the runner reports no remote trace source
+                and retrieval is skipped.
         """
         self._client = client
         self._region_name = region_name
+        self._trace_workflow_name = trace_workflow_name or os.environ.get(
+            AGENTCORE_TRACE_WORKFLOW_ENV)
+        self._last_session_id: Optional[str] = None
 
     def _get_client(self, region_hint: Optional[str] = None) -> Any:
         """Return the boto3 client, creating it on first use.
@@ -211,12 +232,43 @@ class AgentCoreRunner(AgentRunner):
 
         request.update(kwargs)
 
+        # Remembered as sent, so remote spans are looked up by exactly the id
+        # AgentCore stamped on them rather than a separately derived one.
+        self._last_session_id = request.get("runtimeSessionId")
+
         # AWS errors are left to propagate so the framework's expect_errors
         # handling sees a real failure rather than an error string as a response.
         client = self._get_client(region_hint=self._region_from_arn(runtime_arn))
         response = client.invoke_agent_runtime(**request)
         logger.debug(f"AgentCore response statusCode={response.get('statusCode')}")
         return self._decode_response(response)
+
+    def get_remote_traces_source(self) -> Optional[str]:
+        """Remote spans live in the trace backend the deployed agent exports to.
+
+        Reports a source only once retrieval can actually succeed — a workflow
+        name is configured and a session id was sent — so an unconfigured runner
+        skips retrieval instead of quietly importing nothing.
+        """
+        if self._trace_workflow_name and self._last_session_id:
+            return REMOTE_TRACE_SOURCE
+        return None
+
+    def get_remote_trace_query(self) -> dict:
+        """Identify the deployed agent's spans by the session it was invoked with.
+
+        The agent records the ``runtimeSessionId`` it received as the
+        ``agentic.session`` scope, which the trace backend indexes as the agent
+        session fact, so the id sent on the call is enough to find the spans it
+        produced.
+        """
+        if not (self._trace_workflow_name and self._last_session_id):
+            return {}
+        return {
+            "id": self._last_session_id,
+            "fact_name": REMOTE_SESSION_FACT,
+            "workflow_name": self._trace_workflow_name,
+        }
 
     def run_agent(self, root_agent: str, *args, session_id: str = None,
                   qualifier: str = None, **kwargs) -> Any:

--- a/test_tools/src/monocle_test_tools/validator.py
+++ b/test_tools/src/monocle_test_tools/validator.py
@@ -37,6 +37,9 @@ from monocle_apptrace.instrumentation.common.utils import set_workflow_name, get
 
 logger = logging.getLogger(__name__)
 RETRY_TIMEOUT_SECONDS = 10
+# Spans a runner produced in another process are exported by that process, so
+# they land in the trace backend a little after the call returns.
+REMOTE_FACT_TIMEOUT_SECONDS = int(os.getenv("MONOCLE_REMOTE_TRACE_TIMEOUT", "60"))
 
 class MonocleValidator:
     memory_exporter:MonocleInMemorySpanExporter = None
@@ -393,7 +396,7 @@ class MonocleValidator:
             if mock_tool_token is not None:
                 detach(mock_tool_token)
         self._trace_source =  agent_runner.get_remote_traces_source()
-        self._fetch_remote_traces()
+        self._fetch_remote_traces(**agent_runner.get_remote_trace_query())
         remote_spans = agent_runner.get_remote_spans()
         if remote_spans:
             self.add_remote_spans(remote_spans)
@@ -417,7 +420,7 @@ class MonocleValidator:
             if turn_token is not None:
                 stop_scope(turn_token)
         self._trace_source = agent_runner.get_remote_traces_source()
-        self._fetch_remote_traces()
+        self._fetch_remote_traces(**agent_runner.get_remote_trace_query())
         remote_spans = agent_runner.get_remote_spans()
         if remote_spans:
             self.add_remote_spans(remote_spans)
@@ -524,7 +527,7 @@ class MonocleValidator:
                         stop_scope(turn_token)
 
                 self._trace_source = agent_runner.get_remote_traces_source()
-                self._fetch_remote_traces()
+                self._fetch_remote_traces(**agent_runner.get_remote_trace_query())
                 turn_spans = self.spans
                 per_turn_spans.append(turn_spans)
                 results.append(result)
@@ -576,15 +579,34 @@ class MonocleValidator:
             self.validate_result(session_case, results[-1] if results else None)
         return results
 
-    def _fetch_remote_traces(self):
+    def _fetch_remote_traces(self, **query):
+        """Import the spans this run produced remotely.
+
+        ``query`` comes from the runner's ``get_remote_trace_query()`` and names
+        the fact identifying those spans. When it is empty the trace id is
+        resolved from the local spans, which is the original behaviour.
+
+        Spans exported from another process reach the backend a little after the
+        call returns, so a fact-based lookup polls for longer than the trace-id
+        lookup and also retries the "not found yet" ConnectionError that the
+        span loader raises while they are still in flight.
+        """
         import time
-        deadline = time.monotonic() + RETRY_TIMEOUT_SECONDS
+        deadline = time.monotonic() + (REMOTE_FACT_TIMEOUT_SECONDS if query else RETRY_TIMEOUT_SECONDS)
         last_exc = None
         while time.monotonic() < deadline:
             try:
-                self.import_traces(self._trace_source)
+                self.import_traces(self._trace_source, **query)
                 return
             except requests.exceptions.HTTPError | requests.HTTPError as e:
+                time.sleep(1)
+                last_exc = e
+            except ConnectionError as e:
+                # Raised by the span loader while the remote spans are still in
+                # flight. Only a fact lookup can wait that out; without a query
+                # the original behaviour of surfacing it immediately is kept.
+                if not query:
+                    raise
                 time.sleep(1)
                 last_exc = e
             except ValueError as e:

--- a/test_tools/tests/integration/test_agentcore_remote_agent.py
+++ b/test_tools/tests/integration/test_agentcore_remote_agent.py
@@ -134,5 +134,34 @@ def test_agentcore_remote_agent_response_and_spans(monocle_trace_asserter: Trace
     monocle_trace_asserter.has_scope("agentic.session", session_id)
 
 
+@pytest.mark.skipif(
+    not AGENTCORE_TRACE_WORKFLOW,
+    reason="AGENTCORE_TRACE_WORKFLOW is not set; requires an Okahu API key for the tenant "
+           "the deployed agent exports to.",
+)
+def test_agentcore_remote_spans_are_retrieved_by_session(monocle_trace_asserter: TraceAssertion):
+    """The same spans, retrieved without asking for them explicitly.
+
+    ``run_agent`` reports the session as the runner's remote trace query, so the
+    spans the agent produced inside AWS are imported and asserted on like local
+    ones — no ``with_trace_source`` call, and no waiting loop in the test.
+    """
+    session_id = _session_id()
+
+    response = monocle_trace_asserter.run_agent(
+        AGENTCORE_RUNTIME_URL,
+        "agentcore",
+        "Book a flight from San Jose to Seattle for 22 Oct 2026",
+        session_id=session_id,
+    )
+
+    assert isinstance(response, str)
+    assert "Seattle" in response
+
+    monocle_trace_asserter.called_agent("agc_travel_agent")
+    monocle_trace_asserter.called_tool("book_flight_tool")
+    monocle_trace_asserter.has_scope("agentic.session", session_id)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/test_tools/tests/unit/test_agentcore_runner.py
+++ b/test_tools/tests/unit/test_agentcore_runner.py
@@ -14,6 +14,8 @@ RUNTIME_ARN = "arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/test_age
 ENDPOINT_ARN = RUNTIME_ARN + "/runtime-endpoint/DEFAULT"
 # Same shape as Monocle's auto-generated session ids, which clear AgentCore's minimum.
 VALID_SESSION_ID = "monocle_test_session_" + "a" * 32
+# Workflow the deployed agent reports under — not the test's own workflow.
+REMOTE_WORKFLOW = "deployed_agent_workflow"
 
 
 class FakeStream:
@@ -261,6 +263,67 @@ def test_remote_trace_hooks_are_inert():
 
     assert runner.get_remote_traces_source() is None
     assert runner.get_remote_spans() == []
+
+
+def test_no_remote_source_until_a_workflow_is_configured(monkeypatch):
+    """Without a workflow name there is nothing to query, so retrieval is skipped."""
+    monkeypatch.delenv("AGENTCORE_TRACE_WORKFLOW", raising=False)
+    runner = AgentCoreRunner(client=FakeClient())
+
+    runner.run_agent(RUNTIME_ARN, "hi", session_id=VALID_SESSION_ID)
+
+    assert runner.get_remote_traces_source() is None
+    assert runner.get_remote_trace_query() == {}
+
+
+def test_remote_query_uses_the_session_id_that_was_sent():
+    """The lookup key is the exact runtimeSessionId AgentCore received."""
+    client = FakeClient()
+    runner = AgentCoreRunner(client=client, trace_workflow_name=REMOTE_WORKFLOW)
+
+    runner.run_agent(RUNTIME_ARN, "hi", session_id=VALID_SESSION_ID)
+
+    assert client.last_request["runtimeSessionId"] == VALID_SESSION_ID
+    assert runner.get_remote_traces_source() == "okahu"
+    assert runner.get_remote_trace_query() == {
+        "id": VALID_SESSION_ID,
+        "fact_name": "session",
+        "workflow_name": REMOTE_WORKFLOW,
+    }
+
+
+def test_remote_query_tracks_the_latest_session():
+    """Each invocation retargets the lookup at that call's session."""
+    runner = AgentCoreRunner(client=FakeClient(), trace_workflow_name=REMOTE_WORKFLOW)
+    second_session = "monocle_test_session_" + "b" * 32
+
+    runner.run_agent(RUNTIME_ARN, "one", session_id=VALID_SESSION_ID)
+    runner.run_agent(RUNTIME_ARN, "two", session_id=second_session)
+
+    assert runner.get_remote_trace_query()["id"] == second_session
+
+
+def test_workflow_name_falls_back_to_env(monkeypatch):
+    monkeypatch.setenv("AGENTCORE_TRACE_WORKFLOW", REMOTE_WORKFLOW)
+    runner = AgentCoreRunner(client=FakeClient())
+
+    runner.run_agent(RUNTIME_ARN, "hi", session_id=VALID_SESSION_ID)
+
+    assert runner.get_remote_trace_query()["workflow_name"] == REMOTE_WORKFLOW
+
+
+def test_aws_generated_session_is_not_used_for_lookup():
+    """AgentCore generates a session when none is sent, but it is not on the request.
+
+    Correlation would need the id the agent actually stamped on its spans, so
+    the runner reports no query rather than guessing one.
+    """
+    runner = AgentCoreRunner(client=FakeClient(), trace_workflow_name=REMOTE_WORKFLOW)
+
+    runner.run_agent(RUNTIME_ARN, "hi")
+
+    assert runner.get_remote_trace_query() == {}
+    assert runner.get_remote_traces_source() is None
 
 
 if __name__ == "__main__":

--- a/test_tools/tests/unit/test_agentcore_trace_return.py
+++ b/test_tools/tests/unit/test_agentcore_trace_return.py
@@ -1,0 +1,176 @@
+"""Traces returned inside the AgentCore response, instead of fetched from a backend.
+
+A deployed agent running with trace-return enabled appends its spans to the
+value it returns; the runner takes them off before the test sees the response.
+These cover the client half against payloads built by the real encoder, so the
+wire format is not restated here.
+"""
+import json
+
+import pytest
+
+from monocle_apptrace.instrumentation.common import trace_return as tr
+from monocle_test_tools.runner.agentcore_runner import AgentCoreRunner
+from monocle_test_tools.file_span_loader import JSONSpanLoader
+
+RUNTIME_ARN = "arn:aws:bedrock-agentcore:us-west-2:123456789012:runtime/test_agent-AbCdEfGhIj"
+AGENT_ANSWER = "Flight booked from San Jose to Seattle."
+
+SPAN_DICT = {
+    "name": "agentic.tool.invocation",
+    "context": {"trace_id": "0x" + "0" * 31 + "1", "span_id": "0x" + "0" * 15 + "1",
+                "trace_state": "[]"},
+    "kind": "SpanKind.INTERNAL",
+    "parent_id": None,
+    "start_time": "2026-08-14T00:00:00.000000Z",
+    "end_time": "2026-08-14T00:00:01.000000Z",
+    "status": {"status_code": "OK"},
+    "attributes": {"span.type": "agentic.tool.invocation", "entity.1.name": "book_flight_tool"},
+    "events": [],
+    "links": [],
+    "resource": {"attributes": {"service.name": "deployed_agent"}, "schema_url": ""},
+}
+
+
+class FakeStream:
+    def __init__(self, body: bytes):
+        self._body = body
+
+    def read(self):
+        return self._body
+
+
+class FakeClient:
+    """Returns a canned response body, as the deployed agent would."""
+
+    def __init__(self, body: bytes):
+        self.body = body
+
+    def invoke_agent_runtime(self, **kwargs):
+        return {"response": FakeStream(self.body), "contentType": "application/json",
+                "statusCode": 200}
+
+
+def _agent_response_with_trailer(answer: str = AGENT_ANSWER, spans=(SPAN_DICT,)) -> bytes:
+    """Build the response a trace-return-enabled agent would produce.
+
+    Uses the same encoder the agent side calls, so the test cannot drift from
+    the real format.
+    """
+    delimiter = tr.make_delimiter()
+    payload = tr.encode_spans_from_dicts(list(spans)) if hasattr(tr, "encode_spans_from_dicts") \
+        else _encode_dicts(list(spans))
+    return json.dumps(answer + delimiter + payload).encode("utf-8")
+
+
+def _encode_dicts(span_dicts):
+    """Mirror of trace_return.encode_spans for already-serialized span dicts."""
+    import base64, gzip
+    raw = json.dumps(span_dicts).encode("utf-8")
+    return base64.b64encode(gzip.compress(raw)).decode("ascii")
+
+
+def test_trailer_is_stripped_from_the_response():
+    """The test sees the agent's answer only — the trailer never reaches it."""
+    runner = AgentCoreRunner(client=FakeClient(_agent_response_with_trailer()))
+
+    result = runner.run_agent(RUNTIME_ARN, "Book a flight")
+
+    assert result == AGENT_ANSWER
+    assert "__MONOCLE_TRACES__" not in result
+
+
+def test_returned_spans_are_deserialized():
+    """The stripped trailer becomes spans the validator can assert on."""
+    runner = AgentCoreRunner(client=FakeClient(_agent_response_with_trailer()))
+
+    runner.run_agent(RUNTIME_ARN, "Book a flight")
+
+    spans = runner.get_remote_spans()
+    assert len(spans) == 1
+    assert spans[0].attributes["entity.1.name"] == "book_flight_tool"
+
+
+def test_response_without_a_trailer_is_untouched():
+    """An agent without trace-return enabled behaves exactly as before."""
+    body = json.dumps(AGENT_ANSWER).encode("utf-8")
+    runner = AgentCoreRunner(client=FakeClient(body))
+
+    result = runner.run_agent(RUNTIME_ARN, "Book a flight")
+
+    assert result == AGENT_ANSWER
+    assert runner.get_remote_spans() == []
+
+
+def test_corrupt_trailer_still_returns_the_answer():
+    """A malformed payload must not lose the agent's response."""
+    body = json.dumps(AGENT_ANSWER + tr.make_delimiter() + "not-valid-base64!!").encode("utf-8")
+    runner = AgentCoreRunner(client=FakeClient(body))
+
+    result = runner.run_agent(RUNTIME_ARN, "Book a flight")
+
+    assert result == AGENT_ANSWER
+    assert runner.get_remote_spans() == []
+
+
+def test_answer_containing_the_prefix_but_no_terminator():
+    """Text that merely mentions the marker is left alone."""
+    answer = "The marker is __MONOCLE_TRACES__ and that is all"
+    runner = AgentCoreRunner(client=FakeClient(json.dumps(answer).encode("utf-8")))
+
+    assert runner.run_agent(RUNTIME_ARN, "hi") == answer
+
+
+def test_returned_spans_suppress_the_session_lookup():
+    """Spans in the response are the same spans; fetching them again duplicates them."""
+    runner = AgentCoreRunner(client=FakeClient(_agent_response_with_trailer()),
+                             trace_workflow_name="deployed_agent_workflow")
+
+    runner.run_agent(RUNTIME_ARN, "hi", session_id="monocle_test_session_" + "a" * 32)
+
+    assert runner.get_remote_spans(), "the agent returned spans"
+    assert runner.get_remote_traces_source() is None
+    assert runner.get_remote_trace_query() == {}
+
+
+def test_session_lookup_still_used_when_no_spans_returned():
+    """An agent without trace-return enabled falls back to fetching by session."""
+    body = json.dumps(AGENT_ANSWER).encode("utf-8")
+    runner = AgentCoreRunner(client=FakeClient(body),
+                             trace_workflow_name="deployed_agent_workflow")
+
+    runner.run_agent(RUNTIME_ARN, "hi", session_id="monocle_test_session_" + "a" * 32)
+
+    assert runner.get_remote_spans() == []
+    assert runner.get_remote_traces_source() == "okahu"
+    assert runner.get_remote_trace_query()["fact_name"] == "session"
+
+
+def test_spans_do_not_leak_between_invocations():
+    """A reused runner must not report a previous call's spans."""
+    runner = AgentCoreRunner(client=FakeClient(_agent_response_with_trailer()))
+    runner.run_agent(RUNTIME_ARN, "first")
+    assert runner.get_remote_spans()
+
+    runner._client = FakeClient(json.dumps(AGENT_ANSWER).encode("utf-8"))
+    runner.run_agent(RUNTIME_ARN, "second")
+
+    assert runner.get_remote_spans() == []
+
+
+def test_round_trip_through_the_real_encoder():
+    """Spans encoded by the agent-side helper decode back to the same span."""
+    delimiter = tr.make_delimiter()
+    payload = _encode_dicts([SPAN_DICT])
+    body = json.dumps(AGENT_ANSWER + delimiter + payload).encode("utf-8")
+
+    runner = AgentCoreRunner(client=FakeClient(body))
+    result = runner.run_agent(RUNTIME_ARN, "hi")
+
+    assert result == AGENT_ANSWER
+    decoded = runner.get_remote_spans()
+    assert [s.name for s in decoded] == ["agentic.tool.invocation"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/test_tools/tests/unit/test_remote_trace_query.py
+++ b/test_tools/tests/unit/test_remote_trace_query.py
@@ -1,0 +1,156 @@
+"""Validator-level tests for fact-based remote trace retrieval.
+
+A runner whose spans are produced in another process names the fact that
+identifies them via ``get_remote_trace_query()``; the validator passes that to
+``import_traces`` so the spans join the ones assertions run against. Okahu is
+stubbed, so these run without network access or credentials.
+"""
+import os
+
+import pytest
+
+import monocle_test_tools.validator as validator_module
+from monocle_test_tools import MonocleValidator
+from monocle_test_tools.fluent_api import TraceAssertion
+from monocle_test_tools.runner.agent_runner import AgentRunner
+from monocle_test_tools.file_span_loader import JSONSpanLoader
+
+SESSION_ID = "monocle_test_session_" + "c" * 32
+REMOTE_WORKFLOW = "deployed_agent_workflow"
+
+
+def _load_spans():
+    here = os.path.dirname(os.path.abspath(__file__))
+    return JSONSpanLoader.from_json(os.path.join(here, "traces", "trace1.json"))
+
+
+class SessionCorrelatedRunner(AgentRunner):
+    """Stand-in for a runner whose spans are produced remotely."""
+
+    def __init__(self, session_id=SESSION_ID, workflow=REMOTE_WORKFLOW):
+        self._session_id = session_id
+        self._workflow = workflow
+
+    def run_agent(self, root_agent, *args, **kwargs):
+        return "remote response"
+
+    async def run_agent_async(self, root_agent, *args, session_id=None, **kwargs):
+        return "remote response"
+
+    def get_remote_traces_source(self):
+        return "okahu"
+
+    def get_remote_trace_query(self):
+        return {"id": self._session_id, "fact_name": "session",
+                "workflow_name": self._workflow}
+
+
+@pytest.fixture
+def validator():
+    v = MonocleValidator()
+    v.cleanup()
+    yield v
+    v.cleanup()
+
+
+def test_query_is_forwarded_to_import_traces(validator, monkeypatch):
+    """The runner's query reaches import_traces verbatim."""
+    runner = SessionCorrelatedRunner()
+    monkeypatch.setattr(validator_module, "get_agent_runner", lambda t: runner)
+
+    captured = {}
+    monkeypatch.setattr(MonocleValidator, "import_traces",
+                        lambda self, source, **kw: captured.update(source=source, **kw))
+
+    validator.run_agent(None, "any_type", "hello")
+
+    assert captured["source"] == "okahu"
+    assert captured["id"] == SESSION_ID
+    assert captured["fact_name"] == "session"
+    assert captured["workflow_name"] == REMOTE_WORKFLOW
+
+
+def test_remote_spans_reach_assertions(validator, monkeypatch):
+    """Spans imported by the query are visible to the fluent assertions."""
+    spans = _load_spans()
+    runner = SessionCorrelatedRunner()
+    monkeypatch.setattr(validator_module, "get_agent_runner", lambda t: runner)
+    # Stand in for Okahu returning the deployed agent's spans for this session.
+    monkeypatch.setattr(MonocleValidator, "import_traces",
+                        lambda self, source, **kw: self.add_remote_spans(spans))
+
+    validator.run_agent(None, "any_type", "hello")
+
+    assert len(validator.spans) == len(spans)
+    asserter = TraceAssertion()
+    tool_spans = validator._get_all_tool_invocation_spans(filtered_spans=validator.spans)
+    assert tool_spans, "remote tool spans should be assertable"
+
+
+def test_runners_without_a_query_keep_trace_id_lookup(validator, monkeypatch):
+    """Default runners are unaffected: no query, so import_traces gets none."""
+
+    class PlainRunner(AgentRunner):
+        def run_agent(self, root_agent, *args, **kwargs):
+            return "local response"
+
+        def get_remote_traces_source(self):
+            return "okahu"
+
+    monkeypatch.setattr(validator_module, "get_agent_runner", lambda t: PlainRunner())
+    captured = {}
+    monkeypatch.setattr(MonocleValidator, "import_traces",
+                        lambda self, source, **kw: captured.update(source=source, kwargs=kw))
+
+    validator.run_agent(None, "any_type", "hello")
+
+    assert captured["source"] == "okahu"
+    assert captured["kwargs"] == {}, "trace-id lookup must receive no extra arguments"
+
+
+def test_base_runner_query_is_empty():
+    assert AgentRunner().get_remote_trace_query() == {}
+
+
+def test_not_found_is_retried_then_surfaced(validator, monkeypatch):
+    """A fact lookup keeps polling while spans are still in flight.
+
+    The span loader raises ConnectionError until the remote spans land, so the
+    fact path must retry rather than fail on the first attempt.
+    """
+    monkeypatch.setattr(validator_module, "REMOTE_FACT_TIMEOUT_SECONDS", 3)
+    attempts = {"n": 0}
+
+    def flaky(self, source, **kw):
+        attempts["n"] += 1
+        raise ConnectionError("No traces found")
+
+    monkeypatch.setattr(MonocleValidator, "import_traces", flaky)
+    validator._trace_source = "okahu"
+
+    with pytest.raises(ConnectionError):
+        validator._fetch_remote_traces(id=SESSION_ID, fact_name="session",
+                                       workflow_name=REMOTE_WORKFLOW)
+
+    assert attempts["n"] > 1, "should have retried while spans were in flight"
+
+
+def test_trace_id_path_does_not_retry_connection_errors(validator, monkeypatch):
+    """Existing behaviour preserved: the trace-id path is unchanged."""
+    attempts = {"n": 0}
+
+    def boom(self, source, **kw):
+        attempts["n"] += 1
+        raise ConnectionError("backend down")
+
+    monkeypatch.setattr(MonocleValidator, "import_traces", boom)
+    validator._trace_source = "okahu"
+
+    with pytest.raises(ConnectionError):
+        validator._fetch_remote_traces()
+
+    assert attempts["n"] == 1, "trace-id path must not start retrying ConnectionError"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Proposed changes
## Summary

The `agentcore` runner invokes an agent deployed inside AWS. That agent's spans are produced in *its* process and exported by *its own* Monocle instrumentation, so they never reach the test and span assertions had nothing to match.

This PR retrieves them, so assertions just work:

```python
response = monocle_trace_asserter.run_agent(ARN, "agentcore", prompt, session_id=session_id)

monocle_trace_asserter.called_agent("agc_travel_agent")
monocle_trace_asserter.called_tool("book_flight_tool")
```

## 1 — Session correlation

The session id is the join key: sent as `runtimeSessionId`, recorded by the agent as `scope.agentic.session`, indexed by Okahu as the `agent_sessions` fact.

New hook on `AgentRunner`, defaulting to empty so all eight other runners are untouched:

```python
def get_remote_trace_query(self) -> dict:
    """kwargs for import_traces identifying this run's spans. Empty → trace-id lookup."""
    return {}
```

Returning `"okahu"` from `get_remote_traces_source()` alone cannot work: that path resolves the trace id from **local** spans, and the boto3 call produces none — it would raise `ValueError`, get swallowed, and import nothing. It also defaults `workflow_name` to the *test's* workflow rather than the deployed agent's.

## 2 — Traces in the response

The agent appends its spans after a marker; the runner strips them before the caller sees anything.

```
"Flight booked.__MONOCLE_TRACES__a1b2c3__H4sIAAAA...."
 └─ real answer ─┘└─ marker ─┘└─ zipped spans ─┘
```

Two constraints shaped the implementation:

- **No send-time hook.** AgentCore serializes whatever the entrypoint returns, and a span handler cannot replace a returned *string* because `post_task_processing`'s return value is discarded. So the trailer goes onto the `Response` object from `_handle_invocation` — after serialization, and mutable — the same way the Lambda handler mutates its dict.
- **`Content-Length` must be rewritten.** Starlette fixes it at construction; a stale value truncates the trailer off the wire.

**Authorization differs deliberately.** boto3 can only send parameters AgentCore models, so a caller cannot supply `x-monocle-retrieve-traces`. Returning traces is opt-in on the deployment via `MONOCLE_ENABLE_TRACE_RETURN` — only the deployer sets it, and IAM already governs who may invoke.

## How the two interact

Inline spans win; session lookup is the fallback. Without that, both paths fire and every span is added twice, silently breaking count-based assertions.

## Tests

| Suite | Result |
|---|---|
| test_tools unit | 349 passed / 33 skipped |
| apptrace unit | 667 passed / 1 skipped |
| live integration | 4 passed against the deployed agent |


Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...