### PR TITLE
fix(test_tools): repair integration test failures

### DIFF
--- a/apptrace/src/monocle_apptrace/instrumentation/common/instrumentor.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/common/instrumentor.py
@@ -406,6 +406,9 @@ def setup_monocle_telemetry(
     return get_monocle_instrumentor()
 
 def reset_span_processors(span_processors:list[SpanProcessor]):
+    # Mirror setup_monocle_telemetry: rebuilding the processor list without this
+    # silently drops trace-return for the rest of the process.
+    span_processors = _append_trace_return_processor(span_processors)
     monocle_span_processor = get_monocle_span_processor()
     if monocle_span_processor:
         clear = getattr(monocle_span_processor, "clear_span_processors", None)

--- a/test_tools/src/monocle_test_tools/pytest_plugin.py
+++ b/test_tools/src/monocle_test_tools/pytest_plugin.py
@@ -150,6 +150,29 @@ def pytest_runtest_makereport(item, call):
             rep.outcome = "failed"
 
             rep.longrepr = traceAssertion.get_assertion_messages()
+            _apply_xfail_to_deferred_failure(item, rep)
+
+
+def _apply_xfail_to_deferred_failure(item, rep) -> None:
+    """Honour @pytest.mark.xfail for assertions that were recorded, not raised.
+
+    Fluent assertions record instead of raising, so pytest's own xfail
+    hookwrapper already saw a passing call and left the marker unapplied.
+    """
+    if item.config.getoption("runxfail", False):
+        return
+    marker = item.get_closest_marker("xfail")
+    if marker is None:
+        return
+    # A falsy literal condition disables it; leave string conditions to pytest.
+    condition = marker.args[0] if marker.args else marker.kwargs.get("condition", True)
+    if not isinstance(condition, str) and not condition:
+        return
+    # `raises=` cannot match a failure that never produced an exception.
+    if marker.kwargs.get("raises") is not None:
+        return
+    rep.outcome = "skipped"
+    rep.wasxfail = marker.kwargs.get("reason", "")
 
 def _is_test_failed(request:pytest.FixtureRequest) -> bool:
     """Check if the test has failed based on the pytest request object."""

--- a/test_tools/src/monocle_test_tools/runner/llamaindex_runner.py
+++ b/test_tools/src/monocle_test_tools/runner/llamaindex_runner.py
@@ -1,13 +1,33 @@
 import asyncio
+import functools
+import inspect
 from typing import Any, Union
 import logging
 logger = logging.getLogger(__name__)
 from monocle_test_tools.runner.agent_runner import AgentRunner
 from llama_index.core.memory.chat_memory_buffer import ChatMemoryBuffer
 
+
+def _memory_kwargs(target, memory):
+    """`memory=` kwargs for `target`, or `{}` when it doesn't accept them.
+
+    Wrappers like ``run_query_engine_async(user_msg)`` take only the message.
+    """
+    if memory is None:
+        return {}
+    try:
+        signature = inspect.signature(target)
+    except (TypeError, ValueError):
+        return {"memory": memory}
+    parameters = signature.parameters.values()
+    if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in parameters):
+        return {"memory": memory}
+    return {"memory": memory} if "memory" in signature.parameters else {}
+
+
 class LlamaIndexRunner(AgentRunner):
     """Runner for LlamaIndex agents."""
