### PR TITLE
feat: allow custom spans to exclude inputs and/or outputs (closes #782)

### DIFF
--- a/apptrace/src/monocle_apptrace/instrumentation/common/custom_span_processor.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/common/custom_span_processor.py
@@ -77,11 +77,62 @@ def extract_output(arguments):
         return json.dumps({"error": "Failed to capture output"})
 
 
-# Custom span entity processor following Monocle's pattern
-CUSTOM_SPAN_PROCESSOR = {
-    "type": "custom",
-    "events": [
-        {
+EXCLUDE_INPUTS = "inputs"
+EXCLUDE_OUTPUTS = "outputs"
+VALID_EXCLUSIONS = (EXCLUDE_INPUTS, EXCLUDE_OUTPUTS)
+
+
+def normalize_exclusions(exclude=None):
+    """Normalize an ``exclude`` option into a set of known exclusion names.
+
+    Accepts None, a single string ("inputs"), or any iterable of strings
+    (["inputs", "outputs"]). Comparison is case-insensitive and whitespace is
+    stripped, so values coming from a YAML config behave the same as values
+    passed in code.
+
+    An unrecognised name is warned about and ignored rather than raising:
+    a typo in a tracing option should not take down the application being
+    traced.
+    """
+    if not exclude:
+        return frozenset()
+
+    items = [exclude] if isinstance(exclude, str) else list(exclude)
+    normalized = set()
+
+    for item in items:
+        name = str(item).strip().lower()
+        if name in VALID_EXCLUSIONS:
+            normalized.add(name)
+        else:
+            logger.warning(
+                f"Ignoring unknown custom span exclusion {item!r}; "
+                f"expected one of {', '.join(VALID_EXCLUSIONS)}"
+            )
+
+    return frozenset(normalized)
+
+
+def build_custom_span_processor(exclude=None):
+    """Build a custom span entity processor, optionally omitting inputs/outputs.
+
+    Args:
+        exclude: None, "inputs", "outputs", or an iterable of those names.
+
+    Returns:
+        An output processor dict following Monocle's pattern. Excluded data is
+        never captured — the accessor is not registered at all, so nothing is
+        serialized and then dropped.
+
+    Note that excluding outputs still records ``error_code``. That is not
+    function output, it is whether the call failed, and losing it would leave
+    an excluded span unable to say that anything went wrong.
+    """
+    excluded = normalize_exclusions(exclude)
+    events = []
+
+    if EXCLUDE_INPUTS not in excluded:
+        events.append({
             "name": "data.input",
             "attributes": [
                 {
@@ -90,21 +141,34 @@ CUSTOM_SPAN_PROCESSOR = {
                     "accessor": lambda arguments: extract_input(arguments)
                 }
             ]
-        },
+        })
+
+    output_attributes = [
         {
-            "name": "data.output",
-            "attributes": [
-                {
-                    "_comment": "Error code if any",
-                    "attribute": "error_code",
-                    "accessor": lambda arguments: get_error_message(arguments)
-                },
-                {
-                    "_comment": "Captured function output",
-                    "attribute": "response",
-                    "accessor": lambda arguments: extract_output(arguments)
-                }
-            ]
+            "_comment": "Error code if any",
+            "attribute": "error_code",
+            "accessor": lambda arguments: get_error_message(arguments)
         }
     ]
-}
+
+    if EXCLUDE_OUTPUTS not in excluded:
+        output_attributes.append({
+            "_comment": "Captured function output",
+            "attribute": "response",
+            "accessor": lambda arguments: extract_output(arguments)
+        })
+
+    events.append({
+        "name": "data.output",
+        "attributes": output_attributes
+    })
+
+    return {
+        "type": "custom",
+        "events": events
+    }
+
+
+# Custom span entity processor following Monocle's pattern.
+# The default captures both inputs and outputs, exactly as before.
+CUSTOM_SPAN_PROCESSOR = build_custom_span_processor()

--- a/apptrace/src/monocle_apptrace/instrumentation/common/instrumentor.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/common/instrumentor.py
@@ -40,7 +40,7 @@ from monocle_apptrace.instrumentation.common.constants import (
     MONOCLE_INSTRUMENTOR, MONOCLE_WORKFLOW_NAME_KEY, CUSTOM_INSTRUMENTATION_FILE_NAME,
     CUSTOM_INSTRUMENTATION_FILE_PATH_ENV, WORKFLOW_NAME_ENV
 )
-from monocle_apptrace.instrumentation.common.custom_span_processor import CUSTOM_SPAN_PROCESSOR
+from monocle_apptrace.instrumentation.common.custom_span_processor import build_custom_span_processor
 from functools import wraps
 
 logger = logging.getLogger(__name__)
@@ -74,7 +74,10 @@ def load_custom_instrumentation() -> List[WrapperMethod]:
                 method=entry.get("method"),
                 span_name=entry.get("span_name"),
                 wrapper_method=task_wrapper if entry.get("sync", True) else atask_wrapper,
-                output_processor=CUSTOM_SPAN_PROCESSOR
+                # `exclude: [inputs, outputs]` opts a method out of having its
+                # arguments or return value captured, for anything that must
+                # not leave the process.
+                output_processor=build_custom_span_processor(entry.get("exclude"))
             ))
     except FileNotFoundError:
         pass

--- a/apptrace/src/monocle_apptrace/instrumentation/common/method_wrappers.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/common/method_wrappers.py
@@ -15,7 +15,7 @@ from monocle_apptrace.instrumentation.common.utils import (
 )
 from monocle_apptrace.instrumentation.common.constants import MONOCLE_INSTRUMENTOR
 from monocle_apptrace.instrumentation.common.instrumentor import get_tracer_provider
-from monocle_apptrace.instrumentation.common.custom_span_processor import CUSTOM_SPAN_PROCESSOR
+from monocle_apptrace.instrumentation.common.custom_span_processor import build_custom_span_processor
 
 logger = logging.getLogger(__name__)
 
@@ -169,16 +169,27 @@ async def amonocle_trace(
         yield  # Still yield to not break the context manager
 
 def monocle_trace_method(
-    span_name: Optional[str] = None
+    span_name: Optional[str] = None,
+    exclude = None
 ):
     """
     Decorator to start and stop a trace for a method. All the spans created in the method will be part of the same trace.
     Captures function inputs (args, kwargs) and outputs (return value) in span events.
-    
+
     Args:
         span_name: Optional custom span name. If None, uses the decorated function's name.
+        exclude: Optionally skip capturing "inputs", "outputs", or both, for
+            methods whose arguments or return values should not leave the
+            process. Accepts a single name or an iterable of names. Excluded
+            data is never captured; the span is still recorded, and an
+            excluded-output span still carries error_code.
+
+    Example:
+        @monocle_trace_method(exclude="inputs")
+        def charge_card(card_number: str) -> Receipt: ...
     """
-    
+    span_processor = build_custom_span_processor(exclude)
+
     def decorator(func):
         tracer = get_tracer(instrumenting_module_name=MONOCLE_INSTRUMENTOR, tracer_provider=get_tracer_provider())
         handler = SpanHandler()
@@ -194,7 +205,7 @@ def monocle_trace_method(
                     handler=handler,
                     to_wrap={
                         "span_name": effective_span_name,
-                        "output_processor": CUSTOM_SPAN_PROCESSOR
+                        "output_processor": span_processor
                     }
                 )(  wrapped=func,                        
                     instance=None,
@@ -210,7 +221,7 @@ def monocle_trace_method(
                     handler=handler,
                     to_wrap={
                         "span_name": effective_span_name,
-                        "output_processor": CUSTOM_SPAN_PROCESSOR
+                        "output_processor": span_processor
                     }
                 )(  wrapped=func,                        
                     instance=None,

--- a/apptrace/tests/unit/test_custom_span_exclude.py
+++ b/apptrace/tests/unit/test_custom_span_exclude.py
@@ -1,0 +1,260 @@
+"""`exclude` opts a custom span out of capturing inputs and/or outputs."""
+
+import json
+import logging
+import os
+import shutil
+import tempfile
+import unittest
+
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from monocle_apptrace.instrumentation.common.constants import (
+    CUSTOM_INSTRUMENTATION_FILE_NAME,
+    CUSTOM_INSTRUMENTATION_FILE_PATH_ENV,
+)
+from monocle_apptrace.instrumentation.common.custom_span_processor import (
+    build_custom_span_processor,
+    normalize_exclusions,
+)
+from monocle_apptrace.instrumentation.common.instrumentor import (
+    get_monocle_instrumentor,
+    setup_monocle_telemetry,
+)
+from monocle_apptrace.instrumentation.common.method_wrappers import monocle_trace_method
+
+
+def event_names(processor):
+    return [event["name"] for event in processor["events"]]
+
+
+def attribute_names(processor, event_name):
+    for event in processor["events"]:
+        if event["name"] == event_name:
+            return [attribute["attribute"] for attribute in event["attributes"]]
+    return []
+
+
+class TestNormalizeExclusions(unittest.TestCase):
+    def test_none_and_empty_exclude_nothing(self):
+        for value in (None, "", [], ()):
+            self.assertEqual(normalize_exclusions(value), frozenset())
+
+    def test_accepts_a_bare_string(self):
+        self.assertEqual(normalize_exclusions("inputs"), frozenset({"inputs"}))
+
+    def test_accepts_an_iterable(self):
+        self.assertEqual(
+            normalize_exclusions(["inputs", "outputs"]), frozenset({"inputs", "outputs"})
+        )
+
+    def test_is_case_and_whitespace_insensitive(self):
+        # Values from a YAML config must behave like values passed in code.
+        self.assertEqual(normalize_exclusions([" Inputs ", "OUTPUTS"]),
+                         frozenset({"inputs", "outputs"}))
+
+    def test_unknown_name_warns_and_is_ignored(self):
+        # A typo in a tracing option must not take down the traced application.
+        with self.assertLogs(
+            "monocle_apptrace.instrumentation.common.custom_span_processor",
+            level=logging.WARNING,
+        ) as captured:
+            result = normalize_exclusions(["input", "outputs"])
+
+        self.assertEqual(result, frozenset({"outputs"}))
+        self.assertIn("input", "".join(captured.output))
+
+
+class TestBuildCustomSpanProcessor(unittest.TestCase):
+    def test_default_captures_inputs_and_outputs(self):
+        processor = build_custom_span_processor()
+
+        self.assertEqual(event_names(processor), ["data.input", "data.output"])
+        self.assertIn("input", attribute_names(processor, "data.input"))
+        self.assertIn("response", attribute_names(processor, "data.output"))
+
+    def test_excluding_inputs_drops_the_input_event(self):
+        processor = build_custom_span_processor("inputs")
+
+        self.assertEqual(event_names(processor), ["data.output"])
+        self.assertIn("response", attribute_names(processor, "data.output"))
+
+    def test_excluding_outputs_drops_only_the_response_attribute(self):
+        processor = build_custom_span_processor("outputs")
+
+        self.assertEqual(event_names(processor), ["data.input", "data.output"])
+        self.assertNotIn("response", attribute_names(processor, "data.output"))
+        # error_code is not output data - it is whether the call failed, and an
+        # excluded span must still be able to say something went wrong.
+        self.assertIn("error_code", attribute_names(processor, "data.output"))
+
+    def test_excluding_both_keeps_only_the_error_code(self):
+        processor = build_custom_span_processor(["inputs", "outputs"])
+
+        self.assertEqual(event_names(processor), ["data.output"])
+        self.assertEqual(attribute_names(processor, "data.output"), ["error_code"])
+
+    def test_the_module_default_is_unchanged(self):
+        from monocle_apptrace.instrumentation.common.custom_span_processor import (
+            CUSTOM_SPAN_PROCESSOR,
+        )
+
+        self.assertEqual(event_names(CUSTOM_SPAN_PROCESSOR), ["data.input", "data.output"])
+        self.assertIn("input", attribute_names(CUSTOM_SPAN_PROCESSOR, "data.input"))
+        self.assertIn("response", attribute_names(CUSTOM_SPAN_PROCESSOR, "data.output"))
+
+
+class _ExporterCase(unittest.TestCase):
+    """Shared telemetry setup: spans go to an in-memory exporter."""
+
+    def setUp(self):
+        existing = get_monocle_instrumentor()
+        if existing is not None:
+            try:
+                existing.uninstrument()
+            except Exception:
+                pass
+
+        self.memory_exporter = InMemorySpanExporter()
+
+    def tearDown(self):
+        try:
+            if getattr(self, "instrumentor", None) is not None:
+                self.instrumentor.uninstrument()
+        except Exception as e:
+            print("Uninstrument failed:", e)
+        return super().tearDown()
+
+    def captured_events(self, span_name):
+        for span in self.memory_exporter.get_finished_spans():
+            if span.name == span_name:
+                return {event.name: dict(event.attributes) for event in span.events}
+        available = [s.name for s in self.memory_exporter.get_finished_spans()]
+        raise AssertionError(f"no span named {span_name!r}; got {available}")
+
+
+class TestDecoratorExclude(_ExporterCase):
+    def setUp(self):
+        super().setUp()
+        self.instrumentor = setup_monocle_telemetry(
+            workflow_name="custom_span_exclude_test",
+            span_processors=[SimpleSpanProcessor(self.memory_exporter)],
+            union_with_default_methods=False,
+        )
+
+    def test_default_records_both(self):
+        @monocle_trace_method(span_name="keeps_both")
+        def handler(secret, flag=True):
+            return {"value": secret}
+
+        handler("s3cret")
+
+        events = self.captured_events("keeps_both")
+        self.assertIn("s3cret", events["data.input"]["input"])
+        self.assertIn("s3cret", events["data.output"]["response"])
+
+    def test_exclude_inputs_omits_the_arguments(self):
+        @monocle_trace_method(span_name="no_inputs", exclude="inputs")
+        def handler(secret):
+            return "ok"
+
+        handler("s3cret")
+
+        events = self.captured_events("no_inputs")
+        self.assertNotIn("data.input", events)
+        self.assertIn("ok", events["data.output"]["response"])
+
+    def test_exclude_outputs_omits_the_return_value(self):
+        @monocle_trace_method(span_name="no_outputs", exclude="outputs")
+        def handler(visible):
+            return "s3cret-result"
+
+        handler("visible-arg")
+
+        events = self.captured_events("no_outputs")
+        self.assertIn("visible-arg", events["data.input"]["input"])
+        self.assertNotIn("response", events["data.output"])
+
+    def test_exclude_both_still_records_the_span(self):
+        @monocle_trace_method(span_name="no_io", exclude=["inputs", "outputs"])
+        def handler(secret):
+            return "s3cret-result"
+
+        handler("s3cret-arg")
+
+        events = self.captured_events("no_io")
+        self.assertNotIn("data.input", events)
+        self.assertNotIn("response", events["data.output"])
+        # The span itself still exists - excluding data must not disable tracing.
+        self.assertIn("data.output", events)
+
+    def test_excluded_span_still_reports_an_error(self):
+        @monocle_trace_method(span_name="failing", exclude=["inputs", "outputs"])
+        def handler():
+            raise ValueError("boom")
+
+        with self.assertRaises(ValueError):
+            handler()
+
+        events = self.captured_events("failing")
+        self.assertTrue(events["data.output"].get("error_code"))
+
+    def test_exclude_does_not_change_the_return_value(self):
+        @monocle_trace_method(span_name="returns", exclude=["inputs", "outputs"])
+        def handler(value):
+            return value * 2
+
+        self.assertEqual(handler(21), 42)
+
+
+class ConfigTarget:
+    def do_work(self, secret: str) -> str:
+        return f"result-for-{secret}"
+
+
+class TestYamlExclude(_ExporterCase):
+    def setUp(self):
+        super().setUp()
+        self.config_dir = tempfile.mkdtemp(prefix="monocle_exclude_")
+        with open(os.path.join(self.config_dir, CUSTOM_INSTRUMENTATION_FILE_NAME), "w") as f:
+            f.write(
+                "instrument:\n"
+                f"  - package: {ConfigTarget.__module__}\n"
+                f"    class: {ConfigTarget.__name__}\n"
+                "    method: do_work\n"
+                "    sync: true\n"
+                "    span_name: config_excluded\n"
+                "    exclude:\n"
+                "      - inputs\n"
+                "      - outputs\n"
+            )
+
+        self._prev_env = os.environ.get(CUSTOM_INSTRUMENTATION_FILE_PATH_ENV)
+        os.environ[CUSTOM_INSTRUMENTATION_FILE_PATH_ENV] = self.config_dir
+
+        self.instrumentor = setup_monocle_telemetry(
+            workflow_name="custom_span_exclude_yaml_test",
+            span_processors=[SimpleSpanProcessor(self.memory_exporter)],
+            union_with_default_methods=False,
+        )
+
+    def tearDown(self):
+        if self._prev_env is None:
+            os.environ.pop(CUSTOM_INSTRUMENTATION_FILE_PATH_ENV, None)
+        else:
+            os.environ[CUSTOM_INSTRUMENTATION_FILE_PATH_ENV] = self._prev_env
+        shutil.rmtree(self.config_dir, ignore_errors=True)
+        return super().tearDown()
+
+    def test_exclude_from_the_config_file_is_honoured(self):
+        self.assertEqual(ConfigTarget().do_work("s3cret"), "result-for-s3cret")
+
+        events = self.captured_events("config_excluded")
+        self.assertNotIn("data.input", events)
+        self.assertNotIn("response", events["data.output"])
+        self.assertNotIn("s3cret", json.dumps(events))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #782.

Custom spans always captured the method's arguments and return value, with no way to opt out — which rules out tracing any method that handles credentials, PII, or payment details, since the only alternative was not tracing it at all.

## The option

`exclude` accepts `"inputs"`, `"outputs"`, or both, on **both** surfaces that create custom spans:

```python
@monocle_trace_method(exclude="inputs")
def charge_card(card_number: str) -> Receipt: ...
```

```yaml
instrument:
  - package: myapp.billing
    class: Billing
    method: charge
    exclude: [inputs, outputs]
```

`build_custom_span_processor(exclude)` assembles the processor with the excluded accessors **left out entirely**, so excluded data is never serialized in the first place rather than captured and then dropped.

## Two judgement calls worth reviewing

**Excluding outputs still records `error_code`.** That attribute isn't function output — it's whether the call failed. Dropping it would leave an excluded span unable to say anything went wrong, which seemed clearly against the point of tracing. Excluding *both* therefore leaves a span carrying only `error_code`, which still tells you the method ran and whether it succeeded.

**An unrecognised name warns and is ignored** rather than raising. A typo in a tracing option shouldn't take down the application being traced. Happy to make it strict if you'd rather.

`CUSTOM_SPAN_PROCESSOR` is still exported and still captures both, so nothing importing it changes behaviour — there's a test asserting exactly that.

Normalization accepts a bare string or any iterable, and is case- and whitespace-insensitive, so a value from YAML behaves like one written in code.

## Tests

17 in `tests/unit/test_custom_span_exclude.py`:

- normalization: `None`/empty, bare string, iterable, mixed case and padding, unknown name warns and is dropped
- processor shape for each of the four combinations, and the module default unchanged
- **the decorator end to end** against an `InMemorySpanExporter`: with `exclude="inputs"` the secret argument is absent from the span; with `exclude="outputs"` the return value is absent
- an excluded span is **still emitted**, and still reports `error_code` when the method raises
- the wrapped function's return value is unchanged
- **the YAML config path**, asserting the secret string appears nowhere in the serialized span events

## Suite status

Windows / Python 3.12. `tests/unit` goes **546 → 563 passed** (my 17).

The 4 failures and 15 collection errors are **identical before and after** this branch — I ran the suite on pristine `main` to confirm. The collection errors are missing optional framework deps in this environment (`torch`, `flask`, `langchain_core`, `boto3`, `haystack`, `pydantic`, `starlette`, `httpx`).

One note in case it's useful: `pip install -e apptrace` fails on Windows because the hatchling build hook shells out to `if [ -f "LICENSE" ]; ...`, which `cmd.exe` can't parse. I ran the suite with `PYTHONPATH=src` and the runtime deps installed directly instead.

Signed off per the DCO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)