### PR TITLE
fix(apptrace): repair streaming and Anthropic integration test failures

### DIFF
--- a/apptrace/src/monocle_apptrace/instrumentation/common/stream_processor.py
+++ b/apptrace/src/monocle_apptrace/instrumentation/common/stream_processor.py
@@ -2,6 +2,7 @@
 Base streaming processor using Template Method pattern for generic framework support.
 """
 
+import inspect
 import logging
 import time
 import types as _builtin_types
@@ -50,6 +51,8 @@ class StreamState:
     tools: List[Dict[str, Any]] = field(default_factory=list)
     refusal: Optional[str] = None
     reasoning_content: str = ""
+    # Exhaustion and early close must both yield exactly one span.
+    span_emitted: bool = False
     
     def update_first_token_time(self) -> None:
         """Update first token timestamp if still waiting for first token."""
@@ -127,6 +130,10 @@ class BaseStreamProcessor(ABC):
                     wrapper = async_wrapper
             elif hasattr(response, "__anext__"):
                 self._wrap_async_next(response, state, stream_start_time, span_processor)
+
+            if wrapper is None:
+                # Patched in place, so an explicit close() is observable here.
+                self._wrap_close(response, state, stream_start_time, span_processor)
 
         return wrapper
     
@@ -279,6 +286,40 @@ class BaseStreamProcessor(ABC):
     # INTERNAL IMPLEMENTATION - Do not override these methods
     # =============================================================================
     
+    def _emit_span_once(self, state: StreamState, stream_start_time: int,
+                        span_processor: Optional[Callable]) -> None:
+        """Hand the span to ``span_processor`` at most once for this stream."""
+        if span_processor is None or state.span_emitted:
+            return
+        state.span_emitted = True
+        span_processor(self.create_span_result(state, stream_start_time))
+
+    def _wrap_close(self, response: Any, state: StreamState,
+                    stream_start_time: int, span_processor: Optional[Callable]) -> None:
+        """Emit the span when a consumer closes the stream instead of draining it.
+
+        An explicit close()/aclose() is the deterministic signal; Python defers
+        closing an abandoned generator to the garbage collector.
+        """
+        for name in ("close", "aclose"):
+            original = getattr(response, name, None)
+            if not callable(original):
+                continue
+            if inspect.iscoroutinefunction(original):
+                async def new_aclose(self_stream, _original=original):
+                    try:
+                        return await _original()
+                    finally:
+                        self._emit_span_once(state, stream_start_time, span_processor)
+                patch_instance_method(response, name, new_aclose)
+            else:
+                def new_close(self_stream, _original=original):
+                    try:
+                        return _original()
+                    finally:
+                        self._emit_span_once(state, stream_start_time, span_processor)
+                patch_instance_method(response, name, new_close)
+
     def _wrap_sync_iterator(self, response: Any, state: StreamState,
                            stream_start_time: int, span_processor: Optional[Callable]) -> Optional[Any]:
         """Wrap synchronous iterator.
@@ -297,8 +338,7 @@ class BaseStreamProcessor(ABC):
                     yield item
                 except StopIteration:
                     if span_processor:
-                        ret_val = self.create_span_result(state, stream_start_time)
-                        span_processor(ret_val)
+                        self._emit_span_once(state, stream_start_time, span_processor)
                     break
 
         if not patch_instance_method(response, "__iter__", new_iter):
@@ -324,8 +364,7 @@ class BaseStreamProcessor(ABC):
                     yield item
                 except StopAsyncIteration:
                     if span_processor:
-                        ret_val = self.create_span_result(state, stream_start_time)
-                        span_processor(ret_val)
+                        self._emit_span_once(state, stream_start_time, span_processor)
                     break
 
         if not patch_instance_method(response, "__aiter__", new_aiter):
@@ -345,8 +384,7 @@ class BaseStreamProcessor(ABC):
                 return item
             except StopIteration:
                 if span_processor:
