### PR TITLE
fix(test_tools): add foundry runner, and render MS Agent turn input a…

### DIFF
--- a/apptrace/src/monocle_apptrace/instrumentation/metamodel/msagent/_helper.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/metamodel/msagent/_helper.py
@@ -141,6 +141,12 @@ def get_tool_description(instance: Any) -> str:
         return ""
 
 
+def _fallback_text(value: Any) -> str:
+    """Stringify a value, unless that yields an object repr."""
+    rendered = str(value)
+    return "" if "object at 0x" in rendered else rendered
+
+
 def extract_request_agent_input(arguments: Dict[str, Any]) -> str:
     """
     Extract input from agent request (turn level) arguments.
@@ -153,31 +159,17 @@ def extract_request_agent_input(arguments: Dict[str, Any]) -> str:
         # For request level, we want the user's query/message
         # which is typically the first argument or 'input'/'message' kwarg
         if args and len(args) > 0:
-            input_val = args[0]
-            # Handle string inputs
-            if isinstance(input_val, str):
-                return input_val
-            # Handle message objects
-            elif hasattr(input_val, "content"):
-                return str(input_val.content)
-            else:
-                return str(input_val)
-        
+            return _extract_text_from_content(args[0]) or _fallback_text(args[0])
+
         # Check kwargs for input
-        if "input" in kwargs:
-            return str(kwargs["input"])
-        elif "message" in kwargs:
-            return str(kwargs["message"])
-        elif "query" in kwargs:
-            return str(kwargs["query"])
-        elif "messages" in kwargs:
+        for key in ("input", "message", "query"):
+            if key in kwargs:
+                return _extract_text_from_content(kwargs[key]) or _fallback_text(kwargs[key])
+        if "messages" in kwargs:
             messages = kwargs["messages"]
             if isinstance(messages, list) and len(messages) > 0:
                 # Get the user message (first or last depending on structure)
-                first_msg = messages[0] if messages else ""
-                if hasattr(first_msg, "content"):
-                    return str(first_msg.content)
-                return str(first_msg)
+                return _extract_text_from_content(messages[0]) or _fallback_text(messages[0])
             return str(messages)
         
         return ""

--- a/apptrace/tests/unit/test_msagent_helper.py
+++ b/apptrace/tests/unit/test_msagent_helper.py
@@ -1,0 +1,177 @@
+"""Unit tests for the MS Agent Framework turn-input helper.
+
+The turn span is the only one handed a raw ``Message``, so it is the only place
+where rendering it wrongly shows up in a trace. It used to read ``content``
+(singular), which agent-framework 1.6.0 renamed to ``contents`` — the guard
+missed, ``str()`` ran on a class with no ``__str__``, and the span recorded
+``<agent_framework._types.Message object at 0x...>`` instead of the prompt.
+
+These tests use stand-in message objects rather than importing
+agent_framework, so they run without it installed.
+"""
+import pytest
+
+from monocle_apptrace.instrumentation.metamodel.msagent._helper import (
+    extract_request_agent_input,
+)
+
+
+def render(value):
+    """Render one positional turn input, the way the turn span does."""
+    return extract_request_agent_input({"args": (value,), "kwargs": {}})
+
+PROMPT = "Book a flight from Delhi to Phuket"
+
+
+class MessageLike:
+    """Stands in for agent-framework >= 1.6.0's Message.
+
+    ``contents`` plural, a computed ``text``, and deliberately no ``__str__``,
+    so ``str()`` on it produces the default object repr — the bug's signature.
+    """
+
+    def __init__(self, text=PROMPT, contents=None):
+        self.contents = contents if contents is not None else [text]
+        self._text = text
+
+    @property
+    def text(self):
+        return self._text
+
+
+class LegacyMessage:
+    """Stands in for an older message object exposing ``content`` singular."""
+
+    def __init__(self, content=PROMPT):
+        self.content = content
+
+
+class ContentLike:
+    """Stands in for agent-framework's Content: to_dict(), and no __str__."""
+
+    def __init__(self, **fields):
+        self._fields = fields
+
+    def to_dict(self):
+        return dict(self._fields)
+
+
+class ContentsOnlyMessage:
+    """A message whose text cannot be computed — e.g. a tool-call-only turn."""
+
+    def __init__(self, contents=None):
+        self.contents = contents if contents is not None else [
+            ContentLike(type="function_call", name="book_flight")
+        ]
+        self.text = ""
+
+
+class Opaque:
+    """No text, no contents, no __str__ — the genuine last resort."""
+
+
+def assert_not_a_repr(value: str) -> None:
+    assert "object at 0x" not in value, f"rendered as an object repr: {value}"
+
+
+# -- rendering one turn input ----------------------------------------------
+
+def test_string_is_returned_unchanged():
+    assert render(PROMPT) == PROMPT
+
+
+def test_message_with_contents_renders_its_text():
+    rendered = render(MessageLike())
+    assert rendered == PROMPT
+    assert_not_a_repr(rendered)
+
+
+def test_legacy_content_singular_is_still_supported():
+    assert render(LegacyMessage()) == PROMPT
+
+
+def test_message_without_usable_text_is_not_a_repr():
+    """A turn carrying no text must still not be exported as an object repr."""
+    assert_not_a_repr(render(ContentsOnlyMessage()))
+
+
+def test_contents_whose_to_dict_raises_still_render():
+    class Hostile:
+        def to_dict(self):
+            raise RuntimeError("boom")
+
+    class Message:
+        text = ""
+        contents = [Hostile()]
+
+    # Nothing better than the repr exists here; the point is that it does not raise.
+    assert isinstance(render(Message()), str)
+
+
+def test_non_string_text_attribute_is_not_trusted():
+    """A `text` that is not a string must not be returned as the input.
+
+    The contents are used instead, joined by the module's own
+    ``_extract_text_from_content``.
+    """
+    class WeirdText:
+        text = 42
+        content = "fallback"
+
+    assert render(WeirdText()) == "fallback"
+
+
+def test_opaque_object_is_stringified_as_a_last_resort():
+    # Nothing better exists here; the point is that it does not raise.
+    assert isinstance(render(Opaque()), str)
+
+
+# -- the accessor the span uses --------------------------------------------
+
+def test_positional_message_is_rendered():
+    rendered = extract_request_agent_input({"args": (MessageLike(),), "kwargs": {}})
+    assert rendered == PROMPT
+    assert_not_a_repr(rendered)
+
+
+def test_positional_string_is_rendered():
+    assert extract_request_agent_input({"args": (PROMPT,), "kwargs": {}}) == PROMPT
+
+
+@pytest.mark.parametrize("key", ["input", "message", "query"])
+def test_message_passed_by_keyword_is_rendered(key):
+    rendered = extract_request_agent_input({"args": (), "kwargs": {key: MessageLike()}})
+    assert rendered == PROMPT
+    assert_not_a_repr(rendered)
+
+
+def test_messages_list_renders_the_first_message():
+    rendered = extract_request_agent_input(
+        {"args": (), "kwargs": {"messages": [MessageLike(), MessageLike("second")]}}
+    )
+    assert rendered == PROMPT
+    assert_not_a_repr(rendered)
+
+
+def test_empty_messages_list_does_not_raise():
+    assert isinstance(
+        extract_request_agent_input({"args": (), "kwargs": {"messages": []}}), str
+    )
+
+
+def test_no_input_yields_empty_string():
+    assert extract_request_agent_input({"args": (), "kwargs": {}}) == ""
+
+
+def test_extraction_failure_is_swallowed():
+    """The accessor must never break span creation."""
+    class Exploding:
+        @property
+        def text(self):
+            raise RuntimeError("boom")
+
+    assert extract_request_agent_input({"args": (Exploding(),), "kwargs": {}}) == ""
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/test_tools/src/monocle_test_tools/runner/foundry_runner.py
+++ b/test_tools/src/monocle_test_tools/runner/foundry_runner.py
@@ -1,0 +1,201 @@
+import asyncio
+import logging
+import os
+import re
+from typing import Any, Optional, Union
+
+import requests
+
+from monocle_test_tools.runner.agent_runner import AgentRunner
+
+logger = logging.getLogger(__name__)
+
+# Okahu holds the deployed agent's spans; the trace is looked up by id, not by a fact.
+REMOTE_TRACE_SOURCE = "okahu"
+REMOTE_TRACE_FACT = "trace"
+# Workflow the deployed agent exports under, when not passed to the constructor.
+FOUNDRY_TRACE_WORKFLOW_ENV = "FOUNDRY_TRACE_WORKFLOW"
+
+# Entra scope for the Foundry project data plane.
+FOUNDRY_SCOPE = "https://ai.azure.com/.default"
+
+# The hosted-agents surface is preview-gated; this is the opt-in azure-ai-projects
+# sends for the agents operations.
+FOUNDRY_FEATURES_HEADER = "Foundry-Features"
+FOUNDRY_FEATURES_VALUE = (
+    "WorkflowAgents=V1Preview,ExternalAgents=V1Preview,"
+    "DraftAgents=V1Preview,AgentsOptimization=V2Preview"
+)
+
+# Required on the agent endpoint route, and rejected on the model-deployment
+# route, so it is added only when the caller left it off.
+DEFAULT_API_VERSION = "v1"
+
+# The response carries the trace id under this header. Something on the path
+# duplicates it as "<id>,<id>", so only the first value is the id.
+TRACE_ID_HEADER = "x-request-id"
+SESSION_ID_HEADER = "x-agent-session-id"
+
+# .../agents/<name>/endpoint/... — the agent addresses itself by name in the body,
+# so the name is read back off the URL rather than asked for twice.
+_AGENT_NAME_RE = re.compile(r"/agents/([^/]+)/endpoint\b")
+
+
+class FoundryRunner(AgentRunner):
+    """Invokes an agent already deployed to Azure AI Foundry.
+
+    ``root_agent`` is the agent's Responses URL, shaped
+    ``{project}/agents/{agent}/endpoint/protocols/openai/responses`` — not the
+    project's ``/openai/v1/responses``, which resolves model deployments.
+
+    Spans come from the deployed agent's own instrumentation and are retrieved
+    from Okahu by the trace id in ``x-request-id``. That needs the workflow name
+    it exports under (``trace_workflow_name`` or ``FOUNDRY_TRACE_WORKFLOW``);
+    without it retrieval is skipped and only the response can be asserted on.
+    """
+
+    def __init__(self, credential: Any = None, trace_workflow_name: Optional[str] = None):
+        """A ``DefaultAzureCredential`` is built lazily when none is passed, so
+        ``az login`` and CI workload identity both work unchanged."""
+        self._credential = credential
+        self._trace_workflow_name = trace_workflow_name or os.environ.get(
+            FOUNDRY_TRACE_WORKFLOW_ENV)
+        self._last_trace_id: Optional[str] = None
+        self._last_session_id: Optional[str] = None
+
+    def _get_token(self) -> str:
+        """Return a bearer token for the Foundry data plane."""
+        if self._credential is None:
+            try:
+                from azure.identity import DefaultAzureCredential
+            except ImportError as e:
+                raise ImportError(
+                    "azure-identity is required to use the Foundry runner. "
+                    "Install it with `pip install azure-identity`."
+                ) from e
+            self._credential = DefaultAzureCredential()
+        return self._credential.get_token(FOUNDRY_SCOPE).token
+
+    @staticmethod
+    def _with_api_version(url: str) -> str:
+        """Add ``api-version``; the agent route rejects the request without it."""
+        if "api-version=" in url:
+            return url
+        separator = "&" if "?" in url else "?"
+        return f"{url}{separator}api-version={DEFAULT_API_VERSION}"
+
+    @staticmethod
+    def _agent_name_from_url(url: str) -> Optional[str]:
+        match = _AGENT_NAME_RE.search(url)
+        return match.group(1) if match else None
+
+    @staticmethod
+    def _build_payload(test_message: Union[str, dict, Any], model: Optional[str]) -> dict:
+        """Encode the message as a non-streaming Responses body.
+
+        A dict is sent verbatim. Streaming is off so assertions read one JSON body.
+        """
+        if isinstance(test_message, dict):
+            return test_message
+        body: dict = {"input": test_message, "stream": False}
+        if model:
+            body["model"] = model
+        return body
+
+    @staticmethod
+    def _first_header_value(value: Optional[str]) -> Optional[str]:
+        """First value of a comma-duplicated header; Foundry returns ``<id>,<id>``."""
+        if not value:
+            return None
+        return value.split(",")[0].strip() or None
+
+    def get_last_trace_id(self) -> Optional[str]:
+        """Trace id the deployed agent reported for the last call."""
+        return self._last_trace_id
+
+    def get_last_session_id(self) -> Optional[str]:
+        """Foundry session id for the last call, for correlation only.
+
+        Not the trace id; Foundry mints a new one unless the call is chained
+        with ``previous_response_id``.
+        """
+        return self._last_session_id
+
+    async def run_agent_async(self, root_agent: str, *args, timeout: int = 180,
+                              model: Optional[str] = None, headers: Optional[dict] = None,
+                              **kwargs) -> Any:
+        """Invoke the deployed agent over the Responses protocol.
+
+        The first positional arg is the message; ``model`` defaults to the agent
+        name in the URL, ``headers`` merge over the defaults, and the rest is
+        passed to ``requests.post``. Returns the ``requests.Response``.
+        """
+        if root_agent is None or not isinstance(root_agent, str):
+            raise ValueError(
+                "For FoundryRunner, root_agent must be the deployed agent's Responses URL string."
+            )
+
+        test_message = args[0] if args else None
+        url = self._with_api_version(root_agent)
+        body = self._build_payload(test_message, model or self._agent_name_from_url(url))
+
+        request_headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self._get_token()}",
+            FOUNDRY_FEATURES_HEADER: FOUNDRY_FEATURES_VALUE,
+        }
+        if headers:
+            request_headers.update(headers)
+
+        # Identifiers belong to one invocation; a reused runner must not report
+        # the previous call's.
+        self._last_trace_id = None
+        self._last_session_id = None
+
+        response = requests.post(url, json=body, headers=request_headers,
+                                 timeout=timeout, **kwargs)
+        logger.debug(f"Foundry response status={response.status_code}")
+
+        # Read before raise_for_status so a failing call still says which trace
+        # to go and look at.
+        self._last_trace_id = self._first_header_value(response.headers.get(TRACE_ID_HEADER))
+        self._last_session_id = self._first_header_value(
+            response.headers.get(SESSION_ID_HEADER))
+
+        response.raise_for_status()
+        return response
+
+    def get_remote_traces_source(self) -> Optional[str]:
+        """Report a source only once retrieval can succeed, so an unconfigured
+        runner skips it instead of importing nothing."""
+        if self._trace_workflow_name and self._last_trace_id:
+            return REMOTE_TRACE_SOURCE
+        return None
+
+    def get_remote_trace_query(self) -> dict:
+        """Identify the deployed agent's spans by the trace id it reported.
+
+        The agent exports under the same trace id Foundry returns in
+        ``x-request-id``, an id this process never used — so the spans found can
+        only be the deployed agent's.
+        """
+        if not (self._trace_workflow_name and self._last_trace_id):
+            return {}
+        return {
+            "id": self._last_trace_id,
+            "fact_name": REMOTE_TRACE_FACT,
+            "workflow_name": self._trace_workflow_name,
+        }
+
+    def run_agent(self, root_agent: str, *args, **kwargs) -> Any:
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        if loop and loop.is_running():
+            import concurrent.futures
+            with concurrent.futures.ThreadPoolExecutor() as pool:
+                future = pool.submit(asyncio.run,
+                                     self.run_agent_async(root_agent, *args, **kwargs))
+                return future.result()
+        return asyncio.run(self.run_agent_async(root_agent, *args, **kwargs))

