### PR TITLE
feat(test-tools)!: make the eval matrix row template-agnostic via judge_output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- feat(test_tools)!: the eval-result matrix row is now template-agnostic — `judge_output` carries the judge's structured output verbatim, and the `hallucination`-specific `claim_verdicts`, `hallucination_types` and `entity_match_check` columns are removed. Previously only those three fields were promoted, so every other template's `structure_output` (e.g. `addressed_aspects` / `missing_aspects` / `completeness_score` on `conversation_completeness`) was dropped and downstream analysis had only the free-text `explanation` to parse. **Migration:** read `row["judge_output"]["claim_verdicts"]` instead of `row["claim_verdicts"]`.
 - feat(exporters): configurable file-name prefix for file and Azure Blob exporters via `MONOCLE_FILE_PREFIX` and `MONOCLE_BLOB_FILE_PREFIX`; S3 `MONOCLE_S3_KEY_PREFIX` renamed to `MONOCLE_S3_FILE_PREFIX` (old name still works with deprecation warning) ([#149](https://github.com/monocle2ai/monocle/issues/149))
 - chore(deps): add `opentelemetry-exporter-otlp-proto-http` as a default dependency so the OTLP exporter works out of the box ([#570](https://github.com/monocle2ai/monocle/issues/570))
 - feat(exporters): add `MONOCLE_CONSOLE` env var to enable console output alongside any configured exporter ([#577](https://github.com/monocle2ai/monocle/pull/577))

--- a/docs/monocle_evaluation_api.md
+++ b/docs/monocle_evaluation_api.md
@@ -534,7 +534,7 @@ pytest --monocle-eval-matrix=path/to/matrix.json   # custom output path
 MONOCLE_EVAL_MATRIX=1 pytest                        # enable via env var (default path)
 ```
 
-At session end the recorder writes `{"generated_at": <UTC ISO8601>, "records": [ ... ]}`. Each record carries a fixed schema: `run_id`, `scenario`, `trace_id`, `expected`, `actual`, `status` (`pass` / `fail` / `error`), `explanation`, `total_tokens`, `claim_verdicts`, `hallucination_types`, `entity_match_check`, plus `fact_id`, `workflow`, and `job_id` (populated for the time-window flow; empty for interactive rows). Output-path precedence: the `--monocle-eval-matrix` value, else `MONOCLE_EVAL_MATRIX`, else the default `test-eval-replay-matrix.json`.
+At session end the recorder writes `{"generated_at": <UTC ISO8601>, "records": [ ... ]}`. Each record carries a fixed, template-agnostic schema: `run_id`, `scenario`, `trace_id`, `expected`, `actual`, `status` (`pass` / `fail` / `error`), `explanation`, `total_tokens`, `fact_id`, `workflow`, `job_id` (populated for the time-window flow; empty for interactive rows), and `judge_output` — the judge's structured output verbatim. No judge field is promoted to a top-level column: every template defines its own `structure_output`, so `claim_verdicts` / `hallucination_types` / `entity_match_check` (hallucination), `addressed_aspects` / `missing_aspects` / `completeness_score` (conversation_completeness), `bias_types` (bias) and any other template's fields are all read from `judge_output`. Output-path precedence: the `--monocle-eval-matrix` value, else `MONOCLE_EVAL_MATRIX`, else the default `test-eval-replay-matrix.json`.
 
 ## 11. Curating Cases from CSV
 

--- a/test_tools/README.md
+++ b/test_tools/README.md
@@ -912,7 +912,7 @@ pytest --monocle-eval-matrix=path/to/matrix.json   # custom path
 MONOCLE_EVAL_MATRIX=1 pytest                        # via env var (default path)
 ```
 
-A row is recorded for every test that calls `check_eval`. At session end the recorder writes `{"generated_at": <UTC ISO8601>, "records": [ ... ]}`, where each record has a fixed schema: `run_id`, `scenario`, `trace_id`, `expected`, `actual`, `status` (`pass`/`fail`/`error`), `explanation`, `total_tokens`, `claim_verdicts`, `hallucination_types`, `entity_match_check`, and (for the filtered flow) `fact_id`, `workflow`, `job_id`. Path precedence: the `--monocle-eval-matrix` value, else `MONOCLE_EVAL_MATRIX`, else the default `test-eval-replay-matrix.json`.
+A row is recorded for every test that calls `check_eval`. At session end the recorder writes `{"generated_at": <UTC ISO8601>, "records": [ ... ]}`, where each record has a fixed, template-agnostic schema: `run_id`, `scenario`, `trace_id`, `expected`, `actual`, `status` (`pass`/`fail`/`error`), `explanation`, `total_tokens`, (for the filtered flow) `fact_id`, `workflow`, `job_id`, and `judge_output` — the judge's structured output verbatim. No judge field is promoted to a top-level column, because every template defines its own `structure_output`: read `claim_verdicts` / `hallucination_types` / `entity_match_check` (hallucination), `addressed_aspects` / `missing_aspects` / `completeness_score` (conversation_completeness), `bias_types` (bias) and so on from `judge_output`. Path precedence: the `--monocle-eval-matrix` value, else `MONOCLE_EVAL_MATRIX`, else the default `test-eval-replay-matrix.json`.
 
 ### CSV eval test cases
 

--- a/test_tools/src/monocle_test_tools/eval_matrix.py
+++ b/test_tools/src/monocle_test_tools/eval_matrix.py
@@ -33,11 +33,19 @@ def build_eval_matrix_row(run_id: str, scenario: str, last_eval: dict, passed: b
 
     Returns a dict with exactly these keys (schema is consumed downstream,
     do not rename): run_id, scenario, trace_id, expected, actual, status,
-    explanation, total_tokens, claim_verdicts, hallucination_types,
-    entity_match_check, fact_id, workflow, job_id.
+    explanation, total_tokens, fact_id, workflow, job_id, judge_output.
 
     The trailing fact_id/workflow/job_id are additive columns for the filtered
     flow; interactive rows carry empty-string defaults so no consumer breaks.
+
+    The schema is TEMPLATE-AGNOSTIC: every eval template defines its own
+    `structure_output`, so no judge field is promoted to a top-level column.
+    `judge_output` carries the judge's structured output verbatim, whatever the
+    template emits — `claim_verdicts` / `hallucination_types` /
+    `entity_match_check` for `hallucination`, `addressed_aspects` /
+    `missing_aspects` / `completeness_score` for `conversation_completeness`,
+    `bias_types` for `bias`, and so on. Read the fields you need from
+    `judge_output`; this function does not need to know them.
     """
     last_eval = last_eval or {}
     judge_output = last_eval.get("judge_output") or {}
@@ -59,12 +67,10 @@ def build_eval_matrix_row(run_id: str, scenario: str, last_eval: dict, passed: b
         "status": status,
         "explanation": last_eval.get("explanation"),
         "total_tokens": last_eval.get("total_tokens"),
-        "claim_verdicts": judge_output.get("claim_verdicts") or [],
-        "hallucination_types": judge_output.get("hallucination_types") or [],
-        "entity_match_check": judge_output.get("entity_match_check") or "",
         "fact_id": last_eval.get("fact_id") or "",
         "workflow": last_eval.get("workflow") or "",
         "job_id": last_eval.get("job_id") or "",
+        "judge_output": judge_output,
     }
 
 

--- a/test_tools/tests/unit/test_eval_matrix.py
+++ b/test_tools/tests/unit/test_eval_matrix.py
@@ -30,14 +30,65 @@ def test_build_eval_matrix_row_pass_includes_tokens():
         "status": "pass",
         "explanation": "matches expectations",
         "total_tokens": 123,
-        "claim_verdicts": [{"claim": "x", "verdict": "supported"}],
-        "hallucination_types": [],
-        "entity_match_check": "ok",
         # Filtered-flow columns default to empty for interactive rows (additive widening).
         "fact_id": "",
         "workflow": "",
         "job_id": "",
+        # No judge field is promoted to a column: the judge's structured output is
+        # carried verbatim so the schema is the same for every template.
+        "judge_output": {
+            "claim_verdicts": [{"claim": "x", "verdict": "supported"}],
+            "hallucination_types": [],
+            "entity_match_check": "ok",
+        },
     }
+
+
+def test_build_eval_matrix_row_schema_is_template_agnostic():
+    """Any template's structured output must survive, and no field is promoted.
+
+    `conversation_completeness` emits addressed_aspects / missing_aspects /
+    completeness_score. Before `judge_output` was carried through, only three
+    `hallucination` fields were promoted to columns and every other template's
+    output was dropped, leaving downstream analysis with free-text
+    `explanation` alone.
+    """
+    last_eval = {
+        "trace_id": "ghi789",
+        "expected": ["complete"],
+        "fact_name": "traces",
+        "label": "partially_complete",
+        "explanation": "the second sub-question is unanswered",
+        "judge_output": {
+            "addressed_aspects": ["who wrote it"],
+            "missing_aspects": ["which prize it won"],
+            "completeness_score": 0.5,
+            "query_coverage": "partial",
+            "follow_up_needed": True,
+        },
+        "total_tokens": 77,
+    }
+
+    row = build_eval_matrix_row(run_id="run-4", scenario="cc_t01", last_eval=last_eval, passed=False)
+
+    assert row["judge_output"]["addressed_aspects"] == ["who wrote it"]
+    assert row["judge_output"]["missing_aspects"] == ["which prize it won"]
+    assert row["judge_output"]["completeness_score"] == 0.5
+    assert row["judge_output"]["query_coverage"] == "partial"
+    assert row["judge_output"]["follow_up_needed"] is True
+    # No template's fields are promoted to top-level columns, so the row keys are
+    # identical whatever the template emitted.
+    for promoted in ("claim_verdicts", "hallucination_types", "entity_match_check",
+                     "addressed_aspects", "missing_aspects", "completeness_score"):
+        assert promoted not in row
+    assert row["status"] == "fail"
+
+
+def test_build_eval_matrix_row_judge_output_defaults_to_empty_dict():
+    """A missing or null judge_output must serialise as {}, never None."""
+    for stash in ({"label": "complete"}, {"label": "complete", "judge_output": None}):
+        row = build_eval_matrix_row(run_id="run-5", scenario="cc_t02", last_eval=stash, passed=True)
+        assert row["judge_output"] == {}
 
 
 def test_build_eval_matrix_row_not_passed_with_label_is_fail():
@@ -55,9 +106,8 @@ def test_build_eval_matrix_row_not_passed_with_label_is_fail():
 
     assert row["status"] == "fail"
     assert row["actual"] == "major_hallucination"
-    assert row["claim_verdicts"] == []
-    assert row["hallucination_types"] == []
-    assert row["entity_match_check"] == ""
+    assert row["judge_output"] == {}
+    assert "claim_verdicts" not in row
 
 
 def test_build_eval_matrix_row_not_passed_without_label_is_error():
@@ -93,9 +143,7 @@ def test_build_eval_matrix_row_is_none_safe_for_missing_judge_output_keys():
     row = build_eval_matrix_row(run_id="run-4", scenario="test_w", last_eval=last_eval, passed=True)
 
     assert row["status"] == "pass"
-    assert row["claim_verdicts"] == []
-    assert row["hallucination_types"] == []
-    assert row["entity_match_check"] == ""
+    assert row["judge_output"] == {}
     # explanation is passed through as-is from last_eval (no forced fallback)
     assert row["explanation"] is None
 


### PR DESCRIPTION
Tracking issue: https://github.com/okahu/monocle_backlog_tracking/issues/229

## Proposed changes

`build_eval_matrix_row` promoted three `hallucination`-template fields to top-level row columns — `claim_verdicts`, `hallucination_types`, `entity_match_check` — and dropped the rest of the judge's structured output. Every eval template defines its own `structure_output`, so for any **other** template the matrix recorded three empty columns and downstream analysis was left with only the free-text `explanation` to parse.

Concretely, `conversation_completeness` emits `addressed_aspects`, `missing_aspects`, `completeness_score`, `query_coverage`, `follow_up_needed` and `response_depth`. A 3-run, 76-scenario replay matrix over that template recorded **none** of them — so the per-aspect table the judge produces on every call, the part that says *which* aspect it thought was missing, could not be used to score or audit the run. It could only be regex-guessed out of prose, which is exactly as unreliable as it sounds.

Rather than promote more field names, this carries the judge's structured output verbatim as `judge_output` and stops promoting any of them:

```python
run_id, scenario, trace_id, expected, actual, status,
explanation, total_tokens, fact_id, workflow, job_id, judge_output
```

The row schema is now identical whatever the template emits, and a consumer reads the fields it wants without `build_eval_matrix_row` needing to know they exist. `judge_output` defaults to `{}` (never `None`) when the stash carries no judge output.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

**Breaking change / migration:** `claim_verdicts`, `hallucination_types` and `entity_match_check` are no longer top-level row keys. Read `row["judge_output"]["claim_verdicts"]` instead of `row["claim_verdicts"]`. Nothing in this repo consumed them — verified by grep across `.py`/`.md`/`.json`/`.yml`; they were only written, documented, and asserted in this module's own tests. A `CHANGELOG.md` entry under `## Unreleased` carries the same migration note.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

`381 passed, 2 skipped` in `test_tools/tests/unit`. One caveat reported rather than hidden: `tests/unit/test_non_llm_core_examples.py` fails at collection in my environment, and it fails identically on unmodified `main` (verified by stashing this change and re-running), so it is pre-existing and unrelated.

Branch was cut from a freshly fetched `origin/main`; the single commit is DCO-signed.

## Further comments

**Why carry the whole dict rather than promote the missing fields?** Promoting per-template names is what created the problem: the schema silently encoded one template's shape, and the failure mode was invisible — the columns were *present and empty*, so a consumer could not distinguish "the judge said nothing" from "this template does not emit that field". Carrying `judge_output` makes the recorder indifferent to which templates exist, so adding a template needs no change here.

**Alternative considered:** keep the three columns for backward compatibility and add `judge_output` alongside. That was the first version of this change, and it was rejected in review — it duplicates data in every row and leaves the schema permanently hallucination-shaped. Since nothing consumes those keys, the clean removal is preferable to a compatibility shim nobody needs.

Tests cover both properties: a `conversation_completeness` `judge_output` survives intact, **and** no field from any template appears as a top-level key.