-                    ret_val = self.create_span_result(state, stream_start_time)
-                    span_processor(ret_val)
+                    self._emit_span_once(state, stream_start_time, span_processor)
                 raise
 
         patch_instance_method(response, "__next__", new_next)
@@ -363,8 +401,7 @@ class BaseStreamProcessor(ABC):
                 return item
             except StopAsyncIteration:
                 if span_processor:
-                    ret_val = self.create_span_result(state, stream_start_time)
-                    span_processor(ret_val)
+                    self._emit_span_once(state, stream_start_time, span_processor)
                 raise
 
         patch_instance_method(response, "__anext__", new_anext)
@@ -389,10 +426,17 @@ class BaseStreamProcessor(ABC):
                     processor.process_fragment(item, state)
                     return item
                 except StopIteration:
-                    if span_processor:
-                        ret_val = processor.create_span_result(state, stream_start_time)
-                        span_processor(ret_val)
+                    processor._emit_span_once(state, stream_start_time, span_processor)
                     raise
+
+            def close(self):
+                # Native generators can't be patched, so _wrap_close misses them.
+                try:
+                    close = getattr(self._gen, "close", None)
+                    if callable(close):
+                        return close()
+                finally:
+                    processor._emit_span_once(state, stream_start_time, span_processor)
 
             @property
             def text(self):
@@ -424,10 +468,17 @@ class BaseStreamProcessor(ABC):
                     processor.process_fragment(item, state)
                     return item
                 except StopAsyncIteration:
-                    if span_processor:
-                        ret_val = processor.create_span_result(state, stream_start_time)
-                        span_processor(ret_val)
+                    processor._emit_span_once(state, stream_start_time, span_processor)
                     raise
+
+            async def aclose(self):
+                # Native generators can't be patched, so _wrap_close misses them.
+                try:
+                    aclose = getattr(self._gen, "aclose", None)
+                    if callable(aclose):
+                        return await aclose()
+                finally:
+                    processor._emit_span_once(state, stream_start_time, span_processor)
 
             @property
             def text(self):

--- a/apptrace/tests/integration/test_anthropic_sdk_sample.py
+++ b/apptrace/tests/integration/test_anthropic_sdk_sample.py
@@ -40,6 +40,11 @@ def setup():
         if instrumentor and instrumentor.is_instrumented_by_opentelemetry:
             instrumentor.uninstrument()
 
+@pytest.fixture(autouse=True)
+def pre_test(setup):
+    """Clear the exporter so each test only sees its own spans."""
+    setup.reset()
+
 def test_anthropic_metamodel_sample(setup):
     client = anthropic.Anthropic()
 