-    
+
     async def run_agent_async(self, root_agent, test_message: Union[str, Any],session_id: str = None):
         """
         Run a LlamaIndex agent asynchronously.
@@ -32,7 +52,7 @@ class LlamaIndexRunner(AgentRunner):
             # Check if root_agent is a callable function (wrapper function)
             if callable(root_agent) and not hasattr(root_agent, 'achat') and not hasattr(root_agent, 'run'):
                 # It's a wrapper function, call it directly with the message
-                result = root_agent(test_message,memory=memory)
+                result = root_agent(test_message, **_memory_kwargs(root_agent, memory))
                 # If it returns a coroutine, await it
                 if asyncio.iscoroutine(result):
                     return await result
@@ -44,7 +64,9 @@ class LlamaIndexRunner(AgentRunner):
             # LlamaIndex agents typically have an async chat or run method
             if agent_type == 'AgentWorkflow' and hasattr(root_agent, 'run'):
                 # AgentWorkflow.run() is awaitable and uses user_msg parameter
-                response = await root_agent.run(user_msg=test_message,memory=memory)
+                response = await root_agent.run(
+                    user_msg=test_message, **_memory_kwargs(root_agent.run, memory)
+                )
                 
             elif hasattr(root_agent, 'achat'):
                 response = await root_agent.achat(test_message)
@@ -54,18 +76,28 @@ class LlamaIndexRunner(AgentRunner):
                 response = await root_agent.aquery(test_message)
             elif hasattr(root_agent, 'run'):
                 # If no async method, run sync method in executor
+                # run_in_executor takes no kwargs -- bind them with partial.
                 response = await asyncio.get_event_loop().run_in_executor(
-                    None, root_agent.run, test_message, memory=memory
+                    None,
+                    functools.partial(
+                        root_agent.run, test_message, **_memory_kwargs(root_agent.run, memory)
+                    ),
                 )
             elif hasattr(root_agent, 'chat'):
                 # For chat-based agents
                 response = await asyncio.get_event_loop().run_in_executor(
-                    None, root_agent.chat, test_message, memory=memory
+                    None,
+                    functools.partial(
+                        root_agent.chat, test_message, **_memory_kwargs(root_agent.chat, memory)
+                    ),
                 )
             elif hasattr(root_agent, 'query'):
                 # For query engines
                 response = await asyncio.get_event_loop().run_in_executor(
-                    None, root_agent.query, test_message, memory=memory
+                    None,
+                    functools.partial(
+                        root_agent.query, test_message, **_memory_kwargs(root_agent.query, memory)
+                    ),
                 )
             else:
                 raise AttributeError(

--- a/test_tools/src/monocle_test_tools/validator.py
+++ b/test_tools/src/monocle_test_tools/validator.py
@@ -255,9 +255,9 @@ class MonocleValidator:
                 raise
             finally:
                 test_failed = validation_failed or (request.session.testsfailed > prior_test_failed_count)
+                # post_test_cleanup stops the scope token; a second stop_scope
+                # double-detaches it ("Token ... has already been used once").
                 self.post_test_cleanup(token, request.node.name, test_failed, validation_error_message)
-                if token is not None:
-                    stop_scope(token)
 
     @staticmethod
     def test_id_generator(val):
@@ -294,9 +294,8 @@ class MonocleValidator:
                 request is not None and request.session.testsfailed > prior_test_failed_count
             )
             test_name = request.node.name if request is not None else test_case_name
+            # post_test_cleanup stops the scope token; see monocle_exporter_wrapper.
             self.post_test_cleanup(token, test_name, test_failed, validation_error_message)
-            if token is not None:
-                stop_scope(token)
 
     def monocle_testcase(self, test_cases_array: list[Union[TestCase, dict]]):
         test_cases: list[TestCase] = []

--- a/test_tools/tests/integration/conftest.py
+++ b/test_tools/tests/integration/conftest.py
@@ -16,3 +16,11 @@ def _plugin_registered_via_entrypoint() -> bool:
 
 if not _plugin_registered_via_entrypoint():
     pytest_plugins = ["monocle_test_tools.pytest_plugin"]
+
+# Must be set before the first setup_monocle_telemetry(), which is when the
+# trace-return SpanProcessor is wired up -- a test module setting it at its own
+# import time loses the race to modules imported earlier during collection.
+# Inert without the retrieval keys, which are read live per request.
+import os
+
+os.environ.setdefault("MONOCLE_ENABLE_TRACE_RETURN", "true")

--- a/test_tools/tests/integration/test_adk_custom_assertions.py
+++ b/test_tools/tests/integration/test_adk_custom_assertions.py
@@ -52,16 +52,18 @@ async def test_does_not_call_agent_passes(monocle_trace_asserter):
 @pytest.mark.asyncio
 async def test_has_input_passes(monocle_trace_asserter):
     """has_input - passes when input matches."""
+    # Tool input is serialized JSON with per-run key order, so the exact-match
+    # has_*/does_not_have_* forms cannot be used here.
     await monocle_trace_asserter.run_agent_async(root_agent, "google_adk",
                         "Book a flight from Miami to Orlando for May 1st 2026")
-    monocle_trace_asserter.called_tool("adk_book_flight_5").has_input("Orlando")
+    monocle_trace_asserter.called_tool("adk_book_flight_5").contains_input("Orlando")
 
 @pytest.mark.asyncio
 async def test_has_any_input_passes(monocle_trace_asserter):
     """has_any_input - passes when any input matches."""
     await monocle_trace_asserter.run_agent_async(root_agent, "google_adk",
                         "Book a flight from Seattle to Portland for May 5th 2026")
-    monocle_trace_asserter.called_tool("adk_book_flight_5").has_any_input("Portland", "Seattle", "Vancouver")
+    monocle_trace_asserter.called_tool("adk_book_flight_5").contains_any_input("Portland", "Seattle", "Vancouver")
 
 @pytest.mark.asyncio
 async def test_does_not_have_input_passes(monocle_trace_asserter):
@@ -241,7 +243,7 @@ async def test_fail_input_contains_wrong_value(monocle_trace_asserter):
     """This test will fail - demonstrates custom message when input contains unexpected value."""
     await monocle_trace_asserter.run_agent_async(root_agent, "google_adk",
                         "Book a flight from Dallas to Houston for March 3rd 2027")
-    monocle_trace_asserter.does_not_have_input(
+    monocle_trace_asserter.does_not_contain_input(
         "Dallas",
         message="SECURITY ALERT: Input contains restricted city 'Dallas' which is not allowed in this context"
     )
@@ -318,7 +320,7 @@ async def test_fail_does_not_have_any_input(monocle_trace_asserter):
     """This test will fail - demonstrates custom message when prohibited inputs are detected."""
     await monocle_trace_asserter.run_agent_async(root_agent, "google_adk",
                         "Book a flight from New York to Los Angeles for Sep 1st 2026")
-    monocle_trace_asserter.does_not_have_any_input(
+    monocle_trace_asserter.does_not_contain_any_input(
         "New York", "Los Angeles", "Chicago",
         message="COMPLIANCE ERROR: Blacklisted cities detected in booking request"
     )
@@ -373,7 +375,7 @@ async def test_fail_does_not_have_any_output(monocle_trace_asserter):
     """This test will fail - demonstrates custom message when booking completion terms present."""
     await monocle_trace_asserter.run_agent_async(root_agent, "google_adk",
                         "Book a flight from Las Vegas to Reno for Sep 30th 2026")
-    monocle_trace_asserter.does_not_have_any_output(
+    monocle_trace_asserter.does_not_contain_any_output(
         "booked", "confirmed", "reserved",
         message="STATUS ERROR: Output contains booking completion terms that shouldn't be present"
     )

--- a/test_tools/tests/integration/test_crewai_simple_agent.py
+++ b/test_tools/tests/integration/test_crewai_simple_agent.py
@@ -69,12 +69,10 @@ async def execute_simple_hotel_booking(request: str):
 
 
 @MonocleValidator().monocle_testcase(agent_test_cases)
-async def test_crewai_simple_hotel_agent(my_test_case: TestCase):# @pytest.mark.asyncio
-# @pytest.mark.parametrize("test_case", agent_test_cases)
-# async def test_crewai_simple_hotel_agent(monocle_test_case):
+async def test_crewai_simple_hotel_agent(my_test_case: TestCase):
     """Test simple CrewAI hotel booking agent."""
-    # Extract the hotel request from test input
-    hotel_request = agent_test_cases.test_input[0]
+    # The current parametrized case, not the module-level list.
+    hotel_request = my_test_case.test_input[0]
     
     # Execute the simple hotel booking
     result = await execute_simple_hotel_booking(hotel_request)

--- a/test_tools/tests/integration/test_crewai_travel_agent.py
+++ b/test_tools/tests/integration/test_crewai_travel_agent.py
@@ -77,8 +77,8 @@ async def test_crewai_travel_agent(my_test_case: TestCase):
     # Extract the travel request from test input
     travel_request = my_test_case.test_input[0]
     
-    # Execute the CrewAI travel request
-    result = await execute_crewai_travel_request(travel_request)
+    # Sync: it calls crew.kickoff, not kickoff_async.
+    result = execute_crewai_travel_request(travel_request)
     
     # Return the result for validation
     await sleep(2)  # To avoid rate limiting

--- a/test_tools/tests/integration/test_crewai_travel_agent_fluent.py
+++ b/test_tools/tests/integration/test_crewai_travel_agent_fluent.py
@@ -13,7 +13,7 @@ async def test_tool_invocation(monocle_trace_asserter:TraceAssertion):
     crew = create_crewai_travel_crew(travel_request)
     
     # Run the agent
-    await monocle_trace_asserter.run_async_agent(crew, "crewai", travel_request)
+    await monocle_trace_asserter.run_agent_async(crew, "crewai", travel_request)
     
     # Verify tool was called
     monocle_trace_asserter.called_tool("crew_book_hotel", "CrewAI Hotel Booking Agent").contains_output("success")
@@ -26,7 +26,7 @@ async def test_agent_invocation(monocle_trace_asserter:TraceAssertion):
     crew = create_crewai_travel_crew(travel_request)
     
     # Run the agent
-    await monocle_trace_asserter.run_async_agent(crew, "crewai", travel_request)
+    await monocle_trace_asserter.run_agent_async(crew, "crewai", travel_request)
     
     # Verify agent was invoked
     monocle_trace_asserter.called_agent("CrewAI Hotel Booking Agent").contains_output("success")

--- a/test_tools/tests/integration/test_http_trace_return.py
+++ b/test_tools/tests/integration/test_http_trace_return.py
@@ -1,18 +1,10 @@
 import os
 
-# MONOCLE_ENABLE_TRACE_RETURN must be "true" *before* MonocleValidator() is
-# constructed anywhere in this process: setup_monocle_telemetry() only wires
-# up the TraceReturnSpanExporter processor once, at instrumentor-setup time,
-# and MonocleValidator is a session-wide singleton. Setting it here at module
-# import time guarantees it is in place before the first construction, as
-# long as this file is run on its own / is the first test module to touch
-# MonocleValidator in the pytest session.
+# conftest.py enables trace-return early enough for any import order; this is
+# a belt-and-braces repeat for running this file standalone.
 os.environ["MONOCLE_ENABLE_TRACE_RETURN"] = "true"
-# Server-side key (default_trace_retrieval_callback checks the incoming
-# x-monocle-retrieve-traces header against this) and client-side key
-# (HttpRunner._maybe_inject_retrieval_key reads this to auto-inject the
-# header). Same value == authorized; must be set before MonocleValidator()
-# is constructed for the same reason as MONOCLE_ENABLE_TRACE_RETURN above.
+# Server-side and client-side keys; matching values == authorized. Read live
+# per request, so import order does not matter for these.
 os.environ["MONOCLE_TRACE_RETRIEVAL_DEFAULT_KEY"] = "e2e-s3cret"
 os.environ["MONOCLE_TRACE_RETRIEVAL_KEY"] = "e2e-s3cret"
 
@@ -22,7 +14,8 @@ import time
 
 import pytest
 
-pytest_plugins = ["monocle_test_tools.pytest_plugin"]
+# The monocle_test_tools plugin is registered by conftest.py; declaring
+# pytest_plugins here too double-registers it and fails collection.
 
 
 def _free_port():

--- a/test_tools/tests/integration/test_http_trace_return_frameworks.py
+++ b/test_tools/tests/integration/test_http_trace_return_frameworks.py
@@ -1,13 +1,7 @@
-"""End-to-end trace-return coverage for the non-FastAPI HTTP server frameworks:
-Flask, aiohttp (Task 6 of the "trace-return across all HTTP frameworks" feature).
+"""End-to-end trace-return coverage for Flask and aiohttp.
 
-Mirrors test_http_trace_return.py (the FastAPI e2e): the env vars below must be
-set *before* MonocleValidator() / setup_monocle_telemetry() is first constructed
-anywhere in the process, because the trace-return SimpleSpanProcessor is wired
-up once, at instrumentor-setup time (see _append_trace_return_processor in
-instrumentor.py). Setting them here at module import time guarantees that, as
-long as this file is the first test module in the pytest session to touch
-MonocleValidator (true when run standalone, per the task's run command).
+Mirrors test_http_trace_return.py. conftest.py enables trace-return early
+enough for any import order; the env vars below repeat that for standalone runs.
 """
 import os
 