--- a/test_tools/src/monocle_test_tools/runner/runner.py
+++ b/test_tools/src/monocle_test_tools/runner/runner.py
@@ -12,6 +12,7 @@ class AgentTypes(str, Enum):
     HTTP = "http"
     HTTP_WITH_OKAHU = "http_with_okahu"
     AGENTCORE = "agentcore"
+    FOUNDRY = "foundry"
 
 def get_agent_runner(runner_type: str) -> AgentRunner:
     if runner_type == AgentTypes.GOOGLE_ADK:
@@ -44,5 +45,8 @@ def get_agent_runner(runner_type: str) -> AgentRunner:
     elif runner_type == AgentTypes.AGENTCORE:
         from .agentcore_runner import AgentCoreRunner
         return AgentCoreRunner()
+    elif runner_type == AgentTypes.FOUNDRY:
+        from .foundry_runner import FoundryRunner
+        return FoundryRunner()
     else:
         raise ValueError(f"Unknown runner type: {runner_type}")

--- a/test_tools/tests/unit/test_foundry_runner.py
+++ b/test_tools/tests/unit/test_foundry_runner.py
@@ -1,0 +1,240 @@
+"""Unit tests for the Foundry runner.
+
+All tests use an injected fake credential and a patched ``requests.post``, so
+they run without azure-identity, Azure credentials, a deployed agent, or any
+network access.
+"""
+import pytest
+import requests
+
+from monocle_test_tools.runner.runner import get_agent_runner, AgentTypes
+from monocle_test_tools.runner.foundry_runner import (
+    FOUNDRY_FEATURES_HEADER,
+    FOUNDRY_SCOPE,
+    FoundryRunner,
+)
+
+PROJECT = "https://acct.services.ai.azure.com/api/projects/proj"
+AGENT_URL = f"{PROJECT}/agents/travel-agent/endpoint/protocols/openai/responses"
+# Workflow the deployed agent reports under — not the test's own workflow.
+REMOTE_WORKFLOW = "deployed_agent_workflow"
+TRACE_ID = "1004ac724700a70b0c8ab9a1f0fe8234"
+SESSION_ID = "0b6e34f11344a024f377e3c346c556286c0665614161cc954ddd5974fd10fa9"
+
+
+class FakeToken:
+    def __init__(self, token="fake-token"):
+        self.token = token
+
+
+class FakeCredential:
+    """Records the scope it was asked for and returns a canned token."""
+
+    def __init__(self, token="fake-token"):
+        self._token = token
+        self.scopes = []
+
+    def get_token(self, *scopes, **kwargs):
+        self.scopes.append(scopes)
+        return FakeToken(self._token)
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, headers=None, text='{"output": []}'):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.text = text
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} Error", response=self)
+
+
+@pytest.fixture
+def captured_post(monkeypatch):
+    """Patch requests.post and record the call it receives."""
+    calls = []
+    response_holder = {
+        "response": FakeResponse(
+            headers={"x-request-id": TRACE_ID, "x-agent-session-id": SESSION_ID}
+        )
+    }
+
+    def fake_post(url, **kwargs):
+        calls.append({"url": url, **kwargs})
+        return response_holder["response"]
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    return calls, response_holder
+
+
+# -- registry ---------------------------------------------------------------
+
+def test_agent_type_mapping():
+    assert AgentTypes.FOUNDRY.value == "foundry"
+    assert isinstance(get_agent_runner("foundry"), FoundryRunner)
+
+
+# -- url handling -----------------------------------------------------------
+
+def test_api_version_is_added_when_missing():
+    assert FoundryRunner._with_api_version(AGENT_URL) == f"{AGENT_URL}?api-version=v1"
+
+
+def test_api_version_supplied_by_the_caller_is_kept():
+    url = f"{AGENT_URL}?api-version=2025-11-15-preview"
+    assert FoundryRunner._with_api_version(url) == url
+
+
+def test_api_version_is_appended_to_an_existing_query():
+    assert FoundryRunner._with_api_version(f"{AGENT_URL}?foo=bar") == (
+        f"{AGENT_URL}?foo=bar&api-version=v1"
+    )
+
+
+def test_agent_name_is_read_off_the_url():
+    assert FoundryRunner._agent_name_from_url(AGENT_URL) == "travel-agent"
+
+
+def test_agent_name_is_none_when_the_url_names_no_agent():
+    assert FoundryRunner._agent_name_from_url(f"{PROJECT}/openai/v1/responses") is None
+
+
+# -- headers ----------------------------------------------------------------
+
+def test_duplicated_request_id_header_yields_one_id():
+    """Foundry returns x-request-id as '<id>,<id>'; the joined form is not an id."""
+    assert FoundryRunner._first_header_value(f"{TRACE_ID},{TRACE_ID}") == TRACE_ID
+
+
+def test_single_valued_request_id_header_is_unchanged():
+    assert FoundryRunner._first_header_value(TRACE_ID) == TRACE_ID
+
+
+@pytest.mark.parametrize("value", [None, "", ",", "  "])
+def test_absent_or_empty_request_id_header_yields_none(value):
+    assert FoundryRunner._first_header_value(value) is None
+
+
+# -- payload ----------------------------------------------------------------
+
+def test_string_message_becomes_a_non_streaming_responses_body():
+    assert FoundryRunner._build_payload("Book a flight", "travel-agent") == {
+        "input": "Book a flight",
+        "stream": False,
+        "model": "travel-agent",
+    }
+
+
+def test_dict_message_is_sent_verbatim():
+    body = {"input": [{"role": "user", "content": []}], "stream": True}
+    assert FoundryRunner._build_payload(body, "travel-agent") == body
+
+
+# -- the request ------------------------------------------------------------
+
+def test_request_carries_token_features_header_and_body(captured_post):
+    calls, _ = captured_post
+    credential = FakeCredential()
+    runner = FoundryRunner(credential=credential, trace_workflow_name=REMOTE_WORKFLOW)
+
+    runner.run_agent(AGENT_URL, "Book a flight from Delhi to Phuket")
+
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["url"] == f"{AGENT_URL}?api-version=v1"
+    assert call["headers"]["Authorization"] == "Bearer fake-token"
+    assert call["headers"][FOUNDRY_FEATURES_HEADER]
+    assert call["json"]["model"] == "travel-agent"
+    assert call["json"]["stream"] is False
+    assert credential.scopes == [(FOUNDRY_SCOPE,)]
+
+
+def test_caller_headers_win_over_the_defaults(captured_post):
+    calls, _ = captured_post
+    runner = FoundryRunner(credential=FakeCredential())
+
+    runner.run_agent(AGENT_URL, "hi", headers={FOUNDRY_FEATURES_HEADER: "Custom=V1"})
+
+    assert calls[0]["headers"][FOUNDRY_FEATURES_HEADER] == "Custom=V1"
+
+
+def test_response_identifiers_are_captured(captured_post):
+    runner = FoundryRunner(credential=FakeCredential(), trace_workflow_name=REMOTE_WORKFLOW)
+
+    runner.run_agent(AGENT_URL, "hi")
+
+    assert runner.get_last_trace_id() == TRACE_ID
+    assert runner.get_last_session_id() == SESSION_ID
+
+
+def test_trace_id_is_captured_even_when_the_call_fails(captured_post):
+    """A failing call must still say which trace to go and look at."""
+    _, holder = captured_post
+    holder["response"] = FakeResponse(status_code=500, headers={"x-request-id": TRACE_ID},
+                                      text="boom")
+    runner = FoundryRunner(credential=FakeCredential(), trace_workflow_name=REMOTE_WORKFLOW)
+
+    with pytest.raises(requests.HTTPError):
+        runner.run_agent(AGENT_URL, "hi")
+
+    assert runner.get_last_trace_id() == TRACE_ID
+
+
+def test_identifiers_do_not_leak_between_calls(captured_post):
+    _, holder = captured_post
+    runner = FoundryRunner(credential=FakeCredential(), trace_workflow_name=REMOTE_WORKFLOW)
+    runner.run_agent(AGENT_URL, "hi")
+    assert runner.get_last_trace_id() == TRACE_ID
+
+    holder["response"] = FakeResponse(headers={})
+    runner.run_agent(AGENT_URL, "hi")
+
+    assert runner.get_last_trace_id() is None
+    assert runner.get_remote_trace_query() == {}
+
+
+def test_root_agent_must_be_a_url():
+    with pytest.raises(ValueError, match="Responses URL"):
+        FoundryRunner(credential=FakeCredential()).run_agent(None, "hi")
+
+
+# -- remote trace retrieval -------------------------------------------------
+
+def test_remote_trace_query_names_the_trace_id(captured_post):
+    runner = FoundryRunner(credential=FakeCredential(), trace_workflow_name=REMOTE_WORKFLOW)
+
+    runner.run_agent(AGENT_URL, "hi")
+
+    assert runner.get_remote_traces_source() == "okahu"
+    assert runner.get_remote_trace_query() == {
+        "id": TRACE_ID,
+        "fact_name": "trace",
+        "workflow_name": REMOTE_WORKFLOW,
+    }
+
+
+def test_retrieval_is_skipped_without_a_workflow_name(captured_post):
+    """Without somewhere to look, retrieval is skipped rather than importing nothing."""
+    runner = FoundryRunner(credential=FakeCredential(), trace_workflow_name=None)
+
+    runner.run_agent(AGENT_URL, "hi")
+
+    assert runner.get_remote_traces_source() is None
+    assert runner.get_remote_trace_query() == {}
+
+
+def test_workflow_name_falls_back_to_the_environment(monkeypatch):
+    monkeypatch.setenv("FOUNDRY_TRACE_WORKFLOW", REMOTE_WORKFLOW)
+    assert FoundryRunner()._trace_workflow_name == REMOTE_WORKFLOW
+
+
+def test_retrieval_is_skipped_before_any_call():
+    runner = FoundryRunner(credential=FakeCredential(), trace_workflow_name=REMOTE_WORKFLOW)
+
+    assert runner.get_remote_traces_source() is None
+    assert runner.get_remote_trace_query() == {}
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
…s text

Two MS Agent Framework fixes.

A foundry runner invokes an agent already deployed to Azure AI Foundry and pulls its spans back from Okahu, so existing assertions apply to a remote agent — the Foundry counterpart to the agentcore runner. root_agent is the agent's Responses URL rather than an agent object. It authenticates with an Entra bearer token via DefaultAzureCredential, so az login and CI workload identity both work unchanged, and retrieves spans by the trace id Foundry returns in x-request-id — an id the test process never used, so the spans found can only be the deployed agent's. Retrieval needs the workflow name the agent exports under (trace_workflow_name or FOUNDRY_TRACE_WORKFLOW); without it retrieval is skipped and only the response is asserted on. Also handled for the caller: api-version is added when absent, since the agent route rejects the request without it; the preview Foundry-Features header is sent; and x-request-id is de-duplicated, because Foundry returns it as "<id>,<id>".

The turn span recorded "<agent_framework._types.Message object at 0x...>" in data.input instead of the prompt. It read `content`, which agent-framework 1.6.0 renamed to `contents`, so the guard missed and str() ran on a class with no __str__. The module's existing _extract_text_from_content already reads a Message through its computed `text`, so it is used instead of hand-rolled attribute checks, and the remaining fallback refuses to export an object repr.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...