### PR TITLE
fix(test_tools): report failed trace exports and empty eval results accurately

### DIFF
--- a/apptrace/src/monocle_apptrace/exporters/okahu/okahu_exporter.py
+++ b/apptrace/src/monocle_apptrace/exporters/okahu/okahu_exporter.py
@@ -40,6 +40,9 @@ class OkahuSpanExporter(SpanExporterBase):
         self.endpoint = endpoint or okahu_endpoint
         api_key: Optional[str] = _get_okahu_api_key()
         self._closed = False
+        # HTTP status of the most recent synchronous upload, so a caller that
+        # gets SpanExportResult.FAILURE can say why (None: no response, e.g. timeout).
+        self.last_status_code: Optional[int] = None
         if not api_key:
             raise ValueError("OKAHU_API_KEY not set.")
         self.timeout = timeout or 15
@@ -81,11 +84,13 @@ class OkahuSpanExporter(SpanExporterBase):
 
         def send_spans_to_okahu(span_list_local=None, is_root=False):
             try:
+                self.last_status_code = None
                 result = self.session.post(
                     url=self.endpoint,
                     data=json.dumps(span_list_local),
                     timeout=self.timeout,
                 )
+                self.last_status_code = result.status_code
                 if result.status_code not in REQUESTS_SUCCESS_STATUS_CODES:
                     logger.error(
                         "Traces cannot be uploaded; status code: %s, message %s",

--- a/test_tools/src/monocle_test_tools/evals/okahu_eval.py
+++ b/test_tools/src/monocle_test_tools/evals/okahu_eval.py
@@ -3,6 +3,7 @@ import logging
 import os
 from datetime import datetime, timezone
 from opentelemetry.sdk.trace import Span
+from opentelemetry.sdk.trace.export import SpanExportResult
 import requests
 from opentelemetry.baggage.propagation import W3CBaggagePropagator
 from monocle_apptrace.exporters.okahu import okahu_exporter
@@ -77,6 +78,22 @@ class OkahuEval(BaseEval):
         """
         from monocle_test_tools.evals.okahu_eval_discovery import discover_fact_evals as _discover
         return _discover(spans, fact_name=fact_name)
+
+    @staticmethod
+    def _no_results_message(job_id, data) -> str:
+        """An empty ``result`` list is a data condition, not a malformed response."""
+        return (
+            f"Evaluation service returned no results for this fact (job {job_id}). The trace may not be "
+            "ingested or indexed yet, the fact or workflow name may not match, or the eval template's "
+            f"scoping dropped every span. Received: {data}"
+        )
+
+    @staticmethod
+    def _unexpected_format_message(data) -> str:
+        return (
+            "Unexpected response format from evaluation service: expected result[0].result to be a JSON "
+            f"string carrying 'label' and 'explanation'. Received: {data}"
+        )
 
     @classmethod
     def _eval_report_by_fact(cls, *, workflow_name, fact_ids, fact_name, start_time,
@@ -266,11 +283,28 @@ class OkahuEval(BaseEval):
         if not api_key:
             raise AssertionError("OKAHU_API_KEY is not configured.")
         
-        # Export spans to Okahu
+        # Export spans to Okahu. The exporter reports a failed upload only
+        # through its return value; ignoring it marked the trace as exported and
+        # every later eval then queried a backend that had nothing, surfacing as
+        # "Expected 'result' key in response" instead of the real problem.
         exporter = okahu_exporter.OkahuSpanExporter(evaluate=True)
-        exporter.export(filtered_spans)
-        exporter.shutdown()
-        
+        try:
+            export_result = exporter.export(filtered_spans)
+        finally:
+            exporter.shutdown()
+        if export_result is None:
+            raise AssertionError(
+                "No spans were uploaded to the Okahu evaluation service: every span was "
+                "filtered out before export, so there is nothing to evaluate."
+            )
+        if export_result != SpanExportResult.SUCCESS:
+            status = getattr(exporter, "last_status_code", None)
+            detail = f"HTTP {status}" if status is not None else "no HTTP response (timeout or exporter shut down)"
+            raise AssertionError(
+                f"Trace export to the Okahu evaluation service failed ({detail}); nothing was ingested, "
+                "so the eval cannot run. Check OKAHU_API_KEY and OKAHU_INGESTION_ENDPOINT."
+            )
+
         self._trace_exported = True
         return trace_id
     
@@ -460,13 +494,15 @@ class OkahuEval(BaseEval):
 
         try:
             job_id = data.get("job_id")
-            eval_result = data.get("result")
+            eval_result = data.get("result") or []
+            if not eval_result:
+                raise AssertionError(self._no_results_message(job_id, data))
             label = json.loads(eval_result[0].get('result')).get('label')
             explanation = json.loads(eval_result[0].get('result')).get('explanation')
+        except AssertionError:
+            raise
         except Exception as exc:
-            raise AssertionError(
-                f"Unexpected response format from evaluation service. Expected 'result' key in response. Received: {data}"
-            ) from exc
+            raise AssertionError(self._unexpected_format_message(data)) from exc
 
         return job_id, label, explanation, eval_result
 
@@ -507,7 +543,8 @@ class OkahuEval(BaseEval):
         # Compute a time window around the full span set for trace filtering (compute/perf).
         # Use the earliest start and latest end across all filtered spans (the workflow envelope),
         # then pad uniformly on either side so aggregate facts spanning multiple traces are covered.
-        pad_seconds = int(os.getenv("OKAHU_EVAL_TIME_PAD_SECONDS", DEFAULT_EVAL_TIME_PAD_SECONDS))
+        # `or`: a variable that is set but empty must fall back to the default too.
+        pad_seconds = int(os.getenv("OKAHU_EVAL_TIME_PAD_SECONDS") or DEFAULT_EVAL_TIME_PAD_SECONDS)
         pad_ns = pad_seconds * 1e9
         earliest_start_ns = min(s.start_time for s in filtered_spans)
         latest_end_ns = max(s.end_time for s in filtered_spans)
@@ -582,6 +619,8 @@ class OkahuEval(BaseEval):
             try:
                 job_id = data.get("job_id")
                 eval_result = data.get("result") or []
+                if not eval_result:
+                    raise AssertionError(self._no_results_message(job_id, data))
                 parsed = json.loads(eval_result[0].get("result"))
                 label = parsed.get("label")
                 explanation = parsed.get("explanation")
@@ -590,9 +629,7 @@ class OkahuEval(BaseEval):
             except AssertionError:
                 raise
             except Exception as exc:
-                raise AssertionError(
-                    f"Unexpected response format from evaluation service. Expected 'result' key in response. Received: {data}"
-                ) from exc
+                raise AssertionError(self._unexpected_format_message(data)) from exc
 
 
             fact_results.append({

--- a/test_tools/tests/unit/test_okahu_eval_export_and_empty_result.py
+++ b/test_tools/tests/unit/test_okahu_eval_export_and_empty_result.py
@@ -1,0 +1,114 @@
+"""Backend failures must be reported as what they are (issue #816).
+
+A failed trace export used to be swallowed and the trace marked as exported,
+and an empty ``result`` list was reported as a malformed response.
+"""
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from opentelemetry.sdk.trace.export import SpanExportResult
+
+from monocle_apptrace.exporters.okahu.okahu_eval_result_exporter import OkahuEvalResultExporter
+from monocle_test_tools.evals import okahu_eval as okahu_eval_module
+from monocle_test_tools.evals.okahu_eval import OkahuEval
+
+
+def _eval() -> OkahuEval:
+    return OkahuEval(eval_options={"trace_source": "file"})
+
+
+def _span():
+    span = MagicMock()
+    span.get_span_context.return_value.trace_id = 0xABC
+    span.attributes = {"workflow.name": "wf"}
+    span.start_time = 1_000_000_000
+    span.end_time = 2_000_000_000
+    return span
+
+
+def _exporter(result, status_code=None):
+    exporter = MagicMock()
+    exporter.export.return_value = result
+    exporter.last_status_code = status_code
+    return exporter
+
+
+def _resp(body: dict):
+    m = MagicMock()
+    m.headers = {"Content-Type": "application/json"}
+    m.raise_for_status.return_value = None
+    m.json.return_value = body
+    return m
+
+
+class TestExportTrace:
+    def test_failed_export_raises_with_status_and_stays_unexported(self, monkeypatch):
+        monkeypatch.setenv("OKAHU_API_KEY", "k")
+        ev = _eval()
+        exporter = _exporter(SpanExportResult.FAILURE, status_code=503)
+        with patch.object(okahu_eval_module.okahu_exporter, "OkahuSpanExporter", return_value=exporter):
+            with pytest.raises(AssertionError) as info:
+                ev.export_trace([_span()])
+        assert "HTTP 503" in str(info.value)
+        assert ev._trace_exported is False
+        exporter.shutdown.assert_called_once()
+
+    def test_failed_export_without_response_names_the_timeout(self, monkeypatch):
+        monkeypatch.setenv("OKAHU_API_KEY", "k")
+        ev = _eval()
+        exporter = _exporter(SpanExportResult.FAILURE, status_code=None)
+        with patch.object(okahu_eval_module.okahu_exporter, "OkahuSpanExporter", return_value=exporter):
+            with pytest.raises(AssertionError, match="no HTTP response"):
+                ev.export_trace([_span()])
+        assert ev._trace_exported is False
+
+    def test_nothing_uploaded_raises(self, monkeypatch):
+        monkeypatch.setenv("OKAHU_API_KEY", "k")
+        ev = _eval()
+        exporter = _exporter(None)
+        with patch.object(okahu_eval_module.okahu_exporter, "OkahuSpanExporter", return_value=exporter):
+            with pytest.raises(AssertionError, match="filtered out"):
+                ev.export_trace([_span()])
+        assert ev._trace_exported is False
+
+    def test_successful_export_marks_trace_exported(self, monkeypatch):
+        monkeypatch.setenv("OKAHU_API_KEY", "k")
+        ev = _eval()
+        exporter = _exporter(SpanExportResult.SUCCESS, status_code=202)
+        with patch.object(okahu_eval_module.okahu_exporter, "OkahuSpanExporter", return_value=exporter):
+            trace_id = ev.export_trace([_span()])
+        assert trace_id == format(0xABC, "032x")
+        assert ev._trace_exported is True
+
+
+def _run_evaluate(ev, body):
+    with patch.object(OkahuEval, "export_trace", return_value="traceid"), \
+         patch.object(OkahuEval, "enumerate_fact_ids", return_value=["traceid"]), \
+         patch("monocle_test_tools.evals.okahu_eval.requests.post", return_value=_resp(body)), \
+         patch.object(OkahuEvalResultExporter, "export_results", return_value=None):
+        return ev.evaluate(filtered_spans=[_span()], template={"name": "t"}, fact_name="traces")
+
+
+def test_empty_result_is_reported_as_no_results(monkeypatch):
+    monkeypatch.setenv("OKAHU_API_KEY", "k")
+    with pytest.raises(AssertionError) as info:
+        _run_evaluate(_eval(), {"job_id": "job-1", "result": []})
+    message = str(info.value)
+    assert "no results" in message
+    assert "job-1" in message
+    assert "Expected 'result' key" not in message
+
+
+def test_malformed_result_entry_is_still_a_format_error(monkeypatch):
+    monkeypatch.setenv("OKAHU_API_KEY", "k")
+    with pytest.raises(AssertionError, match="Unexpected response format"):
+        _run_evaluate(_eval(), {"job_id": "job-1", "result": [{"result": "not json"}]})
+
+
+def test_empty_time_pad_env_uses_the_default(monkeypatch):
+    monkeypatch.setenv("OKAHU_API_KEY", "k")
+    monkeypatch.setenv("OKAHU_EVAL_TIME_PAD_SECONDS", "")
+    judge = {"label": "ok", "explanation": "fine"}
+    label, explanation = _run_evaluate(_eval(), {"job_id": "job-1", "result": [{"result": json.dumps(judge)}]})
+    assert (label, explanation) == ("ok", "fine")

--- a/test_tools/tests/unit/test_okahu_eval_export_and_empty_result.py
+++ b/test_tools/tests/unit/test_okahu_eval_export_and_empty_result.py
@@ -112,3 +112,13 @@ def test_empty_time_pad_env_uses_the_default(monkeypatch):
     judge = {"label": "ok", "explanation": "fine"}
     label, explanation = _run_evaluate(_eval(), {"job_id": "job-1", "result": [{"result": json.dumps(judge)}]})
     assert (label, explanation) == ("ok", "fine")
+
+
+def test_missing_api_key_is_reported_before_export(monkeypatch):
+    monkeypatch.delenv("OKAHU_API_KEY", raising=False)
+    ev = _eval()
+    with patch.object(okahu_eval_module.okahu_exporter, "OkahuSpanExporter") as exporter_cls:
+        with pytest.raises(AssertionError, match="OKAHU_API_KEY is not configured"):
+            ev.export_trace([_span()])
+    exporter_cls.assert_not_called()
+    assert ev._trace_exported is False


### PR DESCRIPTION
## Proposed changes

Fixes #816 (items 1–3).

`OkahuEval.export_trace` discarded the exporter's return value, so a failed upload (bad API key, 5xx, timeout) still marked the trace as exported and every later eval queried a backend that had nothing. That surfaced much later as `Unexpected response format ... Expected 'result' key in response`, which also fired for a perfectly well-formed response whose `result` list was simply empty.

- `export_trace` now shuts the exporter down in a `finally`, raises when nothing was uploaded (every span filtered out), and raises with the HTTP status (or "no HTTP response (timeout or exporter shut down)") when the export failed. `_trace_exported` stays `False`.
- `OkahuSpanExporter` records `last_status_code` for the most recent upload so the eval can name the status. (Small addition in apptrace; no behaviour change there.)
- Both result-parsing sites treat an empty `result` list as "no results for this fact" (with the job id and the likely causes: trace not ingested/indexed yet, fact or workflow name mismatch, template scoping dropped every span) instead of a format error. The format error itself now says what shape was expected (`result[0].result` as a JSON string with `label`/`explanation`).
- Item 3: `OKAHU_EVAL_TIME_PAD_SECONDS` falls back to the default when the variable is set but empty, matching the other env reads that already use `or`.

Item 4 (mapping infrastructure failures to ERROR/SKIP instead of `AssertionError`) is deliberately not touched: the issue asks for a design decision first. All raises here stay `AssertionError`, so existing consumers of the fluent API are unaffected. The `.strip()` on a possibly-`None` key mentioned under item 3 is already safe on `main` (`(os.getenv(...) or "").strip()`).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/monocle2ai/monocle/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the CLA (DCO sign-off on the commit)
- [x] Lint and unit tests pass locally with my changes (`pylint` on the two touched files goes from 8.85 to 8.95, one `invalid-envvar-default` warning removed; `test_tools/tests/unit` okahu eval suites: 38 passed)
- [x] I have added tests that prove my fix is effective or that my feature works (`test_tools/tests/unit/test_okahu_eval_export_and_empty_result.py`: failed export with/without HTTP status, nothing uploaded, successful export, empty `result`, malformed entry still a format error, empty pad env, missing API key)
- [ ] I have added the necessary documentation (if appropriate) — not needed, error messages only
- [x] Any dependent changes have been merged and published in downstream modules — none

## Further comments

The `last_status_code` attribute is read with `getattr(..., None)` so a test double or an older exporter without it still produces a useful message.