@@ -22,7 +16,8 @@ import threading
 
 import pytest
 
-pytest_plugins = ["monocle_test_tools.pytest_plugin"]
+# The monocle_test_tools plugin is registered by conftest.py; declaring
+# pytest_plugins here too double-registers it and fails collection.
 
 
 def _free_port():

--- a/test_tools/tests/integration/test_okahu_trace_assertions.py
+++ b/test_tools/tests/integration/test_okahu_trace_assertions.py
@@ -1,10 +1,33 @@
+import os
+
 import pytest
+import requests
 from monocle_test_tools import TraceAssertion
 from monocle_test_tools.okahu_span_loader import OkahuSpanLoader
 
-# Update these constants with real values from your Okahu environment to run the tests
-DEMO_WORKFLOW_NAME = "Okahu-Loader-Demo"
-PLACEHOLDER_TRACE_ID = "642dbd9d0dfcfdbdc8849f67f34c8a19"
+# Point at your own tenant's data via OKAHU_DEMO_WORKFLOW_NAME / OKAHU_DEMO_TRACE_ID.
+DEMO_WORKFLOW_NAME = os.getenv("OKAHU_DEMO_WORKFLOW_NAME", "Okahu-Loader-Demo")
+PLACEHOLDER_TRACE_ID = os.getenv("OKAHU_DEMO_TRACE_ID", "642dbd9d0dfcfdbdc8849f67f34c8a19")
+
+
+def _load_demo_spans(asserter: TraceAssertion):
+    """Load the demo trace, skipping if this tenant does not have it.
+
+    A missing trace is an absent fixture, not a product defect.
+    """
+    try:
+        spans = OkahuSpanLoader.get_spans(DEMO_WORKFLOW_NAME, PLACEHOLDER_TRACE_ID)
+    except requests.HTTPError as exc:
+        status = exc.response.status_code if exc.response is not None else None
+        if status in (401, 403, 404):
+            pytest.skip(
+                f"Okahu demo trace {DEMO_WORKFLOW_NAME}/{PLACEHOLDER_TRACE_ID} unavailable "
+                f"(HTTP {status}); set OKAHU_DEMO_WORKFLOW_NAME / OKAHU_DEMO_TRACE_ID "
+                f"(and OKAHU_API_KEY / OKAHU_API_ENDPOINT) to a trace in your tenant."
+            )
+        raise
+    asserter.load_spans(spans)
+
 
 @pytest.fixture()
 def monocle_trace_asserter():
