### PR TITLE
Karmehr/okahu pagination

### DIFF
--- a/docs/monocle_evaluation_api.md
+++ b/docs/monocle_evaluation_api.md
@@ -516,7 +516,7 @@ monocle_trace_asserter \
 |---|---|---|
 | `min_facts` | `1` | Fail the run if fewer than this many facts were discovered — guards against a vacuous pass on an empty window. |
 | `fail_threshold` | `0` | Allow up to this many non-matching facts before the assertion fails. |
-| `max_facts` | `OKAHU_MAX_FACTS` (`1000`) | Runaway guard — fail loudly if the window discovers more than this many facts. |
+| `max_facts` | `OKAHU_MAX_FACTS` (`1000`) | Runaway guard — fail loudly if the window discovers more than this many facts. Applies to filtered evals and to `setup_test_cases` discovery. |
 
 **Reading results.** Both the filtered and single-fact paths populate the same report (filtered = N facts; single-fact = a 1-fact report), on pass **and** failure:
 

--- a/test_tools/README.md
+++ b/test_tools/README.md
@@ -627,6 +627,8 @@ Each fact costs a request for its spans, plus one per fact above trace level to 
 
 Since a wide window now yields every fact rather than the first hundred, it also costs proportionally more collection time — roughly one span request per trace. Freeze to JSON, or narrow the window, if that matters to you.
 
+**Discovery is capped.** Because every page is now walked, a wide window can yield thousands of facts — and each one costs a span request plus, with `check_eval`, an eval. `max_facts` bounds that, defaulting to 1000 and overridable per call or with the `OKAHU_MAX_FACTS` environment variable (the same variable `okahu_filtered_eval` already honours). A window holding more raises, naming the count and the ceiling, rather than silently returning the first 1000 — a truncated subset is what the pagination fix set out to remove. Narrow the window, or raise the ceiling deliberately. The cap applies to `setup_test_cases` only: loading one named session or scope with `with_trace_source` is never bounded by it.
+
 **A fact that will not load does not cost you the window.** `setup_test_cases` runs at collection time, so raising would mean *no* tests run at all. Instead the fact is still returned, carrying the reason, and the first `testcase=` call it reaches fails with it — so it shows up as one failing test named after the fact while every other case runs normally. The bulk eval report is one call for all facts, so if *it* fails the reason is recorded against each of them.
 
 ```
@@ -1289,7 +1291,7 @@ validator.check_duration_limits(max_duration=30.0, units="seconds", span_type="w
 | `MONOCLE_TRACE_OUTPUT_PATH` | Directory for file-based trace output | `.monocle/test_traces` |
 | `OKAHU_API_KEY` | API key for Okahu evaluation and trace export | — |
 | `OKAHU_EVALUATION_ENDPOINT` | Override the Okahu evaluation endpoint | `https://eval.okahu.co/api` |