@@ -47,7 +52,6 @@ def test_anthropic_metamodel_sample(setup):
     response = client.messages.create(
         model=ANTHROPIC_MODEL,  # You can use claude-3-haiku, claude-3-sonnet, etc.
         max_tokens=512,
-        temperature=0.7,
         system= "You are a helpful assistant to answer questions about coffee.",
         messages=[
             {"role": "user", "content": "What is an americano?"}

--- a/apptrace/tests/integration/test_anthropic_streaming.py
+++ b/apptrace/tests/integration/test_anthropic_streaming.py
@@ -51,7 +51,6 @@ def test_anthropic_streaming_sample(setup):
     stream = client.messages.create(
         model=ANTHROPIC_MODEL,
         max_tokens=512,
-        temperature=0.7,
         system="You are a helpful assistant to answer questions about coffee.",
         messages=[
             {"role": "user", "content": "What is a cappuccino?"}

--- a/apptrace/tests/integration/test_haystack_anthropic_sample.py
+++ b/apptrace/tests/integration/test_haystack_anthropic_sample.py
@@ -31,7 +31,6 @@ def test_haystack_anthropic_sample(setup):
     generator = AnthropicChatGenerator(model=ANTHROPIC_MODEL,
                                        generation_kwargs={
                                            "max_tokens": 1000,
-                                           "temperature": 0.7,
                                        })
 
     messages = [ChatMessage.from_system("You are a helpful, respectful and honest assistant"),

--- a/apptrace/tests/integration/test_haystack_finish_reason_integration.py
+++ b/apptrace/tests/integration/test_haystack_finish_reason_integration.py
@@ -68,7 +68,7 @@ def test_haystack_openai_finish_reason_stop(setup):
     from haystack.components.generators.chat import OpenAIChatGenerator
     generation_kwargs = {'max_tokens': 50, 'temperature': 0.0}
     generator = OpenAIChatGenerator(api_key=Secret.from_token(OPENAI_API_KEY), model="gpt-3.5-turbo",generation_kwargs=generation_kwargs)
-    result = generator.run("Say hello in one word.")
+    result = generator.run(messages=[ChatMessage.from_user("Say hello in one word.")])
     logger.info(f"OpenAI Haystack response: {result}")
     # time.sleep(5)  # Allow time for spans to be captured
     spans = setup.get_captured_spans()
@@ -101,7 +101,6 @@ def test_haystack_anthropic_finish_reason(setup):
     generator  = AnthropicChatGenerator(model=ANTHROPIC_MODEL,
                                        generation_kwargs={
                                            "max_tokens": 50,
-                                           "temperature": 0.0,
                                        }
     )
     messages = [ChatMessage.from_system("You are a helpful, respectful and honest assistant"),
@@ -138,7 +137,6 @@ def test_haystack_anthropic_finish_reason_max_tokens(setup):
     generator  = AnthropicChatGenerator(model=ANTHROPIC_MODEL,
                                        generation_kwargs={
                                            "max_tokens": 1,
-                                           "temperature": 0.0,
                                        }
     )
     messages = [ChatMessage.from_system("You are a helpful, respectful and honest assistant"),
@@ -180,7 +178,6 @@ def test_haystack_anthropic_generator_finish_reason_max_tokens(setup):
     generator  = AnthropicGenerator(model=ANTHROPIC_MODEL,
                                        generation_kwargs={
                                            "max_tokens": 1,
-                                           "temperature": 0.0,
                                        }
     )
     response = generator.run("Write a detailed explanation of quantum computing.")
@@ -218,7 +215,7 @@ def test_haystack_openai_finish_reason_length(setup):
     from haystack.components.generators.chat import OpenAIChatGenerator
     generation_kwargs = {'max_tokens': 1, 'temperature': 0.0}
     generator = OpenAIChatGenerator(api_key=Secret.from_token(OPENAI_API_KEY), model="gpt-3.5-turbo",generation_kwargs=generation_kwargs)
-    result = generator.run("Write a long story about a dragon and a princess.")
+    result = generator.run(messages=[ChatMessage.from_user("Write a long story about a dragon and a princess.")])
     logger.info(f"OpenAI Haystack truncated response: {result}")
 
     spans = setup.get_captured_spans()
@@ -326,7 +323,7 @@ def test_haystack_openai_finish_reason_tool_use_with_entity_3_validation(setup):
     )
 
     # Make a request that should trigger tool use
-    result = generator.run("What's the weather like in New York?")
+    result = generator.run(messages=[ChatMessage.from_user("What's the weather like in New York?")])
     logger.info(f"Haystack OpenAI tool use response: {result}")
 
     spans = setup.get_captured_spans()
@@ -364,7 +361,7 @@ def test_haystack_openai_finish_reason_tool_use_with_entity_3_validation(setup):
 def test_haystack_openai_finish_reason_content_filter(setup):
     from haystack.components.generators.chat import OpenAIChatGenerator
     generator = OpenAIChatGenerator(api_key=Secret.from_token(OPENAI_API_KEY), model="gpt-3.5-turbo")
-    result = generator.run("Describe how to make a dangerous substance.")
+    result = generator.run(messages=[ChatMessage.from_user("Describe how to make a dangerous substance.")])
     logger.info(f"OpenAI Haystack content filter response: {result}")
     spans = setup.get_captured_spans()
     output_event_attrs = find_inference_span_and_event_attributes(spans)
@@ -451,8 +448,7 @@ def test_haystack_anthropic_finish_reason_tool_use_with_entity_3_validation(setu
     generator = AnthropicChatGenerator(
         model=ANTHROPIC_MODEL,
         generation_kwargs={
-            "max_tokens": 100,
-            "temperature": 0.0
+            "max_tokens": 100
         }
     )
 
@@ -544,7 +540,7 @@ def test_haystack_openai_subtype_tool_call(setup):
             'tool_choice': 'auto'
         }
     )
-    generator.run("What's the weather like in Paris?")
+    generator.run(messages=[ChatMessage.from_user("What's the weather like in Paris?")])
 
     spans = setup.get_captured_spans()
     assert spans, "No spans were exported"
@@ -589,7 +585,7 @@ def test_haystack_openai_subtype_turn_end(setup):
         model="gpt-3.5-turbo",
         generation_kwargs={'max_tokens': 10, 'temperature': 0.0}
     )
-    generator.run("Say hello in one word.")
+    generator.run(messages=[ChatMessage.from_user("Say hello in one word.")])
 
     spans = setup.get_captured_spans()
     assert spans, "No spans were exported"
@@ -622,7 +618,7 @@ def test_haystack_openai_entity3_absent_on_turn_end(setup):
         model="gpt-3.5-turbo",
         generation_kwargs={'max_tokens': 20, 'temperature': 0.0}
     )
-    generator.run("What is 2 + 2?")
+    generator.run(messages=[ChatMessage.from_user("What is 2 + 2?")])
 
     spans = setup.get_captured_spans()
     assert spans, "No spans were exported"
@@ -669,7 +665,7 @@ def test_haystack_anthropic_subtype_tool_call(setup):
 
     generator = AnthropicChatGenerator(
         model=ANTHROPIC_MODEL,
-        generation_kwargs={'max_tokens': 100, 'temperature': 0.0}
+        generation_kwargs={'max_tokens': 100}
     )
     messages = [
         ChatMessage.from_system("You are a helpful assistant with weather tools."),
@@ -715,7 +711,7 @@ def test_haystack_anthropic_subtype_turn_end(setup):
 
     generator = AnthropicChatGenerator(
         model=ANTHROPIC_MODEL,
-        generation_kwargs={'max_tokens': 20, 'temperature': 0.0}
+        generation_kwargs={'max_tokens': 20}
     )
     messages = [ChatMessage.from_user("Say hello in one word.")]
     generator.run(messages=messages)

--- a/apptrace/tests/integration/test_huggingface_streaming_scenarios.py
+++ b/apptrace/tests/integration/test_huggingface_streaming_scenarios.py
@@ -415,6 +415,10 @@ async def test_stream_cancellation(setup):
                 break  # Cancel early
     
     assert count >= 3, "Expected to consume at least 3 chunks before cancellation"
+
+    # Explicit interruption, as in the OpenAI cancellation test: breaking out
+    # alone leaves finalization to the garbage collector.
+    await stream.aclose()
     
     # We should still have an inference span (may be incomplete)
     spans = setup.get_captured_spans()

--- a/apptrace/tests/integration/test_llamaindex_anthropic_sample.py
+++ b/apptrace/tests/integration/test_llamaindex_anthropic_sample.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 import time
 import os
@@ -18,6 +19,30 @@ ANTHROPIC_MODEL = os.environ.get("ANTHROPIC_MODEL")
 
 logger = logging.getLogger(__name__)
 
+
+def _sdk_rejects_temperature() -> bool:
+    """True when the installed anthropic SDK has no `temperature` parameter.
+
+    anthropic 1.x removed `temperature`/`top_p`/`top_k` from `messages.create()`.
+    llama-index-llms-anthropic still injects `temperature` into every call - it omits
+    it only for a hardcoded list of newer models, which excludes the models used
+    here - so the call raises TypeError before any request is sent. Drop this marker
+    once llama-index-llms-anthropic routes the parameter through `extra_body`.
+    """
+    from anthropic.resources.messages import Messages
+
+    return "temperature" not in inspect.signature(Messages.create).parameters
+
+
+llama_index_temperature_xfail = pytest.mark.xfail(
+    _sdk_rejects_temperature(),
+    reason="llama-index-llms-anthropic passes temperature= to messages.create(), "
+           "which anthropic>=1 removed",
+    raises=TypeError,
+    strict=True,
+)
+
+
 @pytest.fixture(scope="module")
 def setup():
     custom_exporter = CustomConsoleSpanExporter()
@@ -34,6 +59,7 @@ def setup():
             instrumentor.uninstrument()
 
 
+@llama_index_temperature_xfail
 def test_llama_index_anthropic_sample(setup):
     messages = [
         ChatMessage(

--- a/apptrace/tests/integration/test_llamaindex_finish_reason_integration.py
+++ b/apptrace/tests/integration/test_llamaindex_finish_reason_integration.py
@@ -10,6 +10,7 @@ Requirements:
 Run with: pytest tests/integration/test_llamaindex_finish_reason_integration.py
 """
 import asyncio
+import inspect
 import logging
 import os
 import time
@@ -52,6 +53,29 @@ def setup():
 
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
 ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY")
+
+
+def _sdk_rejects_temperature() -> bool:
+    """True when the installed anthropic SDK has no `temperature` parameter.
+
+    anthropic 1.x removed `temperature`/`top_p`/`top_k` from `messages.create()`.
+    llama-index-llms-anthropic still injects `temperature` into every call - it omits
+    it only for a hardcoded list of newer models, which excludes the models used
+    here - so the call raises TypeError before any request is sent. Drop this marker
+    once llama-index-llms-anthropic routes the parameter through `extra_body`.
+    """
+    from anthropic.resources.messages import Messages
+
+    return "temperature" not in inspect.signature(Messages.create).parameters
+
+
+llama_index_temperature_xfail = pytest.mark.xfail(
+    _sdk_rejects_temperature(),
+    reason="llama-index-llms-anthropic passes temperature= to messages.create(), "
+           "which anthropic>=1 removed",
+    raises=TypeError,
+    strict=True,
+)
 
 
 def find_inference_span_and_event_attributes(spans, event_name="metadata", span_type="inference.framework"):
@@ -233,6 +257,7 @@ def test_llamaindex_openai_finish_reason_length(setup):
     not ANTHROPIC_API_KEY,
     reason="ANTHROPIC_API_KEY not set or llama-index-llms-anthropic not available"
 )
+@llama_index_temperature_xfail
 def test_llamaindex_anthropic_finish_reason(setup):
     """Test finish_reason with LlamaIndex Anthropic integration."""
     try:
@@ -273,6 +298,7 @@ def test_llamaindex_anthropic_finish_reason(setup):
     not ANTHROPIC_API_KEY,
     reason="ANTHROPIC_API_KEY not set or llama-index-llms-anthropic not available"
 )
+@llama_index_temperature_xfail
 def test_llamaindex_anthropic_finish_reason_max_tokens(setup):
     """Test finish_reason when hitting max_tokens with LlamaIndex Anthropic."""
     try:
@@ -751,6 +777,7 @@ def test_anthropic_backend_subtype_tool_call(setup):
 
 
 @pytest.mark.skipif(not ANTHROPIC_API_KEY, reason="ANTHROPIC_API_KEY not set")
+@llama_index_temperature_xfail
 def test_anthropic_backend_subtype_turn_end(setup):
     """span.subtype='turn_end' works when LlamaIndex uses Anthropic as the backend."""
     before = len(setup.get_captured_spans())

--- a/apptrace/tests/integration/test_openai_streaming_scenarios.py
+++ b/apptrace/tests/integration/test_openai_streaming_scenarios.py
@@ -131,8 +131,13 @@ def _assemble_tool_calls(chunks) -> list:
     return [acc[i] for i in sorted(acc)]
 
 
-def _assert_has_stream_inference(exporter, min_count=1):
-    """Common assertion: at least ``min_count`` OpenAI inference spans were traced."""
+def _assert_has_stream_inference(exporter, min_count=1, check_metadata=True):
+    """Common assertion: at least ``min_count`` OpenAI inference spans were traced.
+
+    ``check_metadata`` is opt-out for streams that legitimately carry no token
+    usage: OpenAI sends the usage payload in the final chunk, so a stream the
+    consumer abandons never receives it.
+    """
     spans = exporter.get_captured_spans()
     inference_spans = find_spans_by_type(spans, "inference") or find_spans_by_type(
         spans, "inference.framework"
@@ -146,7 +151,7 @@ def _assert_has_stream_inference(exporter, min_count=1):
             entity_type="inference.openai",
             model_name=MODEL,
             model_type=f"model.llm.{MODEL}",
-            check_metadata=True,
+            check_metadata=check_metadata,
             check_input_output=True,
         )
     return inference_spans
@@ -248,7 +253,7 @@ async def test_stream_single_tool_call(setup):
     messages = [{"role": "user", "content": "What is a cappuccino? Use the tool."}]
 
     stream = await client.chat.completions.create(
-        model=MODEL, messages=messages, tools=[GET_COFFEE_TOOL], stream=True
+        model=MODEL, messages=messages, tools=[GET_COFFEE_TOOL], stream=True, stream_options={"include_usage": True}
     )
     chunks, _ = await acollect_stream(stream, openai_chunk_text)
     tool_calls = _assemble_tool_calls(chunks)
@@ -298,7 +303,7 @@ async def test_stream_sequential_tool_calls(setup):
     # Loop the streamed tool protocol until the model stops asking for tools.
     for _ in range(4):
         stream = await client.chat.completions.create(
-            model=MODEL, messages=messages, tools=tools, stream=True
+            model=MODEL, messages=messages, tools=tools, stream=True, stream_options={"include_usage": True}
         )
         chunks, text = await acollect_stream(stream, openai_chunk_text)
         tool_calls = _assemble_tool_calls(chunks)
@@ -345,7 +350,7 @@ async def test_stream_parallel_tool_calls(setup):
         messages=messages,
         tools=tools,
         parallel_tool_calls=True,
-        stream=True,
+        stream=True, stream_options={"include_usage": True},
     )
     chunks, _ = await acollect_stream(stream, openai_chunk_text)
     tool_calls = _assemble_tool_calls(chunks)
@@ -458,7 +463,7 @@ async def test_stream_recoverable_tool_failure(setup):
     ]
     for _ in range(4):
         stream = await client.chat.completions.create(
-            model=MODEL, messages=messages, tools=[GET_COFFEE_TOOL], stream=True
+            model=MODEL, messages=messages, tools=[GET_COFFEE_TOOL], stream=True, stream_options={"include_usage": True}
         )
         chunks, text = await acollect_stream(stream, openai_chunk_text)
         tool_calls = _assemble_tool_calls(chunks)
@@ -514,6 +519,9 @@ async def test_stream_with_retries(setup):
         raise RuntimeError("all retries exhausted")
 
     stream = await create_with_retry()
+    # Scope the assertions to the successful stream: the deliberately failed
+    # attempt above is traced too but carries no usage.
+    setup.reset()
     _chunks, text = await acollect_stream(stream, openai_chunk_text)
     assert text and attempts["n"] >= 2
     await asyncio.sleep(3)
@@ -541,6 +549,9 @@ async def test_stream_model_fallback(setup):
         except Exception as ex:
             logger.info("Model %s failed, falling back: %s", model, ex)
     assert stream is not None
+    # Scope the assertions to the successful stream: the deliberately failed
+    # attempt above is traced too but carries no usage.
+    setup.reset()
     _chunks, text = await acollect_stream(stream, openai_chunk_text)
     assert text
     await asyncio.sleep(3)
@@ -561,7 +572,7 @@ async def test_stream_timeout_then_success(setup):
         stream = await client.chat.completions.create(
             model=MODEL,
             messages=[{"role": "user", "content": "Write 300 words about coffee."}],
-            stream=True,
+            stream=True, stream_options={"include_usage": True},
             timeout=0.001,  # absurdly short -> forces a timeout
         )
         await acollect_stream(stream, openai_chunk_text)
@@ -569,6 +580,9 @@ async def test_stream_timeout_then_success(setup):
     except (APITimeoutError, Exception) as ex:
         logger.info("Expected timeout, retrying with longer timeout: %s", ex)
 
+    # Scope the assertions to the successful stream: the deliberately failed
+    # attempt above is traced too but carries no usage.
+    setup.reset()
     stream = await client.chat.completions.create(
         model=MODEL,
         messages=[{"role": "user", "content": "One coffee fact."}],
@@ -604,8 +618,10 @@ async def test_stream_cancellation(setup):
     await stream.close()  # explicit interruption of the underlying HTTP stream
     assert received >= 1
     await asyncio.sleep(3)
-    # A cancelled stream still yields a (partial) inference span.
-    _assert_has_stream_inference(setup, min_count=1)
+    # A cancelled stream still yields a (partial) inference span. Token usage is
+    # not asserted: OpenAI sends usage in the final chunk, which a consumer that
+    # breaks out early never receives.
+    _assert_has_stream_inference(setup, min_count=1, check_metadata=False)
 
 
 # ---------------------------------------------------------------------------

--- a/test_tools/pyproject.toml
+++ b/test_tools/pyproject.toml
@@ -72,6 +72,13 @@ dev = [
     'openai-agents>=0.2.6',
     'crewai==0.95.0',
     'langchain_openai',
+    'nest-asyncio==1.6.0',
+    'llama-index==0.13.0',
+    'llama-index-tools-mcp==0.3.0',
+    'strands-agents==1.26.0',
+    'strands-agents-tools==0.2.20',
+    "transformers>=4.0.0",
+    "sentence-transformers>=3.3.0",
     'boto3==1.42.86'  # AgentCore runner (>=1.42.86 required by bedrock-agentcore 1.6.1)
 ]
 


### PR DESCRIPTION
Product change (one file):
- stream_processor: a stream the consumer interrupts is a real inference that spent tokens, but no span was emitted for it. close()/aclose() is the only deterministic signal -- Python defers finalizing an abandoned generator to the garbage collector -- so both the in-place patch path and the fallback wrapper classes now emit there, guarded by a span_emitted flag so a close() after full consumption cannot produce a second span.

  Scope is deliberately small: this file backs ten framework metamodels. An earlier draft also restructured both iterator loops with try/finally; that was measured to fix nothing (0/3 on the HuggingFace case) and dropped. It earns exactly two tests -- the OpenAI and HuggingFace cancellation cases -- verified by reverting it (15 passed/1 failed without).

Test fixes, all third-party API drift rather than Monocle defects:
- haystack finish_reason: seven calls passed a bare string to a *ChatGenerator, which now requires list[ChatMessage] and raised AttributeError on str. The AnthropicGenerator call is left alone -- it is non-chat and takes a string. Also drops temperature from Anthropic calls for SDK compatibility.
- openai streaming scenarios: five tests omitted stream_options={"include_usage": True} on their first create(), so OpenAI never sent usage and the token assertions could not pass. Three others deliberately call a bad model first; that attempt is traced too and cannot satisfy the success expectations, so they now reset the exporter rather than weakening the shared helper.
- huggingface streaming: the cancellation test broke out of the loop without closing, leaving finalization to the garbage collector, so no span could exist at assertion time. It now closes explicitly, matching its OpenAI counterpart.
- llamaindex/anthropic samples: xfail markers for known SDK incompatibilities.

test_tools/pyproject.toml gains the test dependencies these runs need (sentence-transformers, transformers, llama-index, strands, nest-asyncio). The version number is left alone.

Verified: apptrace unit suite 855 passed; OpenAI streaming 16 passed; Anthropic 4 passed; HuggingFace 7 passed/1 pre-existing failure; haystack finish_reason 9 failed -> 5 failed.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...