@@ -16,7 +39,7 @@ def monocle_trace_asserter():
 
 
 def test_agent_tool_and_io_assertions(monocle_trace_asserter: TraceAssertion):
-    monocle_trace_asserter.load_spans(OkahuSpanLoader.get_spans(DEMO_WORKFLOW_NAME, PLACEHOLDER_TRACE_ID))
+    _load_demo_spans(monocle_trace_asserter)
 
     # Verify expected agents were invoked (and one was not)
     monocle_trace_asserter.called_agent("okahu_demo_cc_agent_supervisor")
@@ -35,7 +58,7 @@ def test_agent_tool_and_io_assertions(monocle_trace_asserter: TraceAssertion):
     monocle_trace_asserter.does_not_contain_output("ORD-B1042")
 
 def test_performance_and_eval(monocle_trace_asserter: TraceAssertion):
-    monocle_trace_asserter.load_spans(OkahuSpanLoader.get_spans(DEMO_WORKFLOW_NAME, PLACEHOLDER_TRACE_ID))
+    _load_demo_spans(monocle_trace_asserter)
 
     # Performance: token usage and workflow duration
     monocle_trace_asserter.under_token_limit(10000)

--- a/test_tools/tests/test_common/llamaindex_travel_agent.py
+++ b/test_tools/tests/test_common/llamaindex_travel_agent.py
@@ -5,7 +5,7 @@ from llama_index.core.tools import FunctionTool
 from llama_index.core.agent.workflow import AgentWorkflow, FunctionAgent
 from llama_index.llms.openai import OpenAI
 from monocle_apptrace.instrumentation.common.instrumentor import setup_monocle_telemetry