-| `OKAHU_MAX_FACTS` | Runaway guard for time-window (filtered) evals: fail loudly if a filter discovers more than this many facts (see [Time-window evaluation](#time-window-filtered-evaluation)) | `1000` |
+| `OKAHU_MAX_FACTS` | Runaway guard: fail loudly if a time-window (filtered) eval discovers, or `setup_test_cases` enumerates, more than this many facts (see [Time-window evaluation](#time-window-filtered-evaluation)) | `1000` |
 | `MONOCLE_EVAL_MATRIX` | Set (to any value, optionally a path) to enable the opt-in eval-result-matrix recorder (see [Eval result matrix](#eval-result-matrix)). Off when unset | unset (off) |
 | `LOCAL_RUN_ID` | Run identifier applied to all spans in a session | ISO datetime at session start |
 

--- a/test_tools/README.md
+++ b/test_tools/README.md
@@ -623,6 +623,10 @@ Since these cases carry agents and tools as well as evals, they feed the selecto
 
 Each fact costs a request for its spans, plus one per fact above trace level to find its traces, plus one for the report. A wide window is a lot of calls — freeze the result to JSON if you will re-run it.
 
+**Every page is walked.** Discovery used to read only the server's first page of 100 and stop, with no indication more existed — a window holding 309 traces produced 100 test cases, and the rest were not dropped or reported, they simply never appeared. `page_size` (default 200, server maximum 1000) now governs the trace enumeration, the fact enumeration and the eval report alike, so they cannot disagree about page depth. If a walk still comes back short of the count the server advertises, a warning names both numbers rather than handing back a short list in silence.
+
+Since a wide window now yields every fact rather than the first hundred, it also costs proportionally more collection time — roughly one span request per trace. Freeze to JSON, or narrow the window, if that matters to you.
+
 **A fact that will not load does not cost you the window.** `setup_test_cases` runs at collection time, so raising would mean *no* tests run at all. Instead the fact is still returned, carrying the reason, and the first `testcase=` call it reaches fails with it — so it shows up as one failing test named after the fact while every other case runs normally. The bulk eval report is one call for all facts, so if *it* fails the reason is recorded against each of them.
 
 ```

--- a/test_tools/src/monocle_test_tools/okahu_span_loader.py
+++ b/test_tools/src/monocle_test_tools/okahu_span_loader.py
@@ -282,7 +282,7 @@ class OkahuSpanLoader:
                          eval_filter: Optional[str] = None,
                          check_eval: Optional[Union[bool, str]] = None,
                          compare_eval: Optional[str] = None,
-                         page_size: int = 100) -> list:
+                         page_size: int = DEFAULT_PAGE_SIZE) -> list:
         """Build FluentTestCases from the traces recorded for a workflow.
 
         One test case per fact in the window. How the facts are found depends on
@@ -364,7 +364,9 @@ class OkahuSpanLoader:
                 eval-tuning question: does a new template reproduce a golden
                 one's labels? Requires ``check_eval`` to be a name, since there
                 is otherwise nothing to attach the borrowed label to.
-            page_size: Rows per page (server max 1000).
+            page_size: Rows per page for the trace/fact enumeration and the eval
+                report alike -- one knob, so they cannot disagree about page
+                depth. Server maximum 1000.
 
         Returns:
             One FluentTestCase per fact that has at least one labelled eval.
@@ -404,11 +406,12 @@ class OkahuSpanLoader:
         if mapped_fact_name == "traces":
             fact_ids = [normalize_fact_id(tid) for tid in cls.get_trace_ids(
                 workflow_name, start_time=start_time, end_time=end_time,
-                eval_filter=eval_filter)]
+                eval_filter=eval_filter, page_size=page_size)]
         else:
             fact_ids = cls.get_fact_ids(
                 workflow_name, mapped_fact_name,
-                start_time=start_time, end_time=end_time, eval_filter=eval_filter)
+                start_time=start_time, end_time=end_time,
+                eval_filter=eval_filter, page_size=page_size)
         if not fact_ids:
             return []
 
@@ -461,7 +464,8 @@ class OkahuSpanLoader:
             try:
                 spans = cls._fact_spans(
                     workflow_name, fact_id, mapped_fact_name=mapped_fact_name,
-                    start_time=start_time, end_time=end_time, eval_filter=eval_filter)
+                    start_time=start_time, end_time=end_time,
+                    eval_filter=eval_filter, page_size=page_size)
             except cls._LOAD_ERRORS as exc:
                 test_cases.append(FluentTestCase(
                     name=fact_id, input=fact,
@@ -489,7 +493,8 @@ class OkahuSpanLoader:
 
     @classmethod
     def _fact_spans(cls, workflow_name, fact_id, *, mapped_fact_name,
-                    start_time, end_time, eval_filter=None) -> list:
+                    start_time, end_time, eval_filter=None,
+                    page_size=None) -> list:
         """Every span belonging to one fact.
 
         A trace-level fact is one trace, so its spans are one call. A higher
@@ -503,7 +508,8 @@ class OkahuSpanLoader:
         spans = []
         for trace_id in cls.get_trace_ids(
                 workflow_name, mapped_fact_name, fact_id,
-                start_time=start_time, end_time=end_time, eval_filter=eval_filter):
+                start_time=start_time, end_time=end_time,
+                eval_filter=eval_filter, page_size=page_size):
             spans.extend(cls.get_spans(
                 workflow_name, trace_id, start_time=start_time, end_time=end_time))
         return spans

--- a/test_tools/src/monocle_test_tools/okahu_span_loader.py
+++ b/test_tools/src/monocle_test_tools/okahu_span_loader.py
@@ -521,6 +521,7 @@ class OkahuSpanLoader:
         start_time: Optional[str] = None,
         end_time: Optional[str] = None,
         eval_filter: Optional[str] = None,
+        page_size: Optional[int] = None,
     ) -> List[str]:
         """Fetch the ids of every fact of one level in a workflow.
 
@@ -551,32 +552,44 @@ class OkahuSpanLoader:
             eval_filter: Optional ``eval`` filter narrowing the result set to
                 facts carrying it -- a bare eval name, or the API's
                 ``name:label;name:label`` form.
+            page_size: Rows per page. Defaults to DEFAULT_PAGE_SIZE (200);
+                the server rejects anything above MAX_PAGE_SIZE (1000).
 
         Returns:
-            The fact ids, in the order the server returned them.
+            The fact ids across every page, in the order the server returned them.
         """
+        page_size = OkahuSpanLoader._resolve_page_size(page_size)
         base = OkahuSpanLoader._get_api_base(endpoint)
         headers = OkahuSpanLoader._get_headers(api_key)
         url = f"{base}/api/v1/workflows/{workflow_name}/facts/{fact_name}/ids"
         params = {"duration_fact": fact_name, "breakdown_filter": fact_name}
         params.update(OkahuSpanLoader._window_params(start_time, end_time))
         params.update(OkahuSpanLoader._eval_param(eval_filter))
+        context_msg = f"{fact_name} ids in workflow '{workflow_name}'"
 
-        data = OkahuSpanLoader._do_get(
-            url, headers, params=params, timeout=timeout,
-            context_msg=f"{fact_name} ids in workflow '{workflow_name}'")
+        def fetch(page_params):
+            return OkahuSpanLoader._do_get(
+                url, headers, params=page_params, timeout=timeout,
+                context_msg=context_msg)
 
-        fact_ids = (data or {}).get("fact_ids")
-        if isinstance(fact_ids, dict):
-            return list(fact_ids)
-        if isinstance(fact_ids, list):
-            return [item.get("fact_id") if isinstance(item, dict) else item
-                    for item in fact_ids]
-        if fact_ids is None:
-            return []
-        raise ConnectionError(
-            f"Okahu returned an unexpected 'fact_ids' for {fact_name} in workflow "
-            f"'{workflow_name}': {type(fact_ids).__name__}")
+        def extract(envelope):
+            """The ids of one page. fact_ids is keyed by id, so its keys ARE the
+            ids and the order is the server's."""
+            fact_ids = (envelope.get("fact_ids")
+                        if isinstance(envelope, dict) else None)
+            if isinstance(fact_ids, dict):
+                return list(fact_ids)
+            if isinstance(fact_ids, list):
+                return [item.get("fact_id") if isinstance(item, dict) else item
+                        for item in fact_ids]
+            if fact_ids is None:
+                return []
+            raise ConnectionError(
+                f"Okahu returned an unexpected 'fact_ids' for {fact_name} in "
+                f"workflow '{workflow_name}': {type(fact_ids).__name__}")
+
+        return OkahuSpanLoader._collect_paged(
+            fetch, params, page_size, extract, context_msg)
 
     @staticmethod
     def get_trace_ids(

--- a/test_tools/src/monocle_test_tools/okahu_span_loader.py
+++ b/test_tools/src/monocle_test_tools/okahu_span_loader.py
@@ -38,6 +38,10 @@ class OkahuSpanLoader:
     DEFAULT_PAGE_SIZE = 200
     MAX_PAGE_SIZE = 1000
 
+    # The ceiling okahu_filtered_eval applies to a filtered run (evals/
+    # okahu_filtered_eval.py:319), so both paths bound a window the same way.
+    DEFAULT_MAX_FACTS = 1000
+
     @staticmethod
     def _get_api_base(endpoint: Optional[str] = None) -> str:
         """Return the Okahu API base URL (no trailing slash).
@@ -105,6 +109,46 @@ class OkahuSpanLoader:
                 f"page_size must be between 1 and {OkahuSpanLoader.MAX_PAGE_SIZE} "
                 f"(the Okahu server's MAX_PAGE_SIZE), got {page_size}")
         return page_size
+
+    @staticmethod
+    def _resolve_max_facts(max_facts: Optional[int] = None) -> int:
+        """The most facts one discovery run may yield: argument, else env, else 1000.
+
+        Mirrors the ceiling okahu_filtered_eval applies to a filtered run
+        (evals/okahu_filtered_eval.py:319), so a deployment already setting
+        OKAHU_MAX_FACTS gets the same bound here. Kept as a separate
+        implementation rather than a shared import because okahu_span_loader and
+        the evals modules form an import cycle -- see the local imports in
+        setup_test_cases.
+
+        An unusable OKAHU_MAX_FACTS -- empty, non-numeric, or not positive -- is
+        logged and ignored rather than stopping discovery, matching how
+        OKAHU_API_TIMEOUT resolves. Deliberately more tolerant than
+        okahu_filtered_eval, whose bare int() would raise on a bad value.
+        """
+        if max_facts is not None:
+            # bool before int: isinstance(True, int) is True, so max_facts=True
+            # would otherwise pass as a ceiling of 1.
+            if isinstance(max_facts, bool) or not isinstance(max_facts, int):
+                raise ValueError(
+                    f"max_facts must be an int, got {type(max_facts).__name__}")
+            if max_facts < 1:
+                raise ValueError(f"max_facts must be at least 1, got {max_facts}")
+            return max_facts
+
+        raw = (os.environ.get("OKAHU_MAX_FACTS") or "").strip()
+        if not raw:
+            return OkahuSpanLoader.DEFAULT_MAX_FACTS
+        try:
+            ceiling = int(raw)
+        except ValueError:
+            ceiling = 0
+        if ceiling < 1:
+            logger.warning(
+                "OKAHU_MAX_FACTS=%r is not a positive integer; using %d",
+                raw, OkahuSpanLoader.DEFAULT_MAX_FACTS)
+            return OkahuSpanLoader.DEFAULT_MAX_FACTS
+        return ceiling
 
     @staticmethod
     def _get_headers(api_key: Optional[str] = None) -> dict:

--- a/test_tools/src/monocle_test_tools/okahu_span_loader.py
+++ b/test_tools/src/monocle_test_tools/okahu_span_loader.py
@@ -531,8 +531,14 @@ class OkahuSpanLoader:
     ) -> List[str]:
         """Fetch the ids of every fact of one level in a workflow.
 
-        Uses:  GET /api/v1/workflows/<wf>/facts/<fact_name>/ids
+        Uses:  GET /api/v1/<apps|workflows>/<wf>/facts/<fact_name>/ids
                ?duration_fact=<fact_name>&breakdown_filter=<fact_name>
+
+        The namespace is resolved the same way get_trace_ids resolves it, trying
+        ``apps`` before ``workflows``. This used to be hardcoded to ``workflows``,
+        which quietly returned nothing on a deployment that keys its tenants
+        under ``apps``: that path answers 200 with an empty ``fact_ids`` rather
+        than 404, so every fact level came back empty and nothing raised.
 
         This is the entry point for any fact level above a trace -- agent
         requests, sessions, conversations. A trace-level set comes from
@@ -567,16 +573,15 @@ class OkahuSpanLoader:
         page_size = OkahuSpanLoader._resolve_page_size(page_size)
         base = OkahuSpanLoader._get_api_base(endpoint)
         headers = OkahuSpanLoader._get_headers(api_key)
-        url = f"{base}/api/v1/workflows/{workflow_name}/facts/{fact_name}/ids"
         params = {"duration_fact": fact_name, "breakdown_filter": fact_name}
         params.update(OkahuSpanLoader._window_params(start_time, end_time))
         params.update(OkahuSpanLoader._eval_param(eval_filter))
         context_msg = f"{fact_name} ids in workflow '{workflow_name}'"
 
         def fetch(page_params):
-            return OkahuSpanLoader._do_get(
-                url, headers, params=page_params, timeout=timeout,
-                context_msg=context_msg)
+            return OkahuSpanLoader._get_resource(
+                base, f"{workflow_name}/facts/{fact_name}/ids", headers,
+                params=page_params, timeout=timeout, context_msg=context_msg)
 
         def extract(envelope):
             """The ids of one page. fact_ids is keyed by id, so its keys ARE the

--- a/test_tools/src/monocle_test_tools/okahu_span_loader.py
+++ b/test_tools/src/monocle_test_tools/okahu_span_loader.py
@@ -603,6 +603,7 @@ class OkahuSpanLoader:
         start_time: Optional[str] = None,
         end_time: Optional[str] = None,
         eval_filter: Optional[str] = None,
+        page_size: Optional[int] = None,
     ) -> List[str]:
         """Fetch trace IDs from Okahu filtered by a fact.
 
@@ -625,9 +626,11 @@ class OkahuSpanLoader:
             api_key: Okahu API key override.
             timeout: Request timeout in seconds. Defaults to
                 OKAHU_API_TIMEOUT, then ``DEFAULT_API_TIMEOUT`` (120).
+            page_size: Rows per page. Defaults to DEFAULT_PAGE_SIZE (200);
+                the server rejects anything above MAX_PAGE_SIZE (1000).
 
         Returns:
-            A list of trace ID strings.
+            A list of trace ID strings, across every page.
 
         Raises:
             ValueError: If exactly one of fact_name / fact_id is given. Half a
@@ -638,6 +641,7 @@ class OkahuSpanLoader:
                 "fact_name and fact_id must be given together or not at all; "
                 f"got fact_name={fact_name!r}, fact_id={fact_id!r}")
 
+        page_size = OkahuSpanLoader._resolve_page_size(page_size)
         base = OkahuSpanLoader._get_api_base(endpoint)
         headers = OkahuSpanLoader._get_headers(api_key)
         params = {}
@@ -646,24 +650,34 @@ class OkahuSpanLoader:
             params["fact_ids"] = fact_id
         params.update(OkahuSpanLoader._window_params(start_time, end_time))
         params.update(OkahuSpanLoader._eval_param(eval_filter))
+        context_msg = (f"traces for {fact_name}='{fact_id}' in workflow "
+                       f"'{workflow_name}'" if fact_name
+                       else f"traces in workflow '{workflow_name}'")
 
-        data = OkahuSpanLoader._get_resource(
-            base, f"{workflow_name}/traces", headers, params=params, timeout=timeout,
-            context_msg=(f"traces for {fact_name}='{fact_id}' in workflow '{workflow_name}'"
-                         if fact_name else f"traces in workflow '{workflow_name}'")
-        )
+        def fetch(page_params):
+            # _get_resource re-resolves the apps/workflows namespace per page.
+            # When 'apps' is correct it returns on the first attempt, so this
+            # costs nothing; only the fallback path spends one debug-level 404
+            # per page, which is cheaper than threading resolved state through
+            # the pager.
+            return OkahuSpanLoader._get_resource(
+                base, f"{workflow_name}/traces", headers, params=page_params,
+                timeout=timeout, context_msg=context_msg)
 
-        trace_list = OkahuSpanLoader._unwrap_list(
-            data, ("traces", "data", "results"),
-            context_msg=f"traces for {fact_name}='{fact_id}'"
-        )
+        def extract(envelope):
+            trace_list = OkahuSpanLoader._unwrap_list(
+                envelope, ("traces", "data", "results"),
+                context_msg=f"traces for {fact_name}='{fact_id}'")
+            ids = []
+            for item in trace_list:
+                if isinstance(item, dict) and "trace_id" in item:
+                    ids.append(item["trace_id"])
+                elif isinstance(item, str):
+                    ids.append(item)
+            return ids
 
-        trace_ids = []
-        for item in trace_list:
-            if isinstance(item, dict) and "trace_id" in item:
-                trace_ids.append(item["trace_id"])
-            elif isinstance(item, str):
-                trace_ids.append(item)
+        trace_ids = OkahuSpanLoader._collect_paged(
+            fetch, params, page_size, extract, context_msg)
 
         logger.debug(
             "Found %d trace(s) for %s='%s' in workflow '%s'",

--- a/test_tools/src/monocle_test_tools/okahu_span_loader.py
+++ b/test_tools/src/monocle_test_tools/okahu_span_loader.py
@@ -204,6 +204,73 @@ class OkahuSpanLoader:
             f"Expected a list from Okahu ({context_msg}), got: {type(data).__name__}"
         )
 
+    @staticmethod
+    def _iter_pages(fetch, params: dict, page_size: int, context_msg: str = ""):
+        """Yield each response envelope, following the page token to exhaustion.
+
+        A GET/query-params sibling of okahu_eval._iter_eval_report_rows, which
+        walks the same protocol over POST/body. Both endpoints signal the end by
+        omitting next_page_token.
+
+        ``fetch`` is a callable taking the params dict and returning the parsed
+        envelope. It is supplied by the caller because get_trace_ids resolves its
+        namespace through _get_resource while get_fact_ids has a fixed URL.
+
+        The envelope is yielded whole rather than its items, so a caller wanting
+        something other than ids -- get_spans, eventually -- can reuse this.
+        """
+        page_token, seen_tokens = None, set()
+        while True:
+            page_params = {**params, "page_size": page_size}
+            if page_token:
+                # These GET routes read the token as 'next_page_token'; only the
+                # POST /evals/report pager spells it 'page_token'. The wrong name
+                # is not an error -- it is ignored and page 1 is re-served.
+                # Verified in okahu/routes/{traces,facts}.py, both of which do:
+                #   req.query_params.get('next_page_token') or ...('prev_page_token')
+                page_params["next_page_token"] = page_token
+            envelope = fetch(page_params)
+            yield envelope
+
+            # An envelope is not always a dict: some responses are a bare list.
+            page_token = (envelope.get("next_page_token")
+                          if isinstance(envelope, dict) else None)
+            if not page_token:
+                return
+            if page_token in seen_tokens:
+                logger.warning(
+                    "Okahu repeated a page token (%s); stopping the walk after "
+                    "%d pages", context_msg, len(seen_tokens) + 1)
+                return
+            seen_tokens.add(page_token)
+
+    @staticmethod
+    def _collect_paged(fetch, params: dict, page_size: int, extract,
+                       context_msg: str = "") -> list:
+        """Every item across every page, with a warning if the total falls short.
+
+        ``extract`` turns one envelope into its items, which is where the two
+        endpoints differ: /traces keys a list, /facts/<n>/ids keys a dict.
+
+        fact_count is read from every page, so a mid-walk revision by the server
+        takes effect -- and it costs nothing, the envelope is already open.
+        """
+        items, advertised = [], None
+        for envelope in OkahuSpanLoader._iter_pages(
+                fetch, params, page_size, context_msg):
+            items.extend(extract(envelope))
+            if isinstance(envelope, dict) and isinstance(
+                    envelope.get("fact_count"), int):
+                advertised = envelope["fact_count"]
+
+        if advertised is not None and len(items) != advertised:
+            # The defect this exists to kill was silent. Never return a short
+            # list without saying so.
+            logger.warning(
+                "Okahu returned %d of %d advertised (%s); the result is incomplete",
+                len(items), advertised, context_msg)
+        return items
+
     # ------------------------------------------------------------------ #
     #  Public helpers                                                     #
     # ------------------------------------------------------------------ #

--- a/test_tools/src/monocle_test_tools/okahu_span_loader.py
+++ b/test_tools/src/monocle_test_tools/okahu_span_loader.py
@@ -531,14 +531,8 @@ class OkahuSpanLoader:
     ) -> List[str]:
         """Fetch the ids of every fact of one level in a workflow.
 
-        Uses:  GET /api/v1/<apps|workflows>/<wf>/facts/<fact_name>/ids
+        Uses:  GET /api/v1/workflows/<wf>/facts/<fact_name>/ids
                ?duration_fact=<fact_name>&breakdown_filter=<fact_name>
-
-        The namespace is resolved the same way get_trace_ids resolves it, trying
-        ``apps`` before ``workflows``. This used to be hardcoded to ``workflows``,
-        which quietly returned nothing on a deployment that keys its tenants
-        under ``apps``: that path answers 200 with an empty ``fact_ids`` rather
-        than 404, so every fact level came back empty and nothing raised.
 
         This is the entry point for any fact level above a trace -- agent
         requests, sessions, conversations. A trace-level set comes from
@@ -573,15 +567,16 @@ class OkahuSpanLoader:
         page_size = OkahuSpanLoader._resolve_page_size(page_size)
         base = OkahuSpanLoader._get_api_base(endpoint)
         headers = OkahuSpanLoader._get_headers(api_key)
+        url = f"{base}/api/v1/workflows/{workflow_name}/facts/{fact_name}/ids"
         params = {"duration_fact": fact_name, "breakdown_filter": fact_name}
         params.update(OkahuSpanLoader._window_params(start_time, end_time))
         params.update(OkahuSpanLoader._eval_param(eval_filter))
         context_msg = f"{fact_name} ids in workflow '{workflow_name}'"
 
         def fetch(page_params):
-            return OkahuSpanLoader._get_resource(
-                base, f"{workflow_name}/facts/{fact_name}/ids", headers,
-                params=page_params, timeout=timeout, context_msg=context_msg)
+            return OkahuSpanLoader._do_get(
+                url, headers, params=page_params, timeout=timeout,
+                context_msg=context_msg)
 
         def extract(envelope):
             """The ids of one page. fact_ids is keyed by id, so its keys ARE the

--- a/test_tools/src/monocle_test_tools/okahu_span_loader.py
+++ b/test_tools/src/monocle_test_tools/okahu_span_loader.py
@@ -326,7 +326,8 @@ class OkahuSpanLoader:
                          eval_filter: Optional[str] = None,
                          check_eval: Optional[Union[bool, str]] = None,
                          compare_eval: Optional[str] = None,
-                         page_size: int = DEFAULT_PAGE_SIZE) -> list:
+                         page_size: int = DEFAULT_PAGE_SIZE,
+                         max_facts: Optional[int] = None) -> list:
         """Build FluentTestCases from the traces recorded for a workflow.
 
         One test case per fact in the window. How the facts are found depends on
@@ -411,6 +412,12 @@ class OkahuSpanLoader:
             page_size: Rows per page for the trace/fact enumeration and the eval
                 report alike -- one knob, so they cannot disagree about page
                 depth. Server maximum 1000.
+            max_facts: The most facts this window may yield. Defaults to
+                OKAHU_MAX_FACTS, then DEFAULT_MAX_FACTS (1000). A wider window
+                raises, naming the count and the variable, rather than
+                generating thousands of cases -- each fact costs a span request
+                and, with check_eval, an eval. Bounds the fact enumeration only;
+                the spans beneath one fact are not counted.
 
         Returns:
             One FluentTestCase per fact that has at least one labelled eval.
@@ -447,6 +454,9 @@ class OkahuSpanLoader:
         # A trace IS its own fact, so the trace list is the fact list. Any level
         # above a trace -- agent requests, sessions -- is enumerated by its own
         # ids API, and each of those facts spans one or more traces.
+        # Resolved before enumeration so a bad argument fails without a request.
+        ceiling = cls._resolve_max_facts(max_facts)
+
         if mapped_fact_name == "traces":
             fact_ids = [normalize_fact_id(tid) for tid in cls.get_trace_ids(
                 workflow_name, start_time=start_time, end_time=end_time,
@@ -456,6 +466,22 @@ class OkahuSpanLoader:
                 workflow_name, mapped_fact_name,
                 start_time=start_time, end_time=end_time,
                 eval_filter=eval_filter, page_size=page_size)
+
+        # Paginating the enumerators removed an accidental ceiling: they used to
+        # stop at the server's first page of 100. Every fact here costs a span
+        # request and, with check_eval, an eval, so an oversized window is
+        # refused before any of that -- never truncated, which would hand back a
+        # silent subset.
+        #
+        # Deliberately checked HERE rather than inside the enumerators: they are
+        # shared with load_by_scope, import_traces and from_okahu_scope, which
+        # load one named fact and have no runaway to guard against.
+        if len(fact_ids) > ceiling:
+            raise AssertionError(
+                f"Okahu discovered {len(fact_ids)} '{fact_name}' facts in workflow "
+                f"'{workflow_name}', exceeding max_facts={ceiling} (set "
+                f"OKAHU_MAX_FACTS to raise the ceiling, or narrow the time window).")
+
         if not fact_ids:
             return []
 

--- a/test_tools/src/monocle_test_tools/okahu_span_loader.py
+++ b/test_tools/src/monocle_test_tools/okahu_span_loader.py
@@ -32,6 +32,12 @@ class OkahuSpanLoader:
     # those timing out; OKAHU_API_TIMEOUT raises or lowers it per deployment.
     DEFAULT_API_TIMEOUT = 120
 
+    # The server's own DEFAULT_PAGE_SIZE is 100 (common/api/util.py:34) and its
+    # MAX_PAGE_SIZE is 1000, enforced with a 400 rather than a clamp. 200 halves
+    # the round trips and matches what the eval-tune-kit clients already request.
+    DEFAULT_PAGE_SIZE = 200
+    MAX_PAGE_SIZE = 1000
+
     @staticmethod
     def _get_api_base(endpoint: Optional[str] = None) -> str:
         """Return the Okahu API base URL (no trailing slash).
@@ -73,6 +79,32 @@ class OkahuSpanLoader:
                 raw, OkahuSpanLoader.DEFAULT_API_TIMEOUT)
             return OkahuSpanLoader.DEFAULT_API_TIMEOUT
         return seconds
+
+    @staticmethod
+    def _resolve_page_size(page_size: Optional[int] = None) -> int:
+        """Rows per page: an explicit value if given, else DEFAULT_PAGE_SIZE.
+
+        parse_page_size on the server (common/api/util.py:558-570) answers an
+        out-of-range value with HTTP 400 rather than clamping, and that 400
+        surfaces mid-collection with no indication of which parameter caused it.
+        Failing here names the bound instead.
+
+        No environment override, unlike the timeout: a timeout is a deployment
+        property, while page size is a tuning detail already exposed as a
+        parameter on setup_test_cases.
+        """
+        if page_size is None:
+            return OkahuSpanLoader.DEFAULT_PAGE_SIZE
+        # bool before int: isinstance(True, int) is True, so page_size=True would
+        # otherwise pass as a page size of 1.
+        if isinstance(page_size, bool) or not isinstance(page_size, int):
+            raise ValueError(
+                f"page_size must be an int, got {type(page_size).__name__}")
+        if not 1 <= page_size <= OkahuSpanLoader.MAX_PAGE_SIZE:
+            raise ValueError(
+                f"page_size must be between 1 and {OkahuSpanLoader.MAX_PAGE_SIZE} "
+                f"(the Okahu server's MAX_PAGE_SIZE), got {page_size}")
+        return page_size
 
     @staticmethod
     def _get_headers(api_key: Optional[str] = None) -> dict:

--- a/test_tools/tests/integration/test_okahu_pagination_live.py
+++ b/test_tools/tests/integration/test_okahu_pagination_live.py
@@ -117,3 +117,27 @@ def test_the_env_var_overrides_the_default(monkeypatch):
     with pytest.raises(AssertionError, match="exceeding max_facts=5"):
         OkahuSpanLoader.setup_test_cases(
             workflow_name=WORKFLOW, start_time=START, end_time=END)
+
+
+# Narrower than START: ~58 traces, comfortably under the default ceiling.
+NARROW_START = "2026-06-01T00:00:00.000Z"
+
+
+def test_a_window_under_the_ceiling_still_builds_every_case(monkeypatch):
+    """The happy path, live.
+
+    The other two ceiling tests both assert refusal, which would still pass if
+    the guard rejected everything. This one proves a window under the limit is
+    undisturbed: every advertised fact becomes a loaded case.
+    """
+    monkeypatch.delenv("OKAHU_MAX_FACTS", raising=False)
+
+    advertised = _advertised(f"{WORKFLOW}/traces", {"start_time": NARROW_START})
+    assert advertised < 1000, (
+        "this window must sit under the ceiling or the test proves nothing")
+
+    cases = OkahuSpanLoader.setup_test_cases(
+        workflow_name=WORKFLOW, start_time=NARROW_START, end_time=END)
+
+    assert len(cases) == advertised, "every fact under the ceiling becomes a case"
+    assert all(c.load_error is None for c in cases), "no case may fail to load"

--- a/test_tools/tests/integration/test_okahu_pagination_live.py
+++ b/test_tools/tests/integration/test_okahu_pagination_live.py
@@ -86,3 +86,34 @@ def test_an_explicit_page_size_reaches_the_same_total():
                                            page_size=25)
 
     assert sorted(wide) == sorted(narrow)
+
+
+def test_the_default_ceiling_refuses_an_oversized_window(monkeypatch):
+    """This window holds ~3368 inferences, comfortably past the default 1000,
+    so the ceiling engages against real data rather than a mock."""
+    monkeypatch.delenv("OKAHU_MAX_FACTS", raising=False)
+
+    with pytest.raises(AssertionError, match="exceeding max_facts=1000"):
+        OkahuSpanLoader.setup_test_cases(
+            workflow_name=WORKFLOW, start_time=START, end_time=END,
+            fact_name="inferences")
+
+
+def test_raising_the_ceiling_lets_the_same_window_through(monkeypatch):
+    """Enumeration alone must still work at that size -- only span loading is
+    expensive, and setup_test_cases is not reached here."""
+    monkeypatch.delenv("OKAHU_MAX_FACTS", raising=False)
+
+    ids = OkahuSpanLoader.get_fact_ids(WORKFLOW, "inferences",
+                                       start_time=START, end_time=END)
+
+    assert len(ids) > 1000, "the window must exceed the default to prove anything"
+    assert len(set(ids)) == len(ids)
+
+
+def test_the_env_var_overrides_the_default(monkeypatch):
+    monkeypatch.setenv("OKAHU_MAX_FACTS", "5")
+
+    with pytest.raises(AssertionError, match="exceeding max_facts=5"):
+        OkahuSpanLoader.setup_test_cases(
+            workflow_name=WORKFLOW, start_time=START, end_time=END)

--- a/test_tools/tests/integration/test_okahu_pagination_live.py
+++ b/test_tools/tests/integration/test_okahu_pagination_live.py
@@ -1,14 +1,14 @@
 """Live proof that the enumerators walk past the server's first page.
 
 Against stage, not prod. The assertions are self-consistency checks rather than
-literals: stage keeps ingesting, so "== 133" would rot within days, while
+literals: the workflow keeps ingesting, so "== 810" would rot within days, while
 "collected everything the server says exists" stays true forever.
 
 Credentials and the stage endpoint come from tests/integration/__init__.py.
 
-At the time of writing this window holds 133 traces and 322 inferences, both
-past the server's default page of 100. Before the fix get_trace_ids returned
-100 and get_fact_ids returned 0.
+At the time of writing this window holds 810 traces and 809 agent_requests, both
+far past the server's default page of 100. Before the fix both enumerators
+returned exactly 100 and said nothing about the rest.
 
 Backlog issue #242.
 """
@@ -18,13 +18,16 @@ import pytest
 
 from monocle_test_tools.okahu_span_loader import OkahuSpanLoader
 
-APP = "monoclepytest_4cvu17"
-START, END = "2026-06-01T00:00:00.000Z", "2026-09-03T23:59:59.000Z"
+# A workflow, not an app: Monocle addresses Okahu by workflow name throughout --
+# the span loader, the eval report and the pytest plugin all do. The window is
+# deliberately wide so both fact levels span several pages.
+WORKFLOW = "karmehr-okahu-monocle"
+START, END = "2025-01-01T00:00:00.000Z", "2026-09-03T23:59:59.000Z"
 SERVER_DEFAULT_PAGE = 100
 
-# The app below lives on stage. Running this against prod would either 404 or
-# walk an unrelated tenant's data, so the endpoint is checked rather than assumed
-# -- _get_api_base falls back to the prod base URL when nothing is configured.
+# Running this against prod would walk an unrelated tenant, so the endpoint is
+# checked rather than assumed -- _get_api_base falls back to the prod base URL
+# when nothing is configured.
 _ON_STAGE = "stage" in OkahuSpanLoader._get_api_base()
 
 pytestmark = [
@@ -47,11 +50,11 @@ def _advertised(path_suffix, params):
 
 
 def test_trace_enumeration_collects_every_page():
-    advertised = _advertised(f"{APP}/traces", {})
+    advertised = _advertised(f"{WORKFLOW}/traces", {})
     assert advertised > SERVER_DEFAULT_PAGE, (
         "this window must span more than one page or the test proves nothing")
 
-    ids = OkahuSpanLoader.get_trace_ids(APP, start_time=START, end_time=END)
+    ids = OkahuSpanLoader.get_trace_ids(WORKFLOW, start_time=START, end_time=END)
 
     assert len(ids) == advertised, "collected everything the server advertises"
     assert len(ids) > SERVER_DEFAULT_PAGE, "the 100-row truncation is gone"
@@ -60,12 +63,13 @@ def test_trace_enumeration_collects_every_page():
 
 
 def test_fact_enumeration_collects_every_page():
+    fact = "agent_requests"
     advertised = _advertised(
-        f"{APP}/facts/inferences/ids",
-        {"duration_fact": "inferences", "breakdown_filter": "inferences"})
+        f"{WORKFLOW}/facts/{fact}/ids",
+        {"duration_fact": fact, "breakdown_filter": fact})
     assert advertised > SERVER_DEFAULT_PAGE
 
-    ids = OkahuSpanLoader.get_fact_ids(APP, "inferences",
+    ids = OkahuSpanLoader.get_fact_ids(WORKFLOW, fact,
                                        start_time=START, end_time=END)
 
     assert len(ids) == advertised
@@ -76,9 +80,9 @@ def test_fact_enumeration_collects_every_page():
 def test_an_explicit_page_size_reaches_the_same_total():
     """Page depth must not change the answer -- only how many round trips it
     takes. A smaller page forces more token follow-ups over the same window."""
-    wide = OkahuSpanLoader.get_trace_ids(APP, start_time=START, end_time=END,
+    wide = OkahuSpanLoader.get_trace_ids(WORKFLOW, start_time=START, end_time=END,
                                          page_size=1000)
-    narrow = OkahuSpanLoader.get_trace_ids(APP, start_time=START, end_time=END,
+    narrow = OkahuSpanLoader.get_trace_ids(WORKFLOW, start_time=START, end_time=END,
                                            page_size=25)
 
     assert sorted(wide) == sorted(narrow)

--- a/test_tools/tests/integration/test_okahu_pagination_live.py
+++ b/test_tools/tests/integration/test_okahu_pagination_live.py
@@ -1,0 +1,84 @@
+"""Live proof that the enumerators walk past the server's first page.
+
+Against stage, not prod. The assertions are self-consistency checks rather than
+literals: stage keeps ingesting, so "== 133" would rot within days, while
+"collected everything the server says exists" stays true forever.
+
+Credentials and the stage endpoint come from tests/integration/__init__.py.
+
+At the time of writing this window holds 133 traces and 322 inferences, both
+past the server's default page of 100. Before the fix get_trace_ids returned
+100 and get_fact_ids returned 0.
+
+Backlog issue #242.
+"""
+import os
+
+import pytest
+
+from monocle_test_tools.okahu_span_loader import OkahuSpanLoader
+
+APP = "monoclepytest_4cvu17"
+START, END = "2026-06-01T00:00:00.000Z", "2026-09-03T23:59:59.000Z"
+SERVER_DEFAULT_PAGE = 100
+
+# The app below lives on stage. Running this against prod would either 404 or
+# walk an unrelated tenant's data, so the endpoint is checked rather than assumed
+# -- _get_api_base falls back to the prod base URL when nothing is configured.
+_ON_STAGE = "stage" in OkahuSpanLoader._get_api_base()
+
+pytestmark = [
+    pytest.mark.skipif(not os.environ.get("OKAHU_API_KEY"),
+                       reason="needs OKAHU_API_KEY"),
+    pytest.mark.skipif(not _ON_STAGE,
+                       reason=f"needs the stage endpoint; got "
+                              f"{OkahuSpanLoader._get_api_base()}"),
+]
+
+
+def _advertised(path_suffix, params):
+    """fact_count straight off page 1, before any paging."""
+    envelope = OkahuSpanLoader._get_resource(
+        OkahuSpanLoader._get_api_base(), path_suffix,
+        OkahuSpanLoader._get_headers(),
+        params={"start_time": START, "end_time": END, **params},
+        context_msg="probe")
+    return envelope.get("fact_count")
+
+
+def test_trace_enumeration_collects_every_page():
+    advertised = _advertised(f"{APP}/traces", {})
+    assert advertised > SERVER_DEFAULT_PAGE, (
+        "this window must span more than one page or the test proves nothing")
+
+    ids = OkahuSpanLoader.get_trace_ids(APP, start_time=START, end_time=END)
+
+    assert len(ids) == advertised, "collected everything the server advertises"
+    assert len(ids) > SERVER_DEFAULT_PAGE, "the 100-row truncation is gone"
+    assert len(set(ids)) == len(ids), (
+        "duplicates mean the token re-served page 1 instead of advancing")
+
+
+def test_fact_enumeration_collects_every_page():
+    advertised = _advertised(
+        f"{APP}/facts/inferences/ids",
+        {"duration_fact": "inferences", "breakdown_filter": "inferences"})
+    assert advertised > SERVER_DEFAULT_PAGE
+
+    ids = OkahuSpanLoader.get_fact_ids(APP, "inferences",
+                                       start_time=START, end_time=END)
+
+    assert len(ids) == advertised
+    assert len(ids) > SERVER_DEFAULT_PAGE
+    assert len(set(ids)) == len(ids)
+
+
+def test_an_explicit_page_size_reaches_the_same_total():
+    """Page depth must not change the answer -- only how many round trips it
+    takes. A smaller page forces more token follow-ups over the same window."""
+    wide = OkahuSpanLoader.get_trace_ids(APP, start_time=START, end_time=END,
+                                         page_size=1000)
+    narrow = OkahuSpanLoader.get_trace_ids(APP, start_time=START, end_time=END,
+                                           page_size=25)
+
+    assert sorted(wide) == sorted(narrow)

--- a/test_tools/tests/unit/test_okahu_pagination.py
+++ b/test_tools/tests/unit/test_okahu_pagination.py
@@ -5,6 +5,7 @@ sent neither, so every enumeration stopped at the server's DEFAULT_PAGE_SIZE of
 100 with no log line, no tally and no exception -- backlog issue #242.
 """
 import pytest
+import requests
 
 from monocle_test_tools.okahu_span_loader import OkahuSpanLoader
 
@@ -306,6 +307,43 @@ class TestGetTraceIdsPaginates:
             OkahuSpanLoader.get_trace_ids("wf", fact_name="agent_sessions")
 
         assert do_get["calls"] == []
+
+
+class TestGetFactIdsNamespace:
+    """get_fact_ids hardcoded /workflows/, while get_trace_ids has always tried
+    'apps' first via _get_resource.
+
+    On stage /api/v1/workflows 404s entirely and only /apps exists -- but
+    /workflows/<app>/facts/<fact>/ids answers 200 with an EMPTY list rather than
+    404, so get_fact_ids returned [] for every app-namespace tenant and nothing
+    raised. The same silent-emptiness class as the pagination defect itself.
+    """
+
+    @pytest.fixture(name="do_get")
+    def do_get_fixture(self, monkeypatch):
+        state = {"urls": [], "not_found": set()}
+
+        def fake_do_get(url, headers, params=None, timeout=None, context_msg=""):
+            state["urls"].append(url)
+            if any(marker in url for marker in state["not_found"]):
+                response = requests.Response()
+                response.status_code = 404
+                raise requests.HTTPError("404", response=response)
+            return {"fact_ids": {"e-1": {}}, "fact_count": 1}
+
+        monkeypatch.setattr(OkahuSpanLoader, "_do_get", staticmethod(fake_do_get))
+        return state
+
+    def test_it_tries_the_apps_namespace_first(self, do_get):
+        OkahuSpanLoader.get_fact_ids("wf", "inferences")
+
+        assert do_get["urls"][0].endswith("/api/v1/apps/wf/facts/inferences/ids")
+
+    def test_it_falls_back_to_workflows_on_404(self, do_get):
+        do_get["not_found"] = {"/api/v1/apps/"}
+
+        assert OkahuSpanLoader.get_fact_ids("wf", "inferences") == ["e-1"]
+        assert do_get["urls"][-1].endswith("/api/v1/workflows/wf/facts/inferences/ids")
 
 
 class TestPageSizeThreading:

--- a/test_tools/tests/unit/test_okahu_pagination.py
+++ b/test_tools/tests/unit/test_okahu_pagination.py
@@ -188,3 +188,58 @@ class TestReconciliation:
             lambda params: _envelope(["a"]), {}, 200, _extract_traces, "ctx")
 
         assert "incomplete" not in caplog.text
+
+
+class TestGetFactIdsPaginates:
+    """/facts/<name>/ids keys fact_ids to a DICT, not a list -- the one shape
+    difference from /traces. The protocol around it is identical."""
+
+    @pytest.fixture(name="do_get")
+    def do_get_fixture(self, monkeypatch):
+        state = {"calls": [], "pages": []}
+
+        def fake_do_get(url, headers, params=None, timeout=None, context_msg=""):
+            state["calls"].append(dict(params or {}))
+            return state["pages"].pop(0)
+
+        monkeypatch.setattr(OkahuSpanLoader, "_do_get", staticmethod(fake_do_get))
+        return state
+
+    def test_it_walks_every_page(self, do_get):
+        do_get["pages"] = [
+            {"fact_ids": {"e-1": {}, "e-2": {}}, "fact_count": 3,
+             "next_page_token": "tok-2"},
+            {"fact_ids": {"e-3": {}}, "fact_count": 3},
+        ]
+
+        assert OkahuSpanLoader.get_fact_ids("wf", "agent_requests") == [
+            "e-1", "e-2", "e-3"]
+        assert do_get["calls"][1]["next_page_token"] == "tok-2"
+
+    def test_it_sends_the_default_page_size(self, do_get):
+        do_get["pages"] = [{"fact_ids": {}, "fact_count": 0}]
+
+        OkahuSpanLoader.get_fact_ids("wf", "agent_requests")
+
+        assert do_get["calls"][0]["page_size"] == 200
+
+    def test_an_explicit_page_size_is_sent(self, do_get):
+        do_get["pages"] = [{"fact_ids": {}, "fact_count": 0}]
+
+        OkahuSpanLoader.get_fact_ids("wf", "agent_requests", page_size=25)
+
+        assert do_get["calls"][0]["page_size"] == 25
+
+    def test_a_bad_page_size_raises_before_any_request(self, do_get):
+        do_get["pages"] = [{"fact_ids": {}, "fact_count": 0}]
+
+        with pytest.raises(ValueError, match="between 1 and 1000"):
+            OkahuSpanLoader.get_fact_ids("wf", "agent_requests", page_size=5000)
+
+        assert do_get["calls"] == [], "no request may be issued"
+
+    def test_an_unexpected_fact_ids_type_still_raises(self, do_get):
+        do_get["pages"] = [{"fact_ids": "nonsense"}]
+
+        with pytest.raises(ConnectionError, match="unexpected 'fact_ids'"):
+            OkahuSpanLoader.get_fact_ids("wf", "agent_requests")

--- a/test_tools/tests/unit/test_okahu_pagination.py
+++ b/test_tools/tests/unit/test_okahu_pagination.py
@@ -306,3 +306,74 @@ class TestGetTraceIdsPaginates:
             OkahuSpanLoader.get_trace_ids("wf", fact_name="agent_sessions")
 
         assert do_get["calls"] == []
+
+
+class TestPageSizeThreading:
+    """One knob. The eval report and the enumerators must not disagree about
+    page depth, so setup_test_cases' page_size reaches all three."""
+
+    @pytest.fixture(name="seen")
+    def seen_fixture(self, monkeypatch):
+        seen = {"trace": [], "fact": [], "report": []}
+
+        def fake_trace_ids(workflow_name, fact_name=None, fact_id=None, **kwargs):
+            seen["trace"].append(kwargs)
+            return ["abc123"]
+
+        def fake_fact_ids(workflow_name, fact_name, **kwargs):
+            seen["fact"].append(kwargs)
+            return ["e-1"]
+
+        def fake_spans(*args, **kwargs):
+            return []
+
+        monkeypatch.setattr(OkahuSpanLoader, "get_trace_ids",
+                            staticmethod(fake_trace_ids))
+        monkeypatch.setattr(OkahuSpanLoader, "get_fact_ids",
+                            staticmethod(fake_fact_ids))
+        monkeypatch.setattr(OkahuSpanLoader, "get_spans", staticmethod(fake_spans))
+
+        from monocle_test_tools.evals.okahu_eval import OkahuEval
+
+        def fake_report(**kwargs):
+            seen["report"].append(kwargs)
+            return {}
+
+        monkeypatch.setattr(OkahuEval, "_eval_report_by_fact",
+                            staticmethod(fake_report))
+        return seen
+
+    def test_the_default_reaches_the_trace_enumerator(self, seen):
+        OkahuSpanLoader.setup_test_cases(
+            workflow_name="wf", start_time="a", end_time="b")
+
+        assert seen["trace"][0]["page_size"] == 200
+
+    def test_an_explicit_size_reaches_the_trace_enumerator(self, seen):
+        OkahuSpanLoader.setup_test_cases(
+            workflow_name="wf", start_time="a", end_time="b", page_size=25)
+
+        assert seen["trace"][0]["page_size"] == 25
+
+    def test_it_reaches_the_fact_enumerator(self, seen):
+        OkahuSpanLoader.setup_test_cases(
+            workflow_name="wf", start_time="a", end_time="b",
+            fact_name="agentic_turns", page_size=25)
+
+        assert seen["fact"][0]["page_size"] == 25
+
+    def test_it_reaches_the_eval_report_too(self, seen):
+        OkahuSpanLoader.setup_test_cases(
+            workflow_name="wf", start_time="a", end_time="b",
+            check_eval="sentiment", page_size=25)
+
+        assert seen["report"][0]["page_size"] == 25
+
+    def test_it_reaches_the_per_fact_trace_lookup(self, seen):
+        """_fact_spans looks up one fact's traces; a fact spanning more than a
+        page would otherwise load a partial span set."""
+        OkahuSpanLoader.setup_test_cases(
+            workflow_name="wf", start_time="a", end_time="b",
+            fact_name="agentic_turns", page_size=25)
+
+        assert seen["trace"][0]["page_size"] == 25

--- a/test_tools/tests/unit/test_okahu_pagination.py
+++ b/test_tools/tests/unit/test_okahu_pagination.py
@@ -5,7 +5,6 @@ sent neither, so every enumeration stopped at the server's DEFAULT_PAGE_SIZE of
 100 with no log line, no tally and no exception -- backlog issue #242.
 """
 import pytest
-import requests
 
 from monocle_test_tools.okahu_span_loader import OkahuSpanLoader
 
@@ -307,43 +306,6 @@ class TestGetTraceIdsPaginates:
             OkahuSpanLoader.get_trace_ids("wf", fact_name="agent_sessions")
 
         assert do_get["calls"] == []
-
-
-class TestGetFactIdsNamespace:
-    """get_fact_ids hardcoded /workflows/, while get_trace_ids has always tried
-    'apps' first via _get_resource.
-
-    On stage /api/v1/workflows 404s entirely and only /apps exists -- but
-    /workflows/<app>/facts/<fact>/ids answers 200 with an EMPTY list rather than
-    404, so get_fact_ids returned [] for every app-namespace tenant and nothing
-    raised. The same silent-emptiness class as the pagination defect itself.
-    """
-
-    @pytest.fixture(name="do_get")
-    def do_get_fixture(self, monkeypatch):
-        state = {"urls": [], "not_found": set()}
-
-        def fake_do_get(url, headers, params=None, timeout=None, context_msg=""):
-            state["urls"].append(url)
-            if any(marker in url for marker in state["not_found"]):
-                response = requests.Response()
-                response.status_code = 404
-                raise requests.HTTPError("404", response=response)
-            return {"fact_ids": {"e-1": {}}, "fact_count": 1}
-
-        monkeypatch.setattr(OkahuSpanLoader, "_do_get", staticmethod(fake_do_get))
-        return state
-
-    def test_it_tries_the_apps_namespace_first(self, do_get):
-        OkahuSpanLoader.get_fact_ids("wf", "inferences")
-
-        assert do_get["urls"][0].endswith("/api/v1/apps/wf/facts/inferences/ids")
-
-    def test_it_falls_back_to_workflows_on_404(self, do_get):
-        do_get["not_found"] = {"/api/v1/apps/"}
-
-        assert OkahuSpanLoader.get_fact_ids("wf", "inferences") == ["e-1"]
-        assert do_get["urls"][-1].endswith("/api/v1/workflows/wf/facts/inferences/ids")
 
 
 class TestPageSizeThreading:

--- a/test_tools/tests/unit/test_okahu_pagination.py
+++ b/test_tools/tests/unit/test_okahu_pagination.py
@@ -243,3 +243,66 @@ class TestGetFactIdsPaginates:
 
         with pytest.raises(ConnectionError, match="unexpected 'fact_ids'"):
             OkahuSpanLoader.get_fact_ids("wf", "agent_requests")
+
+
+class TestGetTraceIdsPaginates:
+    """/traces keys a LIST of trace objects. Same protocol as /facts/<n>/ids."""
+
+    @pytest.fixture(name="do_get")
+    def do_get_fixture(self, monkeypatch):
+        state = {"calls": [], "pages": []}
+
+        def fake_do_get(url, headers, params=None, timeout=None, context_msg=""):
+            state["calls"].append(dict(params or {}))
+            return state["pages"].pop(0)
+
+        monkeypatch.setattr(OkahuSpanLoader, "_do_get", staticmethod(fake_do_get))
+        return state
+
+    def test_it_walks_every_page(self, do_get):
+        do_get["pages"] = [
+            _envelope(["t1", "t2"], fact_count=3, next_page_token="tok-2"),
+            _envelope(["t3"], fact_count=3),
+        ]
+
+        assert OkahuSpanLoader.get_trace_ids("wf") == ["t1", "t2", "t3"]
+        assert do_get["calls"][1]["next_page_token"] == "tok-2"
+
+    def test_the_window_and_filter_survive_every_page(self, do_get):
+        do_get["pages"] = [
+            _envelope(["t1"], fact_count=2, next_page_token="tok-2"),
+            _envelope(["t2"], fact_count=2),
+        ]
+
+        OkahuSpanLoader.get_trace_ids("wf", "agent_sessions", "sess_1",
+                                      start_time="a", end_time="b",
+                                      eval_filter="frustration")
+
+        for call in do_get["calls"]:
+            assert call["duration_fact"] == "agent_sessions"
+            assert call["fact_ids"] == "sess_1"
+            assert call["start_time"] == "a"
+            assert call["eval"] == "frustration"
+
+    def test_a_short_walk_warns(self, do_get, caplog):
+        do_get["pages"] = [_envelope(["t1"], fact_count=309)]
+
+        assert OkahuSpanLoader.get_trace_ids("wf") == ["t1"]
+        assert "1 of 309" in caplog.text
+
+    def test_a_bad_page_size_raises_before_any_request(self, do_get):
+        do_get["pages"] = [_envelope([], fact_count=0)]
+
+        with pytest.raises(ValueError, match="between 1 and 1000"):
+            OkahuSpanLoader.get_trace_ids("wf", page_size=0)
+
+        assert do_get["calls"] == []
+
+    def test_half_a_fact_filter_still_raises_before_any_request(self, do_get):
+        """The existing guard must run before the pager touches the network."""
+        do_get["pages"] = [_envelope([], fact_count=0)]
+
+        with pytest.raises(ValueError, match="fact_name and fact_id"):
+            OkahuSpanLoader.get_trace_ids("wf", fact_name="agent_sessions")
+
+        assert do_get["calls"] == []

--- a/test_tools/tests/unit/test_okahu_pagination.py
+++ b/test_tools/tests/unit/test_okahu_pagination.py
@@ -1,0 +1,48 @@
+"""Pagination for the Okahu fact and trace enumerators.
+
+The API pages with page_size out and next_page_token back. Monocle previously
+sent neither, so every enumeration stopped at the server's DEFAULT_PAGE_SIZE of
+100 with no log line, no tally and no exception -- backlog issue #242.
+"""
+import pytest
+
+from monocle_test_tools.okahu_span_loader import OkahuSpanLoader
+
+
+@pytest.fixture(autouse=True)
+def _okahu_env(monkeypatch):
+    monkeypatch.setenv("OKAHU_API_KEY", "test-key")
+    monkeypatch.setenv("OKAHU_API_ENDPOINT", "https://api.example")
+    monkeypatch.delenv("OKAHU_API_TIMEOUT", raising=False)
+
+
+class TestResolvePageSize:
+    """Bounds are checked here so an out-of-range value never reaches the wire.
+
+    The server answers a bad page_size with HTTP 400 rather than clamping, and
+    that 400 surfaces mid-collection without naming the parameter that caused it.
+    """
+
+    def test_default_is_200(self):
+        assert OkahuSpanLoader._resolve_page_size(None) == 200
+
+    def test_an_explicit_size_is_honoured(self):
+        assert OkahuSpanLoader._resolve_page_size(50) == 50
+
+    def test_the_server_maximum_is_allowed(self):
+        assert OkahuSpanLoader._resolve_page_size(1000) == 1000
+
+    @pytest.mark.parametrize("bad", [0, -1, 1001])
+    def test_out_of_range_raises_naming_the_bound(self, bad):
+        with pytest.raises(ValueError, match="between 1 and 1000"):
+            OkahuSpanLoader._resolve_page_size(bad)
+
+    def test_a_string_raises(self):
+        with pytest.raises(ValueError, match="must be an int"):
+            OkahuSpanLoader._resolve_page_size("200")
+
+    def test_a_bool_raises(self):
+        """isinstance(True, int) is True in Python, so page_size=True would
+        otherwise resolve to a page size of 1 rather than being rejected."""
+        with pytest.raises(ValueError, match="must be an int"):
+            OkahuSpanLoader._resolve_page_size(True)

--- a/test_tools/tests/unit/test_okahu_pagination.py
+++ b/test_tools/tests/unit/test_okahu_pagination.py
@@ -46,3 +46,145 @@ class TestResolvePageSize:
         otherwise resolve to a page size of 1 rather than being rejected."""
         with pytest.raises(ValueError, match="must be an int"):
             OkahuSpanLoader._resolve_page_size(True)
+
+
+def _envelope(ids, fact_count=None, next_page_token=None, key="traces"):
+    """A response envelope shaped like the real API's."""
+    body = {key: [{"trace_id": i} for i in ids]}
+    if fact_count is not None:
+        body["fact_count"] = fact_count
+    if next_page_token is not None:
+        body["next_page_token"] = next_page_token
+    return body
+
+
+def _extract_traces(envelope):
+    """Pull trace ids out of an envelope, list-container style."""
+    if not isinstance(envelope, dict):
+        return []
+    return [item["trace_id"] for item in envelope.get("traces", [])]
+
+
+class TestIterPages:
+
+    def test_the_token_is_sent_as_next_page_token(self):
+        """The GET routes read 'next_page_token'; only the POST /evals/report
+        pager spells it 'page_token'. Sending the wrong name is not an error --
+        it is ignored and page 1 is re-served, which is indistinguishable from
+        the bug being fixed. A mock that ignored param names could not catch it,
+        so this one serves page 2 ONLY for the correct name.
+        """
+        calls = []
+
+        def fetch(params):
+            calls.append(dict(params))
+            if params.get("next_page_token") is None:
+                return _envelope(["a", "b"], fact_count=4, next_page_token="tok-2")
+            assert params["next_page_token"] == "tok-2"
+            return _envelope(["c", "d"], fact_count=4)
+
+        collected = OkahuSpanLoader._collect_paged(
+            fetch, {"start_time": "x"}, 200, _extract_traces, "traces in 'wf'")
+
+        assert collected == ["a", "b", "c", "d"]
+        assert "page_token" not in calls[1], "the POST pager's name must not be used"
+
+    def test_page_size_is_sent_on_every_request(self):
+        calls = []
+
+        def fetch(params):
+            calls.append(dict(params))
+            if len(calls) == 1:
+                return _envelope(["a"], fact_count=2, next_page_token="tok-2")
+            return _envelope(["b"], fact_count=2)
+
+        OkahuSpanLoader._collect_paged(fetch, {}, 50, _extract_traces, "ctx")
+
+        assert [c["page_size"] for c in calls] == [50, 50]
+
+    def test_a_single_page_issues_exactly_one_request(self):
+        calls = []
+
+        def fetch(params):
+            calls.append(dict(params))
+            return _envelope(["a", "b"], fact_count=2)
+
+        collected = OkahuSpanLoader._collect_paged(
+            fetch, {}, 200, _extract_traces, "ctx")
+
+        assert collected == ["a", "b"]
+        assert len(calls) == 1
+        assert "next_page_token" not in calls[0]
+
+    def test_three_pages_concatenate_in_server_order(self):
+        pages = [
+            _envelope(["a", "b"], fact_count=5, next_page_token="t2"),
+            _envelope(["c", "d"], fact_count=5, next_page_token="t3"),
+            _envelope(["e"], fact_count=5),
+        ]
+
+        def fetch(params):
+            return pages.pop(0)
+
+        assert OkahuSpanLoader._collect_paged(
+            fetch, {}, 2, _extract_traces, "ctx") == ["a", "b", "c", "d", "e"]
+
+    def test_an_empty_payload_gives_an_empty_list(self):
+        collected = OkahuSpanLoader._collect_paged(
+            lambda params: _envelope([], fact_count=0), {}, 200,
+            _extract_traces, "ctx")
+
+        assert collected == []
+
+    def test_a_bare_list_envelope_does_not_crash(self):
+        """Some mocks -- and the API's older shapes -- return a bare list rather
+        than a dict. Reading the token off it must not raise AttributeError."""
+        collected = OkahuSpanLoader._collect_paged(
+            lambda params: [{"trace_id": "a"}], {}, 200,
+            lambda env: [i["trace_id"] for i in env] if isinstance(env, list) else [],
+            "ctx")
+
+        assert collected == ["a"]
+
+    def test_a_repeated_token_stops_the_walk(self, caplog):
+        """A server echoing a token would spin the loop forever. Discovery runs
+        at pytest collection time, so a hang is worse than a wrong answer."""
+        calls = []
+
+        def fetch(params):
+            calls.append(dict(params))
+            return _envelope(["a"], fact_count=99, next_page_token="same-token")
+
+        collected = OkahuSpanLoader._collect_paged(
+            fetch, {}, 200, _extract_traces, "traces in 'wf'")
+
+        assert len(calls) == 2, "page 1, one follow-up, then stop"
+        assert collected == ["a", "a"]
+        assert "repeated a page token" in caplog.text
+
+
+class TestReconciliation:
+
+    def test_a_short_result_warns_naming_both_numbers(self, caplog):
+        """The defect being fixed was silent. Never return short without saying so."""
+        collected = OkahuSpanLoader._collect_paged(
+            lambda params: _envelope(["a", "b"], fact_count=309), {}, 200,
+            _extract_traces, "traces in 'wf'")
+
+        assert collected == ["a", "b"]
+        assert "2 of 309" in caplog.text
+        assert "traces in 'wf'" in caplog.text
+
+    def test_a_complete_result_is_silent(self, caplog):
+        OkahuSpanLoader._collect_paged(
+            lambda params: _envelope(["a", "b"], fact_count=2), {}, 200,
+            _extract_traces, "ctx")
+
+        assert "incomplete" not in caplog.text
+
+    def test_no_fact_count_means_no_warning(self, caplog):
+        """An envelope without fact_count advertises nothing to reconcile against."""
+        OkahuSpanLoader._collect_paged(
+            lambda params: _envelope(["a"]), {}, 200, _extract_traces, "ctx")
+
+        assert "incomplete" not in caplog.text

--- a/test_tools/tests/unit/test_okahu_pagination.py
+++ b/test_tools/tests/unit/test_okahu_pagination.py
@@ -377,3 +377,61 @@ class TestPageSizeThreading:
             fact_name="agentic_turns", page_size=25)
 
         assert seen["trace"][0]["page_size"] == 25
+
+
+class TestResolveMaxFacts:
+    """The ceiling on how many facts one discovery run may yield.
+
+    Mirrors okahu_filtered_eval.py:319 -- same parameter name, same env var,
+    same default -- so a deployment already setting OKAHU_MAX_FACTS gets the
+    same bound from discovery.
+    """
+
+    def test_default_is_1000(self, monkeypatch):
+        monkeypatch.delenv("OKAHU_MAX_FACTS", raising=False)
+
+        assert OkahuSpanLoader._resolve_max_facts(None) == 1000
+
+    def test_env_overrides_the_default(self, monkeypatch):
+        monkeypatch.setenv("OKAHU_MAX_FACTS", "50")
+
+        assert OkahuSpanLoader._resolve_max_facts(None) == 50
+
+    def test_an_explicit_argument_wins_over_env(self, monkeypatch):
+        monkeypatch.setenv("OKAHU_MAX_FACTS", "50")
+
+        assert OkahuSpanLoader._resolve_max_facts(25) == 25
+
+    def test_an_argument_equal_to_the_default_is_still_honoured(self, monkeypatch):
+        """A numeric default would make this indistinguishable from taking the
+        default, which is why the signature defaults to None."""
+        monkeypatch.setenv("OKAHU_MAX_FACTS", "50")
+
+        assert OkahuSpanLoader._resolve_max_facts(1000) == 1000
+
+    @pytest.mark.parametrize("bad_env", ["", "   ", "abc", "0", "-1", "1.5"])
+    def test_an_unusable_env_value_is_logged_and_ignored(self, monkeypatch, caplog,
+                                                         bad_env):
+        """A misconfigured variable must not stop discovery -- same tolerance as
+        OKAHU_API_TIMEOUT, and deliberately unlike okahu_filtered_eval's bare
+        int() which would raise."""
+        monkeypatch.setenv("OKAHU_MAX_FACTS", bad_env)
+
+        assert OkahuSpanLoader._resolve_max_facts(None) == 1000
+        if bad_env.strip():
+            assert "OKAHU_MAX_FACTS" in caplog.text
+
+    @pytest.mark.parametrize("bad", [0, -1, -100])
+    def test_a_non_positive_argument_raises(self, bad):
+        with pytest.raises(ValueError, match="at least 1"):
+            OkahuSpanLoader._resolve_max_facts(bad)
+
+    def test_a_string_argument_raises(self):
+        with pytest.raises(ValueError, match="must be an int"):
+            OkahuSpanLoader._resolve_max_facts("1000")
+
+    def test_a_bool_argument_raises(self):
+        """isinstance(True, int) is True in Python, so max_facts=True would
+        otherwise resolve to a ceiling of 1."""
+        with pytest.raises(ValueError, match="must be an int"):
+            OkahuSpanLoader._resolve_max_facts(True)

--- a/test_tools/tests/unit/test_okahu_pagination.py
+++ b/test_tools/tests/unit/test_okahu_pagination.py
@@ -435,3 +435,148 @@ class TestResolveMaxFacts:
         otherwise resolve to a ceiling of 1."""
         with pytest.raises(ValueError, match="must be an int"):
             OkahuSpanLoader._resolve_max_facts(True)
+
+
+class TestMaxFactsCeiling:
+    """A window yielding more facts than the ceiling is refused, not truncated.
+
+    Truncating would hand back a silent subset -- the exact defect the
+    pagination fix removes. The guard fails loudly and says how to proceed.
+    """
+
+    @pytest.fixture(name="seen")
+    def seen_fixture(self, monkeypatch):
+        """Stub the enumerators so a test can choose how many facts exist."""
+        state = {"trace_kwargs": [], "fact_kwargs": [], "ids": ["t1", "t2"]}
+
+        def fake_trace_ids(workflow_name, fact_name=None, fact_id=None, **kwargs):
+            state["trace_kwargs"].append(kwargs)
+            return list(state["ids"])
+
+        def fake_fact_ids(workflow_name, fact_name, **kwargs):
+            state["fact_kwargs"].append(kwargs)
+            return list(state["ids"])
+
+        monkeypatch.setattr(OkahuSpanLoader, "get_trace_ids",
+                            staticmethod(fake_trace_ids))
+        monkeypatch.setattr(OkahuSpanLoader, "get_fact_ids",
+                            staticmethod(fake_fact_ids))
+        monkeypatch.setattr(OkahuSpanLoader, "get_spans",
+                            staticmethod(lambda *a, **k: []))
+        return state
+
+    def test_under_the_ceiling_passes(self, seen, monkeypatch):
+        monkeypatch.delenv("OKAHU_MAX_FACTS", raising=False)
+        seen["ids"] = [f"t{i}" for i in range(999)]
+
+        cases = OkahuSpanLoader.setup_test_cases(
+            workflow_name="wf", start_time="a", end_time="b")
+
+        assert len(cases) == 999
+
+    def test_exactly_at_the_ceiling_passes(self, seen, monkeypatch):
+        """> ceiling, not >= : 1000 is allowed, matching okahu_filtered_eval."""
+        monkeypatch.delenv("OKAHU_MAX_FACTS", raising=False)
+        seen["ids"] = [f"t{i}" for i in range(1000)]
+
+        cases = OkahuSpanLoader.setup_test_cases(
+            workflow_name="wf", start_time="a", end_time="b")
+
+        assert len(cases) == 1000
+
+    def test_one_over_the_ceiling_raises(self, seen, monkeypatch):
+        monkeypatch.delenv("OKAHU_MAX_FACTS", raising=False)
+        seen["ids"] = [f"t{i}" for i in range(1001)]
+
+        with pytest.raises(AssertionError, match="exceeding max_facts=1000"):
+            OkahuSpanLoader.setup_test_cases(
+                workflow_name="wf", start_time="a", end_time="b")
+
+    def test_the_message_names_the_count_the_ceiling_and_the_env_var(self, seen):
+        seen["ids"] = [f"t{i}" for i in range(3368)]
+
+        with pytest.raises(AssertionError) as exc:
+            OkahuSpanLoader.setup_test_cases(
+                workflow_name="wf", start_time="a", end_time="b", max_facts=1000)
+
+        message = str(exc.value)
+        assert "3368" in message
+        assert "max_facts=1000" in message
+        assert "OKAHU_MAX_FACTS" in message
+        assert "narrow the time window" in message
+        assert "wf" in message
+
+    def test_an_explicit_argument_is_honoured(self, seen):
+        seen["ids"] = [f"t{i}" for i in range(11)]
+
+        with pytest.raises(AssertionError, match="exceeding max_facts=10"):
+            OkahuSpanLoader.setup_test_cases(
+                workflow_name="wf", start_time="a", end_time="b", max_facts=10)
+
+    def test_the_env_var_is_honoured(self, seen, monkeypatch):
+        monkeypatch.setenv("OKAHU_MAX_FACTS", "5")
+        seen["ids"] = [f"t{i}" for i in range(6)]
+
+        with pytest.raises(AssertionError, match="exceeding max_facts=5"):
+            OkahuSpanLoader.setup_test_cases(
+                workflow_name="wf", start_time="a", end_time="b")
+
+    def test_it_applies_to_non_trace_fact_levels_too(self, seen, monkeypatch):
+        monkeypatch.delenv("OKAHU_MAX_FACTS", raising=False)
+        seen["ids"] = [f"e-{i}" for i in range(1001)]
+
+        with pytest.raises(AssertionError, match="exceeding max_facts=1000"):
+            OkahuSpanLoader.setup_test_cases(
+                workflow_name="wf", start_time="a", end_time="b",
+                fact_name="agentic_turns")
+
+    def test_a_bad_max_facts_raises_before_any_enumeration(self, seen):
+        """Resolved before the enumerators run, so a bad argument costs no request."""
+        with pytest.raises(ValueError, match="at least 1"):
+            OkahuSpanLoader.setup_test_cases(
+                workflow_name="wf", start_time="a", end_time="b", max_facts=0)
+
+        assert seen["trace_kwargs"] == [], "no enumeration may be issued"
+
+    def test_the_enumerators_are_not_given_a_ceiling(self, seen):
+        """The whole design: the ceiling never enters the shared span-loading
+        plumbing, so no other caller of get_trace_ids/get_fact_ids can inherit
+        it. See load_by_scope, import_traces, from_okahu_scope."""
+        OkahuSpanLoader.setup_test_cases(
+            workflow_name="wf", start_time="a", end_time="b", max_facts=10)
+
+        assert "max_facts" not in seen["trace_kwargs"][0]
+
+
+class TestPlumbingHasNoCeiling:
+    """Structural guard: if someone later threads max_facts into the shared
+    loaders, these fail. That coupling is what made the first attempt at this
+    feature silently cap load_by_scope and _fact_spans."""
+
+    @pytest.mark.parametrize("name", ["get_trace_ids", "get_fact_ids",
+                                      "_collect_paged", "_iter_pages"])
+    def test_the_shared_loaders_take_no_max_facts(self, name):
+        import inspect
+
+        params = inspect.signature(getattr(OkahuSpanLoader, name)).parameters
+        assert "max_facts" not in params, (
+            f"{name} must stay free of the ceiling -- it is shared with "
+            f"load_by_scope, import_traces and from_okahu_scope")
+
+    def test_feature_b_loads_more_traces_than_the_ceiling(self, monkeypatch):
+        """load_by_scope fetches one scope's traces. It must not be bounded by a
+        discovery ceiling, no matter how many traces that scope holds."""
+        monkeypatch.delenv("OKAHU_MAX_FACTS", raising=False)
+        trace_ids = [f"t{i}" for i in range(1500)]
+
+        def fake_do_get(url, headers, params=None, timeout=None, context_msg=""):
+            return _envelope(trace_ids, fact_count=1500)
+
+        monkeypatch.setattr(OkahuSpanLoader, "_do_get", staticmethod(fake_do_get))
+        monkeypatch.setattr(OkahuSpanLoader, "get_spans",
+                            staticmethod(lambda *a, **k: ["span"]))
+
+        spans = OkahuSpanLoader.load_by_scope(
+            workflow_name="wf", scope_name="test_id", scope_id="run-42")
+
+        assert len(spans) == 1500

--- a/test_tools/tests/unit/test_setup_test_cases.py
+++ b/test_tools/tests/unit/test_setup_test_cases.py
@@ -871,16 +871,12 @@ class TestGetFactIds:
         return seen
 
     def test_hits_the_ids_path_for_the_fact(self, get):
-        """The namespace is resolved, not hardcoded: 'apps' is tried first and
-        only a 404 falls back to 'workflows', matching get_trace_ids. This test
-        previously asserted the hardcoded workflows path, which returned an empty
-        fact_ids with a 200 on app-namespace deployments."""
         from monocle_test_tools.okahu_span_loader import OkahuSpanLoader
 
         OkahuSpanLoader.get_fact_ids("wf", "agent_requests",
                                      start_time="a", end_time="b")
 
-        assert get["url"].endswith("/api/v1/apps/wf/facts/agent_requests/ids")
+        assert get["url"].endswith("/api/v1/workflows/wf/facts/agent_requests/ids")
 
     def test_sends_duration_fact_and_breakdown_filter(self, get):
         from monocle_test_tools.okahu_span_loader import OkahuSpanLoader

--- a/test_tools/tests/unit/test_setup_test_cases.py
+++ b/test_tools/tests/unit/test_setup_test_cases.py
@@ -871,12 +871,16 @@ class TestGetFactIds:
         return seen
 
     def test_hits_the_ids_path_for_the_fact(self, get):
+        """The namespace is resolved, not hardcoded: 'apps' is tried first and
+        only a 404 falls back to 'workflows', matching get_trace_ids. This test
+        previously asserted the hardcoded workflows path, which returned an empty
+        fact_ids with a 200 on app-namespace deployments."""
         from monocle_test_tools.okahu_span_loader import OkahuSpanLoader
 
         OkahuSpanLoader.get_fact_ids("wf", "agent_requests",
                                      start_time="a", end_time="b")
 
-        assert get["url"].endswith("/api/v1/workflows/wf/facts/agent_requests/ids")
+        assert get["url"].endswith("/api/v1/apps/wf/facts/agent_requests/ids")
 
     def test_sends_duration_fact_and_breakdown_filter(self, get):
         from monocle_test_tools.okahu_span_loader import OkahuSpanLoader


### PR DESCRIPTION
## Proposed changes

The Okahu `/traces` and `/facts/<name>/ids` endpoints paginate — each response
carries the page's payload, an advertised `fact_count`, and a `next_page_token`
when more remains. The span loader participated in none of it: `get_trace_ids`
and `get_fact_ids` each issued one GET, sent no `page_size`, and never sent a
token back. `_unwrap_list` then discarded the envelope those fields live in, so
the evidence that more data existed was destroyed before any caller could act
on it.

The result was a silent truncation at the server's `DEFAULT_PAGE_SIZE` of 100.
A trace past position 100 did not become a dropped case and did not become a
`load_error` case — it never entered the system. No log line, no tally, no
exception.

**This is invisible below 100 facts and hard-caps above it.** A window holding
58 traces was always correct, which is why it went unnoticed; a window holding
810 returned exactly 100. That cliff is what makes it P0 rather than a known
limit — discovery does not degrade gradually, it stops dead at 100 the moment a
window gets big enough.

Measured on stage, workflow `karmehr-okahu-monocle`, `2025-01-01 … 2026-09-03`,
running the pre-fix loader against the post-fix one over the same window:

| | before | after | server advertises |
|---|---:|---:|---:|
| `get_trace_ids` | 100 | 810 | 810 |
| `get_fact_ids("agent_requests")` | 100 | 809 | 809 |

### Review follow-up: a ceiling on how many facts are processed

Paginating removed an *accidental* cost ceiling — the old truncation at 100
bounded the work as a side effect. Discovery is now unbounded, so `max_facts`
bounds it deliberately: default 1000, overridable per call or with the
`OKAHU_MAX_FACTS` environment variable, which is the same parameter name,
variable and default `okahu_filtered_eval` already applies to a filtered run.

A window holding more **raises**, naming the count and the ceiling, rather than
returning the first 1000 — a silent subset is the defect this PR removes. Over
the same stage window: 810 traces passes, 3368 inferences raises.

The check lives in `setup_test_cases`, not in the enumerators. `get_trace_ids`,
`get_fact_ids`, `_collect_paged` and `_iter_pages` are byte-identical to the
pagination commits above, so `load_by_scope`, `import_traces` and
`from_okahu_scope` — which load one named session or scope and have no runaway
to bound — cannot inherit the ceiling. A signature-guard test enforces that.

The cap therefore counts facts (traces, agentic turns, inferences, agentic
sessions) and not the spans beneath a single fact, which is one level of
granularity below what it polices.

Out of scope, tracked separately: an empty window still yields zero cases, which
`parametrize` turns into a vacuously green run. That is pre-existing and
unaffected by this PR.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