-from llama_index.core.agent import ReActAgent
+from llama_index.core.agent.workflow import ReActAgent
 from llama_index.tools.mcp import aget_tools_from_mcp_url
 import logging
 
@@ -129,6 +129,18 @@ async def run_agent(user_msg: str = None):
         else:
             return str(resp)
 
+def _agent_text(response) -> str:
+    """Text of a workflow-agent result.
+
+    AgentOutput.response is a ChatMessage; str() on it adds an "assistant: "
+    prefix that breaks the similarity comparer.
+    """
+    content = getattr(getattr(response, "response", None), "content", None)
+    if content is not None:
+        return str(content)
+    return str(response)
+
+
 async def setup_react_agent():
     """Create a simple ReActAgent for testing achat/arun methods."""
     llm = OpenAI(model="gpt-4o")
@@ -145,56 +157,40 @@ async def setup_react_agent():
         description="Books a hotel stay."
     )
     
-    agent = ReActAgent.from_tools(
-        [flight_tool, hotel_tool],
-        llm=llm,
-        verbose=True
-    )
+    agent = ReActAgent(tools=[flight_tool, hotel_tool], llm=llm, verbose=True)
     return agent
 
 async def run_react_agent_achat(user_msg: str):
-    """Test ReActAgent with achat method (async chat)."""
+    """Test ReActAgent via its async run() entrypoint."""
     agent = await setup_react_agent()
-    response = await agent.achat(user_msg)
-    
-    if hasattr(response, 'response'):
-        return str(response.response)
-    else:
-        return str(response)
+    response = await agent.run(user_msg=user_msg)
+    return _agent_text(response)
 
 async def run_react_agent_aquery(user_msg: str):
-    """Test ReActAgent with aquery method if available."""
+    """Test ReActAgent driven with chat_history rather than a bare user_msg."""
     agent = await setup_react_agent()
-    
-    # Some agents have aquery method
-    if hasattr(agent, 'aquery'):
-        response = await agent.aquery(user_msg)
-    else:
-        # Fallback to achat
-        response = await agent.achat(user_msg)
-    
-    if hasattr(response, 'response'):
-        return str(response.response)
-    else:
-        return str(response)
+    from llama_index.core.base.llms.types import ChatMessage
+    response = await agent.run(chat_history=[ChatMessage(role="user", content=user_msg)])
+    return _agent_text(response)
 
-def run_react_agent_chat(user_msg: str):
-    """Test ReActAgent with synchronous chat method."""
+async def run_react_agent_chat(user_msg: str):
+    """Test a single-tool ReActAgent.
+
+    Async because the workflow ReActAgent has no synchronous chat()/query()
+    entrypoint -- run() is the only one. The test that drives this asserts on
+    the emitted tool-invocation span, which is unaffected.
+    """
     llm = OpenAI(model="gpt-4o")
-    
+
     flight_tool = FunctionTool.from_defaults(
         fn=book_flight,
         name="lmx_book_flight_tool_sync",
         description="Books a flight from one airport to another."
     )
-    
-    agent = ReActAgent.from_tools([flight_tool], llm=llm, verbose=True)
-    response = agent.chat(user_msg)
-    
-    if hasattr(response, 'response'):
-        return str(response.response)
-    else:
-        return str(response)
+
+    agent = ReActAgent(tools=[flight_tool], llm=llm, verbose=True)
+    response = await agent.run(user_msg=user_msg)
+    return _agent_text(response)
 
 def run_query_engine(user_msg: str):
     """Test QueryEngine with synchronous query method."""


### PR DESCRIPTION
Fixes a set of unrelated defects that together accounted for most of the integration-suite failures.

Product fixes:
- validator: post_test_cleanup already stops the scope token, but both wrappers stopped it a second time. The double detach raised "RuntimeError: <Token ...> has already been used once" from the finally block while the real exception was propagating, burying every failing test's actual error.
- pytest_plugin: honour @pytest.mark.xfail for fluent assertions. They record rather than raise, so the outcome is flipped to "failed" after pytest's own xfail hookwrapper has already seen a passing call, leaving the marker unapplied. ~26 intentional-failure tests reported as hard FAILED; three that silently stopped failing were masked as passes.
- llamaindex_runner: only pass memory= to callables that accept it, and bind it with functools.partial for run_in_executor, which takes no kwargs.
- instrumentor: reset_span_processors now re-appends the trace-return processor like setup_monocle_telemetry does. Rebuilding the processor list on an initialised instrumentor silently dropped trace-return for the rest of the process.

Test fixes:
- crewai: use the parametrized case rather than the module-level list; drop an await on a sync helper; run_async_agent -> run_agent_async.
- llamaindex: migrate to llama-index 0.13 (ReActAgent.from_tools removed, chat/achat/aquery replaced by run()); extract text from AgentOutput so the ChatMessage role prefix does not break the similarity comparer.
- adk assertions: tool input is serialized JSON with per-run key order, so the exact-match has_*/does_not_have_* forms can never match a fragment. Switched five call sites to the substring forms.
- okahu trace assertions: make the pinned workflow/trace id overridable and skip on 401/403/404 instead of failing on absent tenant data.
- http trace return: stop double-registering the pytest plugin already registered by conftest, and enable trace-return in conftest so it is set before the first setup_monocle_telemetry() regardless of import order.

Verified: apptrace unit suite 855 passed; integration failures 77 -> 15, with the remainder being Okahu tenant configuration, tuned-too-tight performance thresholds, and LLM nondeterminism.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...